### PR TITLE
fix alert put api not verify bug

### DIFF
--- a/src/models/alert_rule.go
+++ b/src/models/alert_rule.go
@@ -163,6 +163,10 @@ func (ar *AlertRule) Update(arf AlertRule) error {
 	arf.CreateBy = ar.CreateBy
 	arf.UpdateAt = time.Now().Unix()
 
+	err = arf.Verify()
+	if err != nil {
+		return err
+	}
 	return DB().Model(ar).Select("*").Updates(arf).Error
 }
 


### PR DESCRIPTION
Fixed a potential bug

In the added webapi of alertrule, the updated put request is not verified, making it problematic if there is a malicious data update
So I added a check on the rule