### PR TITLE
replace lable host to ident

### DIFF
--- a/src/server/router/router_prom.go
+++ b/src/server/router/router_prom.go
@@ -104,6 +104,10 @@ func remoteWrite(c *gin.Context) {
 
 		// find ident label
 		for j := 0; j < len(req.Timeseries[i].Labels); j++ {
+			if req.Timeseries[i].Labels[j].Name == "host" {
+				req.Timeseries[i].Labels[j].Name = "ident"
+			}
+
 			if req.Timeseries[i].Labels[j].Name == "ident" {
 				ident = req.Timeseries[i].Labels[j].Value
 			}


### PR DESCRIPTION
采集端使用telegraf采集端时，主机标识为“host”，需改为“ident”
用[[outputs.http]]性能有较大提升(因使用protobuf)，telegraf配置段参考如下：
[[outputs.http]]
  url = "http://n9e_ip/prometheus/v1/write"
  data_format = "prometheusremotewrite"
  [outputs.http.headers]
     Content-Type = "application/x-protobuf"
     Content-Encoding = "snappy"
     X-Prometheus-Remote-Write-Version = "0.1.0"