### PR TITLE
MOD:fix webcom read: connection reset by peer err

### DIFF
--- a/src/pkg/poster/post.go
+++ b/src/pkg/poster/post.go
@@ -19,6 +19,11 @@ func PostJSON(url string, timeout time.Duration, v interface{}) (response []byte
 	bf := bytes.NewBuffer(bs)
 
 	client := http.Client{
+		Transport: &http.Transport{
+			MaxConnsPerHost:     500,
+			MaxIdleConns:        20,
+			MaxIdleConnsPerHost: 20,
+		},
 		Timeout: timeout,
 	}
 


### PR DESCRIPTION
**企业微信有丢消息的情况**

**查看日志发现如下报错，加了参数后，观察一天没报错了，请求企业微信的机器是阿里云上国外的机器，辛苦看下这样是否合适**:
```
read: connection reset by peer
```

Fixes #
 
**Special notes for your reviewer**: