### PR TITLE
fix: fix plugin error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/mattn/go-isatty v0.0.12
 	github.com/orcaman/concurrent-map v0.0.0-20210501183033-44dafcb38ecc
 	github.com/pkg/errors v0.9.1
-	github.com/prometheus/client_golang v1.11.0
+	github.com/prometheus/client_golang vv1.12.2
 	github.com/prometheus/common v0.26.0
 	github.com/prometheus/prometheus v2.5.0+incompatible
 	github.com/tidwall/gjson v1.14.0
@@ -36,7 +36,7 @@ require (
 	github.com/Azure/go-ntlmssp v0.0.0-20200615164410-66371956d46c // indirect
 	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/fatih/camelcase v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/mattn/go-isatty v0.0.12
 	github.com/orcaman/concurrent-map v0.0.0-20210501183033-44dafcb38ecc
 	github.com/pkg/errors v0.9.1
-	github.com/prometheus/client_golang vv1.12.2
+	github.com/prometheus/client_golang v1.12.2
 	github.com/prometheus/common v0.26.0
 	github.com/prometheus/prometheus v2.5.0+incompatible
 	github.com/tidwall/gjson v1.14.0


### PR DESCRIPTION
fix: fix plugin error

在某些情况下，使用go plugin编译通知插件的时候，会因为使用的github.com/cespare/xxhash/v2 库版本问题，引发如下错误：

export GOPROXY=http://goproxy.cn,direct
go build -buildmode=plugin -o notify.so notify.go
# github.com/cespare/xxhash/v2
asm: xxhash_amd64.s:120: when dynamic linking, R15 is clobbered by a global variable access and is used here: 00092 (/root/go/pkg/mod/github.com/cespare/xxhash/v2@v2.1.1/xxhash_amd64.s:120)       ADDQ    R15, AX
asm: assembly failed
make: *** [plugin] Error 2

该库主要由github.com/prometheus/client_golang 引用，升级该prometheus客户端版本，间接升级cespare/xxhash到 v2.1.2，即可解决该问题。