### PR TITLE
监控大盘图表编辑，新增chart id(cid)，修复json校验不通过问题

### DIFF
--- a/docker/initsql/a-n9e.sql
+++ b/docker/initsql/a-n9e.sql
@@ -202,6 +202,7 @@ CREATE TABLE `chart_group` (
 -- deprecated
 CREATE TABLE `chart` (
     `id` bigint unsigned not null auto_increment,
+    `cid` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL DEFAULT '',
     `group_id` bigint unsigned not null comment 'chart group id',
     `configs` text,
     `weight` int not null default 0,

--- a/src/models/chart.go
+++ b/src/models/chart.go
@@ -2,6 +2,7 @@ package models
 
 type Chart struct {
 	Id      int64  `json:"id" gorm:"primaryKey"`
+	Cid 	string `json:"cid"`
 	GroupId int64  `json:"group_id"`
 	Configs string `json:"configs"`
 	Weight  int    `json:"weight"`
@@ -15,6 +16,12 @@ func ChartsOf(chartGroupId int64) ([]Chart, error) {
 	var objs []Chart
 	err := DB().Where("group_id = ?", chartGroupId).Order("weight").Find(&objs).Error
 	return objs, err
+}
+
+func GetChartByCid(cid string) (Chart, error) {
+	var obj Chart
+	err := DB().Where("cid = ?", cid).Limit(1).Find(&obj).Error
+	return obj, err
 }
 
 func (c *Chart) Add() error {

--- a/src/webapi/router/router_chart.go
+++ b/src/webapi/router/router_chart.go
@@ -41,6 +41,7 @@ func chartPut(c *gin.Context) {
 				continue;
 			}
 			if cg.Id > 0 {
+				chartitem.Id = cg.Id
 				ginx.Dangerous(chartitem.Update("cid","configs", "weight", "group_id"))
 			}else {
 				chartitem.Id = 0

--- a/src/webapi/router/router_chart.go
+++ b/src/webapi/router/router_chart.go
@@ -7,6 +7,13 @@ import (
 	"github.com/didi/nightingale/v5/src/models"
 )
 
+type ChartFront struct {
+	Id 	string `json:"id"`
+	GroupId int64  `json:"group_id"`
+	Configs string `json:"configs"`
+	Weight  int    `json:"weight"`
+}
+
 func chartGets(c *gin.Context) {
 	lst, err := models.ChartsOf(ginx.QueryInt64(c, "cgid"))
 	ginx.NewRender(c).Data(lst, err)
@@ -23,11 +30,23 @@ func chartAdd(c *gin.Context) {
 }
 
 func chartPut(c *gin.Context) {
-	var arr []models.Chart
-	ginx.BindJSON(c, &arr)
+	var arr_tmp []ChartFront
+	ginx.BindJSON(c, &arr_tmp)
 
-	for i := 0; i < len(arr); i++ {
-		ginx.Dangerous(arr[i].Update("configs", "weight", "group_id"))
+	for i := 0; i < len(arr_tmp); i++ {
+		if len(arr_tmp[i].Id) > 0 {
+			chartitem := models.Chart{Cid:arr_tmp[i].Id,GroupId:arr_tmp[i].GroupId,Configs:arr_tmp[i].Configs,Weight:arr_tmp[i].Weight}
+			cg,err := models.GetChartByCid(chartitem.Cid)
+			if err != nil{
+				continue;
+			}
+			if cg.Id > 0 {
+				ginx.Dangerous(chartitem.Update("cid","configs", "weight", "group_id"))
+			}else {
+				chartitem.Id = 0
+				chartitem.Add()
+			}
+		}
 	}
 
 	ginx.NewRender(c).Message(nil)


### PR DESCRIPTION
**What type of PR is this?**
bug
**What this PR does / why we need it**:
<!--
"Nice to have" "You need it" is not a good reason. :)
-->
前端请求/api/n9e/busi-group/id/charts，post数据中id为字符串：
[{"configs":"{...}","weight":0,"id":"dbb8310a-b961-4f15-bd2a-0391517238aa"}]，
**Chart** 模型中，**id**为**int64**，会导致**ShouldBindJSON**校验异常

```
type Chart struct {
	Id      int64  `json:"id" gorm:"primaryKey"`
	Cid 	string `json:"cid"`
	GroupId int64  `json:"group_id"`
	Configs string `json:"configs"`
	Weight  int    `json:"weight"`
}
```

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or "Fixes (paste link of issue)"
-->
Fixes #
1、chart表中新增chart id(cid)
2、在前端不修改的情况下，引入临时Chart模型

```
type ChartFront struct {
	Id 	string `json:"id"`
	GroupId int64  `json:"group_id"`
	Configs string `json:"configs"`
	Weight  int    `json:"weight"`
}
```
**Special notes for your reviewer**: