### PR TITLE
 feat: 添加Telegram Bot通知支持

### DIFF
--- a/docker/n9eetc/script/notify/notify.go
+++ b/docker/n9eetc/script/notify/notify.go
@@ -29,6 +29,7 @@ func (n *N9EPlugin) Notify(bs []byte) {
 		"dingtalk_robot_token",
 		"wecom_robot_token",
 		"feishu_robot_token",
+		"telegram_robot_token",
 	}
 	for _, ch := range channels {
 		if ret := gjson.GetBytes(bs, ch); ret.Exists() {

--- a/docker/n9eetc/server.conf
+++ b/docker/n9eetc/server.conf
@@ -78,7 +78,7 @@ Timeout=30000
 TemplatesDir = "./etc/template"
 NotifyConcurrency = 10
 # use builtin go code notify
-NotifyBuiltinChannels = ["email", "dingtalk", "wecom", "feishu", "mm"]
+NotifyBuiltinChannels = ["email", "dingtalk", "wecom", "feishu", "mm", "telegram"]
 
 [Alerting.CallScript]
 # built in sending capability in go code

--- a/docker/n9eetc/template/telegram.tpl
+++ b/docker/n9eetc/template/telegram.tpl
@@ -1,0 +1,7 @@
+**级别状态**: {{if .IsRecovered}}<font color="info">S{{.Severity}} Recovered</font>{{else}}<font color="warning">S{{.Severity}} Triggered</font>{{end}}
+**规则标题**: {{.RuleName}}{{if .RuleNote}}
+**规则备注**: {{.RuleNote}}{{end}}
+**监控指标**: {{.TagsJSON}}
+{{if .IsRecovered}}**恢复时间**：{{timeformat .LastEvalTime}}{{else}}**触发时间**: {{timeformat .TriggerTime}}
+**触发时值**: {{.TriggerValue}}{{end}}
+**发送时间**: {{timestamp}}

--- a/docker/n9eetc/webapi.conf
+++ b/docker/n9eetc/webapi.conf
@@ -44,6 +44,11 @@ Label = "mm bot"
 # do not change Key
 Key = "mm"
 
+[[NotifyChannels]]
+Label = "telegram机器人"
+# do not change Key
+Key = "telegram"
+
 [[ContactKeys]]
 Label = "Wecom Robot Token"
 # do not change Key
@@ -63,6 +68,11 @@ Key = "feishu_robot_token"
 Label = "MatterMost Webhook URL"
 # do not change Key
 Key = "mm_webhook_url"
+
+[[ContactKeys]]
+Label = "Telegram Robot Token"
+# do not change Key
+Key = "telegram_robot_token"
 
 [Log]
 # log write dir

--- a/etc/script/notify/notify.go
+++ b/etc/script/notify/notify.go
@@ -23,6 +23,7 @@ func (n *N9EPlugin) Notify(bs []byte) {
 		"dingtalk_robot_token",
 		"wecom_robot_token",
 		"feishu_robot_token",
+		"telegram_robot_token",
 	}
 	for _, ch := range channels {
 		if ret := gjson.GetBytes(bs, ch); ret.Exists() {

--- a/etc/server.conf
+++ b/etc/server.conf
@@ -78,7 +78,7 @@ Timeout=30000
 TemplatesDir = "./etc/template"
 NotifyConcurrency = 10
 # use builtin go code notify
-NotifyBuiltinChannels = ["email", "dingtalk", "wecom", "feishu", "mm"]
+NotifyBuiltinChannels = ["email", "dingtalk", "wecom", "feishu", "mm", "telegram"]
 
 [Alerting.CallScript]
 # built in sending capability in go code

--- a/etc/template/telegram.tpl
+++ b/etc/template/telegram.tpl
@@ -1,0 +1,9 @@
+**级别状态**: {{if .IsRecovered}}<font color="info">S{{.Severity}} Recovered</font>{{else}}<font color="warning">S{{.Severity}} Triggered</font>{{end}}
+**规则标题**: {{.RuleName}}{{if .RuleNote}}
+**规则备注**: {{.RuleNote}}{{end}}{{if .TargetIdent}}
+**监控对象**: {{.TargetIdent}}{{end}}
+**监控指标**: {{.TagsJSON}}{{if not .IsRecovered}}
+**触发时值**: {{.TriggerValue}}{{end}}
+{{if .IsRecovered}}**恢复时间**: {{timeformat .LastEvalTime}}{{else}}**首次触发时间**: {{timeformat .FirstTriggerTime}}{{end}}
+{{$time_duration := sub now.Unix .FirstTriggerTime }}{{if .IsRecovered}}{{$time_duration = sub .LastEvalTime .FirstTriggerTime }}{{end}}**持续时长**: {{humanizeDurationInterface $time_duration}}
+**发送时间**: {{timestamp}}

--- a/etc/webapi.conf
+++ b/etc/webapi.conf
@@ -44,6 +44,11 @@ Label = "mm bot"
 # do not change Key
 Key = "mm"
 
+[[NotifyChannels]]
+Label = "telegram机器人"
+# do not change Key
+Key = "telegram"
+
 [[ContactKeys]]
 Label = "Wecom Robot Token"
 # do not change Key
@@ -63,6 +68,11 @@ Key = "feishu_robot_token"
 Label = "MatterMost Webhook URL"
 # do not change Key
 Key = "mm_webhook_url"
+
+[[ContactKeys]]
+Label = "Telegram Robot Token"
+# do not change Key
+Key = "telegram_robot_token"
 
 [Log]
 # log write dir

--- a/src/server/common/sender/telegram.go
+++ b/src/server/common/sender/telegram.go
@@ -20,7 +20,7 @@ type telegram struct {
 
 func SendTelegram(message TelegramMessage) {
 	for i := 0; i < len(message.Tokens); i++ {
-		if !strings.Contains(message.Tokens[i], "/") && strings.HasPrefix(message.Tokens[i], "https://") {
+		if !strings.Contains(message.Tokens[i], "/") && !strings.HasPrefix(message.Tokens[i], "https://") {
 			logger.Errorf("telegram_sender: result=fail invalid token=%s", message.Tokens[i])
 			continue
 		}
@@ -29,6 +29,10 @@ func SendTelegram(message TelegramMessage) {
 			url = message.Tokens[i]
 		} else {
 			array := strings.Split(message.Tokens[i], "/")
+			if len(array) != 2 {
+				logger.Errorf("telegram_sender: result=fail invalid token=%s", message.Tokens[i])
+				continue
+			}
 			botToken := array[0]
 			chatId := array[1]
 			url = "https://api.telegram.org/bot" + botToken + "/sendMessage?chat_id=" + chatId

--- a/src/server/common/sender/telegram.go
+++ b/src/server/common/sender/telegram.go
@@ -1,0 +1,48 @@
+package sender
+
+import (
+	"strings"
+	"time"
+
+	"github.com/didi/nightingale/v5/src/pkg/poster"
+	"github.com/toolkits/pkg/logger"
+)
+
+type TelegramMessage struct {
+	Text   string
+	Tokens []string
+}
+
+type telegram struct {
+	ParseMode string `json:"parse_mode"`
+	Text      string `json:"text"`
+}
+
+func SendTelegram(message TelegramMessage) {
+	for i := 0; i < len(message.Tokens); i++ {
+		if !strings.Contains(message.Tokens[i], "/") && strings.HasPrefix(message.Tokens[i], "https://") {
+			logger.Errorf("telegram_sender: result=fail invalid token=%s", message.Tokens[i])
+			continue
+		}
+		var url string
+		if strings.HasPrefix(message.Tokens[i], "https://") {
+			url = message.Tokens[i]
+		} else {
+			array := strings.Split(message.Tokens[i], "/")
+			botToken := array[0]
+			chatId := array[1]
+			url = "https://api.telegram.org/bot" + botToken + "/sendMessage?chat_id=" + chatId
+		}
+		body := telegram{
+			ParseMode: "markdown",
+			Text:      message.Text,
+		}
+
+		res, code, err := poster.PostJSON(url, time.Second*5, body, 3)
+		if err != nil {
+			logger.Errorf("telegram_sender: result=fail url=%s code=%d error=%v response=%s", url, code, err, string(res))
+		} else {
+			logger.Infof("telegram_sender: result=succ url=%s code=%d response=%s", url, code, string(res))
+		}
+	}
+}

--- a/src/server/engine/notify.go
+++ b/src/server/engine/notify.go
@@ -126,6 +126,7 @@ func handleNotice(notice Notice, bs []byte) {
 	dingtalkset := make(map[string]struct{})
 	feishuset := make(map[string]struct{})
 	mmset := make(map[string]struct{})
+	telegramset := make(map[string]struct{})
 
 	for _, user := range notice.Event.NotifyUsersObj {
 		if user.Email != "" {
@@ -160,6 +161,11 @@ func handleNotice(notice Notice, bs []byte) {
 		ret = gjson.GetBytes(bs, "mm_webhook_url")
 		if ret.Exists() {
 			mmset[ret.String()] = struct{}{}
+		}
+
+		ret = gjson.GetBytes(bs, "telegram_robot_token")
+		if ret.Exists() {
+			telegramset[ret.String()] = struct{}{}
 		}
 	}
 
@@ -258,6 +264,23 @@ func handleNotice(notice Notice, bs []byte) {
 			sender.SendMM(sender.MatterMostMessage{
 				Text:   content,
 				Tokens: StringSetKeys(mmset),
+			})
+		case "telegram":
+			if len(telegramset) == 0 {
+				continue
+			}
+
+			if !slice.ContainsString(config.C.Alerting.NotifyBuiltinChannels, "telegram") {
+				continue
+			}
+
+			content, has := notice.Tpls["telegram.tpl"]
+			if !has {
+				content = "telegram.tpl not found"
+			}
+			sender.SendTelegram(sender.TelegramMessage{
+				Text:   content,
+				Tokens: StringSetKeys(telegramset),
 			})
 		}
 	}

--- a/src/server/engine/notify_maintainer.go
+++ b/src/server/engine/notify_maintainer.go
@@ -65,6 +65,7 @@ func notifyMaintainerWithBuiltin(title, msg, triggerTime string, users []*models
 	dingtalkset := make(map[string]struct{})
 	feishuset := make(map[string]struct{})
 	mmset := make(map[string]struct{})
+	telegramset := make(map[string]struct{})
 
 	for _, user := range users {
 		if user.Email != "" {
@@ -99,6 +100,11 @@ func notifyMaintainerWithBuiltin(title, msg, triggerTime string, users []*models
 		ret = gjson.GetBytes(bs, "mm_webhook_url")
 		if ret.Exists() {
 			mmset[ret.String()] = struct{}{}
+		}
+
+		ret = gjson.GetBytes(bs, "telegram_robot_token")
+		if ret.Exists() {
+			telegramset[ret.String()] = struct{}{}
 		}
 	}
 
@@ -151,6 +157,15 @@ func notifyMaintainerWithBuiltin(title, msg, triggerTime string, users []*models
 			sender.SendMM(sender.MatterMostMessage{
 				Text:   content,
 				Tokens: StringSetKeys(mmset),
+			})
+		case "telegram":
+			if len(telegramset) == 0 {
+				continue
+			}
+			content := "**Title: **" + title + "\n**Content: **" + msg + "\n**Time: **" + triggerTime
+			sender.SendTelegram(sender.TelegramMessage{
+				Text:   content,
+				Tokens: StringSetKeys(telegramset),
 			})
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
告警通知功能增强
**What this PR does / why we need it**:
<!--
"Nice to have" "You need it" is not a good reason. :)
-->
增加了Telegram Bot通知的内置支持，具体的通知模板参考自企业微信机器人

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or "Fixes (paste link of issue)"
-->
Fixes #345
 
**Special notes for your reviewer**:

使用时，在用户的更多联系方式中，增加 telegram_robot_token 的配置项，值格式为 ”botToken/chatId“ ，也可以直接填入整个url链接，例如 ”https://api.telegram.org/botxxxx:xxxxxxxx/sendMessage?chat_id=123456“ ，支持url链接意味着使用方可以通过指定的自定义域名正向代理telegram官方api域名，从而达到国内正常使用的目的

我已经通过企业微信Bot的相关逻辑大概找了一些需要修改的地方，可能会有部分遗漏