### PR TITLE
fix: webapi conf sso section typo

### DIFF
--- a/etc/webapi.conf
+++ b/etc/webapi.conf
@@ -149,7 +149,7 @@ Email = "mail"
 
 [OIDC]
 Enable = false
-DiaplayName = "OIDC登录"
+DisplayName = "OIDC登录"
 RedirectURL = "http://n9e.com/callback"
 SsoAddr = "http://sso.example.org"
 ClientId = ""
@@ -164,7 +164,7 @@ Email = "email"
 
 [CAS]
 Enable = false
-DiaplayName = "CAS登录"
+DisplayName = "CAS登录"
 SsoAddr = "https://cas.example.com/cas/"
 RedirectURL = "http://127.0.0.1:18000/callback/cas"
 CoverAttributes = false


### PR DESCRIPTION
**What type of PR is this?**

**What this PR does / why we need it**:
<!--
"Nice to have" "You need it" is not a good reason. :)
-->
The `etc/webapi.conf` file contains typos that confuse first-time users in configuring SSO.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or "Fixes (paste link of issue)"
-->
Fixes #
 
**Special notes for your reviewer**:

After configuring SSO login according to the /etc/webapi.conf example file, accessing the WEB login page will not show SSO login options, and accessing `<host>/api/n9e/auth/sso-config` through the API interface will return the message : 
```json
{"dat":{"oidcDisplayName":"", "casDisplayName":"", "oauthDisplayName":""}, "err":""}
```
After reviewing the [source code](https://github.com/ccfos/nightingale/blob/main/src/pkg/cas/cas.go#LL20C3-L20C3), I found a spelling error in the configuration file. Fixing this error will helpful for first-time users.