### PR TITLE
remove docker compose platform

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -6,7 +6,7 @@ networks:
 
 services:
   mysql:
-    platform: linux/x86_64
+#    platform: linux/x86_64
     image: "mysql:5.7"
     container_name: mysql
     hostname: mysql


### PR DESCRIPTION
我直接在运行docker安装时报错
````
root@localhost:~/nightingale/docker# docker-compose up -d
ERROR: The Compose file './docker-compose.yaml' is invalid because:
Unsupported config option for services.mysql: 'platform'
````
错误截图:
![image](https://user-images.githubusercontent.com/1478692/210977494-5ce25c55-8d7a-402a-b933-b5df48f5072f.png)

移除platform字段后成功。
我的环境:
````
ubuntu 20.04
root@localhost:~/nightingale/docker# docker-compose version
docker-compose version 1.25.0, build unknown
docker-py version: 4.1.0
CPython version: 3.8.10
OpenSSL version: OpenSSL 1.1.1f  31 Mar 2020
````