### PR TITLE
[fix] fix the docker problem of apple chip

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -6,6 +6,7 @@ networks:
 
 services:
   mysql:
+    platform: linux/x86_64
     image: "mysql:5.7"
     container_name: mysql
     hostname: mysql


### PR DESCRIPTION
**What type of PR is this?**

When i start up a docker-compose, then occured a prob without platform.

[Docker (Apple Silicon/M1 Preview) MySQL "no matching manifest for linux/arm64/v8 in the manifest list entries"]

**What this PR does / why we need it**:
<!--
"Nice to have" "You need it" is not a good reason. :)
-->

Add the platform for mysql.
platform: linux/x86_64
 
**Special notes for your reviewer**: