### PR TITLE
bug: user update by multifields, param need '...'

### DIFF
--- a/src/models/user.go
+++ b/src/models/user.go
@@ -95,7 +95,7 @@ func (u *User) Update(selectField interface{}, selectFields ...interface{}) erro
 		return err
 	}
 
-	return DB().Model(u).Select(selectField, selectFields).Updates(u).Error
+	return DB().Model(u).Select(selectField, selectFields...).Updates(u).Error
 }
 
 func (u *User) UpdateAllFields() error {


### PR DESCRIPTION
**What type of PR is this?**
bugfix

**What this PR does / why we need it**:
多字段更新用户时，参数作为slice接受，需要拆包之后再往下传入。该bug导致user.Update方法只能成功更新第一个参数对应的字段

**Which issue(s) this PR fixes**:
无