### PR TITLE
修复go plugin相关错误

### DIFF
--- a/docker/n9eetc/script/notify/README.md
+++ b/docker/n9eetc/script/notify/README.md
@@ -29,7 +29,7 @@ type inter interface {
 [Alerting.CallPlugin]
 Enable = false
 PluginPath = "./etc/script/notify.so"
-# 注意此处caller必须在notify.so中作为变量暴露
-Caller = "n9eCaller"
+# 注意此处caller必须在notify.so中作为变量暴露,首字母必须大写才能暴露
+Caller = "N9eCaller"
 ```
 

--- a/docker/n9eetc/script/notify/notify.go
+++ b/docker/n9eetc/script/notify/notify.go
@@ -37,8 +37,8 @@ func (n *N9EPlugin) Notify(bs []byte) {
 	}
 }
 
-// will be loaded for alertingCall
-var n9eCaller = N9EPlugin{
+// will be loaded for alertingCall , The first letter must be capitalized to be exported
+var N9eCaller = N9EPlugin{
 	Name:        "n9e",
 	Description: "演示告警通过动态链接库方式通知",
 	BuildAt:     time.Now().Local().Format("2006/01/02 15:04:05"),

--- a/etc/script/notify/README.md
+++ b/etc/script/notify/README.md
@@ -29,7 +29,7 @@ type inter interface {
 [Alerting.CallPlugin]
 Enable = false
 PluginPath = "./etc/script/notify.so"
-# 注意此处caller必须在notify.so中作为变量暴露
-Caller = "n9eCaller"
+# 注意此处caller必须在notify.so中作为变量暴露,首字母必须大写才能暴露
+Caller = "N9eCaller"
 ```
 

--- a/etc/script/notify/notify.go
+++ b/etc/script/notify/notify.go
@@ -37,8 +37,8 @@ func (n *N9EPlugin) Notify(bs []byte) {
 	}
 }
 
-// will be loaded for alertingCall
-var n9eCaller = N9EPlugin{
+// will be loaded for alertingCall , The first letter must be capitalized to be exported
+var N9eCaller = N9EPlugin{
 	Name:        "n9e",
 	Description: "演示告警通过动态链接库方式通知",
 	BuildAt:     time.Now().Local().Format("2006/01/02 15:04:05"),

--- a/etc/server.conf
+++ b/etc/server.conf
@@ -85,7 +85,8 @@ ScriptPath = "./etc/script/notify.py"
 Enable = false
 # use a plugin via `go build -buildmode=plugin -o notify.so`
 PluginPath = "./etc/script/notify.so"
-Caller = "n9eCaller"
+# The first letter must be capitalized to be exported
+Caller = "N9eCaller"
 
 [Alerting.RedisPub]
 Enable = false


### PR DESCRIPTION
修复通过go plugin模式处理告警的时候的相关错误

错误如下：
2022-05-26 17:02:18.376607 ERROR engine/notify.go:425 failed to load caller: plugin: symbol n9eCaller not found in plugin plugin/unnamed-067de70ddf4feb0cb88dba22a1dc78d7e8da49bc
现象：提示找不到符号 n9eCaller 
解决方案：go plugin暴露的变量或函数必须以大写开头