### PR TITLE
use slim base image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:2
+FROM python:2.7.8-slim
+#FROM python:2
 #FROM ubuntu:21.04
 
 WORKDIR /app

--- a/docker/Dockerfile.goreleaser
+++ b/docker/Dockerfile.goreleaser
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM python:2
+FROM --platform=$BUILDPLATFORM python:2.7.8-slim
 
 
 WORKDIR /app


### PR DESCRIPTION
1. 使用slim镜像作为基础镜像，打包后镜像大小约从 890M -> 290M
无法使用apline镜像，发送告警时会出现`x509: certificate signed by unknown authority response=`错误

<img width="594" alt="image" src="https://user-images.githubusercontent.com/72858153/184113856-a12f97b0-de7f-4f96-a475-78cf6b4efd0b.png">
