### PR TITLE
fix proxy auth username error

### DIFF
--- a/src/webapi/router/router_mw.go
+++ b/src/webapi/router/router_mw.go
@@ -59,7 +59,7 @@ func proxyAuth() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		user := handleProxyUser(c)
 		c.Set("userid", user.Id)
-		c.Set("username", user)
+		c.Set("username", user.Username)
 		c.Next()
 	}
 }


### PR DESCRIPTION
修复使用proxyauth认证方式时，username ctx设置错误的bug