### PR TITLE
修复记录规则不生效问题

### DIFF
--- a/src/server/common/conv/sample.go
+++ b/src/server/common/conv/sample.go
@@ -96,6 +96,9 @@ func labelsToLabelsProto(labels model.Metric, rule *models.RecordingRule) (resul
 	}
 	result = append(result, nameLs)
 	for k, v := range labels {
+		if k == LabelName {
+			continue
+		}
 		if model.LabelNameRE.MatchString(string(k)) {
 			result = append(result, &prompb.Label{
 				Name:  string(k),


### PR DESCRIPTION
**What type of PR is this?**
FIX

__name__字段重复，导致无法写TSDB
```
2022-10-12 17:05:36.844801 WARNING writer/writer.go:80 example timeseries:labels:<name:"__name__" value:"cpu_zheng_test" > labels:<name:"__name__" value:"cpu_usage_idle" > labels:<name:"busigroup" value:"ops.test" > labels:<name:"cpu" value:"cpu-total" > labels:<name:"ident" value:"xxx-ops-n9e-test01.xxx" > labels:<name:"app" value:"1" > samples:<value:89.74012824976322 timestamp:1665565536844 >
```