### PR TITLE
refactor: error info return

### DIFF
--- a/src/server/router/router_opentsdb.go
+++ b/src/server/router/router_opentsdb.go
@@ -173,6 +173,9 @@ func handleOpenTSDB(c *gin.Context) {
 	for i := 0; i < len(arr); i++ {
 		if err := arr[i].Clean(ts); err != nil {
 			logger.Debugf("opentsdb msg clean error: %s", err.Error())
+			if fail == 0 {
+				msg = fmt.Sprintf("%s , Error clean: %s", msg, err.Error())
+			}
 			fail++
 			continue
 		}
@@ -180,6 +183,9 @@ func handleOpenTSDB(c *gin.Context) {
 		pt, err := arr[i].ToProm()
 		if err != nil {
 			logger.Debugf("opentsdb msg to tsdb error: %s", err.Error())
+			if fail == 0 {
+				msg = fmt.Sprintf("%s , Error toprom: %s", msg, err.Error())
+			}
 			fail++
 			continue
 		}


### PR DESCRIPTION
refactor: error info return

因为日志都是debug，所以在没开启debug的时候也应该让客户端知道错误的一些信息（否则服务端和客户端都不知道发生了什么），所以返回第一条错误信息到msg中给客户端。