### PR TITLE
target tags can rewrite labels deined in categraf config file

### DIFF
--- a/etc/server.conf
+++ b/etc/server.conf
@@ -16,6 +16,9 @@ DisableUsageReport = false
 # config | database
 ReaderFrom = "config"
 
+# if true, target tags can rewrite labels defined in categraf config file
+LabelRewrite = false
+
 [Log]
 # log write dir
 Dir = "logs"

--- a/src/server/config/config.go
+++ b/src/server/config/config.go
@@ -256,6 +256,7 @@ type Config struct {
 	EngineDelay        int64
 	DisableUsageReport bool
 	ReaderFrom         string
+	LabelRewrite	   bool
 	ForceUseServerTS   bool
 	Log                logx.Config
 	HTTP               httpx.Config


### PR DESCRIPTION
**What type of PR is this?**
a new feature, target tags can rewrite labels defined in categraf config file
**What this PR does / why we need it**:
sometimes we want to modify labels which defined in client agent. but it is difficult as there is  so many client. Of course we can do this by salt or ansible. Currently, when the label on the target is the same as the label in the configuration file, the label in the configuration file prevails. With a few modifications, you can make the label on the target overwrite the label in the configuration file.