### PR TITLE
get alert-rule node

### DIFF
--- a/src/server/router/router.go
+++ b/src/server/router/router.go
@@ -92,6 +92,7 @@ func configRoute(r *gin.Engine, version string) {
 	r.GET("/memory/target", targetGet)
 	r.GET("/memory/user", userGet)
 	r.GET("/memory/user-group", userGroupGet)
+	r.GET("/memory/node/alert-rule", alertRuleNodeGet)
 
 	r.GET("/metrics", gin.WrapH(promhttp.Handler()))
 

--- a/src/server/router/router_memsto.go
+++ b/src/server/router/router_memsto.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/didi/nightingale/v5/src/server/idents"
 	"github.com/didi/nightingale/v5/src/server/memsto"
+	"github.com/didi/nightingale/v5/src/server/naming"
 )
 
 func alertRuleGet(c *gin.Context) {
@@ -42,4 +43,10 @@ func userGroupGet(c *gin.Context) {
 	id := ginx.QueryInt64(c, "id")
 	ug := memsto.UserGroupCache.GetByUserGroupId(id)
 	c.JSON(200, gin.H{"id": id, "user_group": ug})
+}
+
+func alertRuleNodeGet(c *gin.Context) {
+	id := ginx.QueryStr(c, "id")
+	node, _ := naming.HashRing.GetNode(id)
+	c.JSON(200, gin.H{"id": id, "node": node})
 }


### PR DESCRIPTION
**What type of PR is this?**
feat

提供告警规则所属node查询接口，方便排查告警日志。

请求方式：
```
# curl -s "http://127.0.0.1:19000/memory/node/alert-rule?id=2"|jq .
{
  "id": "2",
  "node": "xxx-ops-n9e-test01.bj+5428:19000"
}
```