### PR TITLE
Fix: 修复第三方api预警规则增加接口问题

### DIFF
--- a/docker/initsql/a-n9e.sql
+++ b/docker/initsql/a-n9e.sql
@@ -230,7 +230,7 @@ CREATE TABLE `alert_rule` (
     `algorithm` varchar(255) not null default '',
     `algo_params` varchar(255),
     `delay` int not null default 0,
-    `severity` tinyint(1) not null comment '0:Emergency 1:Warning 2:Notice',
+    `severity` tinyint(1) not null comment '1:Emergency 2:Warning 3:Notice',
     `disabled` tinyint(1) not null comment '0:enabled 1:disabled',
     `prom_for_duration` int not null comment 'prometheus for, unit:s',
     `prom_ql` varchar(8192) not null comment 'promql',

--- a/src/models/alert_rule.go
+++ b/src/models/alert_rule.go
@@ -24,7 +24,7 @@ type AlertRule struct {
 	AlgoParams           string      `json:"-" gorm:"algo_params"`         // params algorithm need
 	AlgoParamsJson       interface{} `json:"algo_params" gorm:"-"`         //
 	Delay                int         `json:"delay"`                        // Time (in seconds) to delay evaluation
-	Severity             int         `json:"severity"`                     // 0: Emergency 1: Warning 2: Notice
+	Severity             int         `json:"severity"`                     // 1: Emergency 2: Warning 3: Notice
 	Disabled             int         `json:"disabled"`                     // 0: enabled, 1: disabled
 	PromForDuration      int         `json:"prom_for_duration"`            // prometheus for, unit:s
 	PromQl               string      `json:"prom_ql"`                      // just one ql


### PR DESCRIPTION
第三方webapi接口有报错：
{
    "dat": {
        "inode资源不足-使用率超过100": "GroupId(0) invalid"
    },
    "err": ""
}
问题原因：
告警规则的Verify策略不允许业务组ID为0

修复策略：
1、可以指定业务组ID，也可以不指定，如果不指定，默认为1
2、修正告警级别描述信息