### PR TITLE
bug: user.go search error

### DIFF
--- a/src/models/user.go
+++ b/src/models/user.go
@@ -465,8 +465,9 @@ func (u *User) BusiGroups(limit int, query string, all ...bool) ([]BusiGroup, er
 			if t == nil {
 				return lst, nil
 			}
-
-			err = DB().Order("name").Limit(limit).Where("id=?", t.GroupId).Find(&lst).Error
+			if t != nil {
+				err = DB().Order("name").Limit(limit).Where("id=?", t.GroupId).Find(&lst).Error
+			}
 		}
 
 		return lst, err


### PR DESCRIPTION
bug: 在业务组管理中搜索业务组列表.如果搜索的业务组名称不存在触发这个隐藏功能搜索ident，但是由于搜索ident也不存在,t为nil。前端报空的弹窗