### PR TITLE
Fix：修复webapi第三方api删除告警规则路由配置错误

### DIFF
--- a/src/webapi/router/router.go
+++ b/src/webapi/router/router.go
@@ -278,7 +278,7 @@ func configRoute(r *gin.Engine, version string) {
 
 		service.GET("/alert-rules", alertRuleGets)
 		service.POST("/alert-rules", alertRuleAddByService)
-		service.DELETE("/alert-rules", alertRuleDel)
+		service.DELETE("/alert-rules/busi-group/:id", alertRuleDel)
 		service.PUT("/alert-rule/:arid", alertRulePutByService)
 		service.GET("/alert-rule/:arid", alertRuleGet)
 		service.GET("/alert-rules-get-by-prod", alertRulesGetByProds)


### PR DESCRIPTION
1、修复webapi第三方api删除告警规则路由配置错误
2、URL中加入busi-group字段，表示后面接的id参数并非规则id而是业务组id，含义更加明确