### PR TITLE
feat: subscribe refactor

### DIFF
--- a/src/models/alert_subscribe.go
+++ b/src/models/alert_subscribe.go
@@ -250,3 +250,16 @@ func AlertSubscribeGetsByCluster(cluster string) ([]*AlertSubscribe, error) {
 	}
 	return slst, err
 }
+
+func (s *AlertSubscribe) MatchCluster(cluster string) bool {
+	if s.Cluster == ClusterAll {
+		return true
+	}
+	clusters := strings.Fields(s.Cluster)
+	for _, c := range clusters {
+		if c == cluster {
+			return true
+		}
+	}
+	return false
+}

--- a/src/models/alert_subscribe.go
+++ b/src/models/alert_subscribe.go
@@ -263,3 +263,17 @@ func (s *AlertSubscribe) MatchCluster(cluster string) bool {
 	}
 	return false
 }
+
+func (s *AlertSubscribe) ModifyEvent(event *AlertCurEvent) {
+	if s.RedefineSeverity == 1 {
+		event.Severity = s.NewSeverity
+	}
+
+	if s.RedefineChannels == 1 {
+		event.NotifyChannels = s.NewChannels
+		event.NotifyChannelsJSON = strings.Fields(s.NewChannels)
+	}
+
+	event.NotifyGroups = s.UserGroupIds
+	event.NotifyGroupsJSON = strings.Fields(s.UserGroupIds)
+}

--- a/src/models/user.go
+++ b/src/models/user.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"fmt"
-
 	"os"
 	"strings"
 	"time"

--- a/src/models/user.go
+++ b/src/models/user.go
@@ -580,7 +580,7 @@ func (u *User) ExtractToken(key string) (string, bool) {
 		ret := gjson.GetBytes(bs, "mm_robot_token")
 		return ret.String(), ret.Exists()
 	case Telegram:
-		ret := gjson.GetBytes(bs, "telgram_robot_token")
+		ret := gjson.GetBytes(bs, "telegram_robot_token")
 		return ret.String(), ret.Exists()
 	case Email:
 		return u.Email, u.Email != ""
@@ -604,7 +604,7 @@ func (u *User) ExtractAllToken() map[string]string {
 	ret[Dingtalk] = gjson.GetBytes(bs, "dingtalk_robot_token").String()
 	ret[Wecom] = gjson.GetBytes(bs, "wecom_robot_token").String()
 	ret[Feishu] = gjson.GetBytes(bs, "feishu_robot_token").String()
-	ret[Mm] = gjson.GetBytes(bs, "mm_robot_token").String()
-	ret[Telegram] = gjson.GetBytes(bs, "telgram_robot_token").String()
+	ret[Mm] = gjson.GetBytes(bs, "mm_webhook_url").String()
+	ret[Telegram] = gjson.GetBytes(bs, "telegram_robot_token").String()
 	return ret
 }

--- a/src/models/user.go
+++ b/src/models/user.go
@@ -25,6 +25,12 @@ const (
 	Mm       = "mm"
 	Telegram = "telegram"
 	Email    = "email"
+
+	DingtalkKey = "dingtalk_robot_token"
+	WecomKey    = "wecom_robot_token"
+	FeishuKey   = "feishu_robot_token"
+	MmKey       = "mm_webhook_url"
+	TelegramKey = "telegram_robot_token"
 )
 
 type User struct {
@@ -567,19 +573,19 @@ func (u *User) ExtractToken(key string) (string, bool) {
 
 	switch key {
 	case Dingtalk:
-		ret := gjson.GetBytes(bs, "dingtalk_robot_token")
+		ret := gjson.GetBytes(bs, DingtalkKey)
 		return ret.String(), ret.Exists()
 	case Wecom:
-		ret := gjson.GetBytes(bs, "wecom_robot_token")
+		ret := gjson.GetBytes(bs, WecomKey)
 		return ret.String(), ret.Exists()
 	case Feishu:
-		ret := gjson.GetBytes(bs, "feishu_robot_token")
+		ret := gjson.GetBytes(bs, FeishuKey)
 		return ret.String(), ret.Exists()
 	case Mm:
-		ret := gjson.GetBytes(bs, "mm_robot_token")
+		ret := gjson.GetBytes(bs, MmKey)
 		return ret.String(), ret.Exists()
 	case Telegram:
-		ret := gjson.GetBytes(bs, "telegram_robot_token")
+		ret := gjson.GetBytes(bs, TelegramKey)
 		return ret.String(), ret.Exists()
 	case Email:
 		return u.Email, u.Email != ""
@@ -600,10 +606,10 @@ func (u *User) ExtractAllToken() map[string]string {
 		return ret
 	}
 
-	ret[Dingtalk] = gjson.GetBytes(bs, "dingtalk_robot_token").String()
-	ret[Wecom] = gjson.GetBytes(bs, "wecom_robot_token").String()
-	ret[Feishu] = gjson.GetBytes(bs, "feishu_robot_token").String()
-	ret[Mm] = gjson.GetBytes(bs, "mm_webhook_url").String()
-	ret[Telegram] = gjson.GetBytes(bs, "telegram_robot_token").String()
+	ret[Dingtalk] = gjson.GetBytes(bs, DingtalkKey).String()
+	ret[Wecom] = gjson.GetBytes(bs, WecomKey).String()
+	ret[Feishu] = gjson.GetBytes(bs, FeishuKey).String()
+	ret[Mm] = gjson.GetBytes(bs, MmKey).String()
+	ret[Telegram] = gjson.GetBytes(bs, TelegramKey).String()
 	return ret
 }

--- a/src/server/common/sender/callback.go
+++ b/src/server/common/sender/callback.go
@@ -1,4 +1,4 @@
-package engine
+package sender
 
 import (
 	"strconv"
@@ -14,8 +14,7 @@ import (
 	"github.com/didi/nightingale/v5/src/server/memsto"
 )
 
-func callback(event *models.AlertCurEvent) {
-	urls := strings.Fields(event.Callbacks)
+func SendCallbacks(urls []string, event *models.AlertCurEvent) {
 	for _, url := range urls {
 		if url == "" {
 			continue

--- a/src/server/common/sender/dingtalk.go
+++ b/src/server/common/sender/dingtalk.go
@@ -11,13 +11,6 @@ import (
 	"github.com/didi/nightingale/v5/src/pkg/poster"
 )
 
-type DingtalkMessage struct {
-	Title     string
-	Text      string
-	AtMobiles []string
-	Tokens    []string
-}
-
 type dingtalkMarkdown struct {
 	Title string `json:"title"`
 	Text  string `json:"text"`

--- a/src/server/common/sender/dingtalk.go
+++ b/src/server/common/sender/dingtalk.go
@@ -1,12 +1,14 @@
 package sender
 
 import (
-	"net/url"
+	"html/template"
 	"strings"
 	"time"
 
-	"github.com/didi/nightingale/v5/src/pkg/poster"
 	"github.com/toolkits/pkg/logger"
+
+	"github.com/didi/nightingale/v5/src/models"
+	"github.com/didi/nightingale/v5/src/pkg/poster"
 )
 
 type DingtalkMessage struct {
@@ -32,48 +34,91 @@ type dingtalk struct {
 	At       dingtalkAt       `json:"at"`
 }
 
-func SendDingtalk(message DingtalkMessage) {
-	ats := make([]string, len(message.AtMobiles))
-	for i := 0; i < len(message.AtMobiles); i++ {
-		ats[i] = "@" + message.AtMobiles[i]
+type DingtalkSender struct {
+	tpl *template.Template
+}
+
+func (ds *DingtalkSender) Send(ctx MessageContext) {
+	if len(ctx.Users) == 0 || ctx.Rule == nil || ctx.Event == nil {
+		return
 	}
 
-	for i := 0; i < len(message.Tokens); i++ {
-		u, err := url.Parse(message.Tokens[i])
-		if err != nil {
-			logger.Errorf("dingtalk_sender: failed to parse error=%v", err)
-		}
+	urls, ats := ds.extract(ctx.Users)
+	if len(urls) == 0 {
+		return
+	}
+	message := BuildTplMessage(ds.tpl, ctx.Event)
 
-		v, err := url.ParseQuery(u.RawQuery)
-		if err != nil {
-			logger.Errorf("dingtalk_sender: failed to parse query error=%v", err)
-		}
-
-		ur := "https://oapi.dingtalk.com/robot/send?access_token=" + u.Path
-		if strings.HasPrefix(message.Tokens[i], "https://") {
-			ur = message.Tokens[i]
-		}
-		body := dingtalk{
-			Msgtype: "markdown",
-			Markdown: dingtalkMarkdown{
-				Title: message.Title,
-				Text:  message.Text,
-			},
-		}
-
-		if v.Get("noat") != "1" {
-			body.Markdown.Text = message.Text + " " + strings.Join(ats, " ")
-			body.At = dingtalkAt{
-				AtMobiles: message.AtMobiles,
-				IsAtAll:   false,
+	for _, url := range urls {
+		var body dingtalk
+		// NoAt in url
+		if strings.Contains(url, "noat=1") {
+			body = dingtalk{
+				Msgtype: "markdown",
+				Markdown: dingtalkMarkdown{
+					Title: ctx.Rule.Name,
+					Text:  message,
+				},
+			}
+		} else {
+			body = dingtalk{
+				Msgtype: "markdown",
+				Markdown: dingtalkMarkdown{
+					Title: ctx.Rule.Name,
+					Text:  message + " " + strings.Join(ats, " "),
+				},
+				At: dingtalkAt{
+					AtMobiles: ats,
+					IsAtAll:   false,
+				},
 			}
 		}
+		ds.doSend(url, body)
+	}
+}
 
-		res, code, err := poster.PostJSON(ur, time.Second*5, body, 3)
-		if err != nil {
-			logger.Errorf("dingtalk_sender: result=fail url=%s code=%d error=%v response=%s", ur, code, err, string(res))
-		} else {
-			logger.Infof("dingtalk_sender: result=succ url=%s code=%d response=%s", ur, code, string(res))
+func (ds *DingtalkSender) SendRaw(users []*models.User, title, message string) {
+	if len(users) == 0 {
+		return
+	}
+	urls, _ := ds.extract(users)
+	body := dingtalk{
+		Msgtype: "markdown",
+		Markdown: dingtalkMarkdown{
+			Title: title,
+			Text:  message,
+		},
+	}
+	for _, url := range urls {
+		ds.doSend(url, body)
+	}
+}
+
+// extract urls and ats from Users
+func (ds *DingtalkSender) extract(users []*models.User) ([]string, []string) {
+	urls := make([]string, 0, len(users))
+	ats := make([]string, 0, len(users))
+
+	for _, user := range users {
+		if user.Phone != "" {
+			ats = append(ats, "@"+user.Phone)
 		}
+		if token, has := user.ExtractToken("dingtalk"); has {
+			url := token
+			if !strings.HasPrefix(token, "https://") {
+				url = "https://oapi.dingtalk.com/robot/send?access_token=" + token
+			}
+			urls = append(urls, url)
+		}
+	}
+	return urls, ats
+}
+
+func (ds *DingtalkSender) doSend(url string, body dingtalk) {
+	res, code, err := poster.PostJSON(url, time.Second*5, body, 3)
+	if err != nil {
+		logger.Errorf("dingtalk_sender: result=fail url=%s code=%d error=%v response=%s", url, code, err, string(res))
+	} else {
+		logger.Infof("dingtalk_sender: result=succ url=%s code=%d response=%s", url, code, string(res))
 	}
 }

--- a/src/server/common/sender/feishu.go
+++ b/src/server/common/sender/feishu.go
@@ -11,12 +11,6 @@ import (
 	"github.com/didi/nightingale/v5/src/pkg/poster"
 )
 
-type FeishuMessage struct {
-	Text      string
-	AtMobiles []string
-	Tokens    []string
-}
-
 type feishuContent struct {
 	Text string `json:"text"`
 }

--- a/src/server/common/sender/feishu.go
+++ b/src/server/common/sender/feishu.go
@@ -1,11 +1,14 @@
 package sender
 
 import (
+	"html/template"
 	"strings"
 	"time"
 
-	"github.com/didi/nightingale/v5/src/pkg/poster"
 	"github.com/toolkits/pkg/logger"
+
+	"github.com/didi/nightingale/v5/src/models"
+	"github.com/didi/nightingale/v5/src/pkg/poster"
 )
 
 type FeishuMessage struct {
@@ -29,28 +32,73 @@ type feishu struct {
 	At      feishuAt      `json:"at"`
 }
 
-func SendFeishu(message FeishuMessage) {
-	for i := 0; i < len(message.Tokens); i++ {
-		url := "https://open.feishu.cn/open-apis/bot/v2/hook/" + message.Tokens[i]
-		if strings.HasPrefix(message.Tokens[i], "https://") {
-			url = message.Tokens[i]
-		}
+type FeishuSender struct {
+	tpl *template.Template
+}
+
+func (fs *FeishuSender) Send(ctx MessageContext) {
+	if len(ctx.Users) == 0 || ctx.Rule == nil || ctx.Event == nil {
+		return
+	}
+	urls, ats := fs.extract(ctx.Users)
+	message := BuildTplMessage(fs.tpl, ctx.Event)
+	for _, url := range urls {
 		body := feishu{
 			Msgtype: "text",
 			Content: feishuContent{
-				Text: message.Text,
+				Text: message,
 			},
-			At: feishuAt{
-				AtMobiles: message.AtMobiles,
+		}
+		if !strings.Contains(url, "noat=1") {
+			body.At = feishuAt{
+				AtMobiles: ats,
 				IsAtAll:   false,
-			},
+			}
 		}
+		fs.doSend(url, body)
+	}
+}
 
-		res, code, err := poster.PostJSON(url, time.Second*5, body, 3)
-		if err != nil {
-			logger.Errorf("feishu_sender: result=fail url=%s code=%d error=%v response=%s", url, code, err, string(res))
-		} else {
-			logger.Infof("feishu_sender: result=succ url=%s code=%d response=%s", url, code, string(res))
+func (fs *FeishuSender) SendRaw(users []*models.User, title, message string) {
+	if len(users) == 0 {
+		return
+	}
+	urls, _ := fs.extract(users)
+	body := feishu{
+		Msgtype: "text",
+		Content: feishuContent{
+			Text: message,
+		},
+	}
+	for _, url := range urls {
+		fs.doSend(url, body)
+	}
+}
+
+func (fs *FeishuSender) extract(users []*models.User) ([]string, []string) {
+	urls := make([]string, 0, len(users))
+	ats := make([]string, 0, len(users))
+
+	for _, user := range users {
+		if user.Phone != "" {
+			ats = append(ats, user.Phone)
 		}
+		if token, has := user.ExtractToken("feishu"); has {
+			url := token
+			if !strings.HasPrefix(token, "https://") {
+				url = "https://open.feishu.cn/open-apis/bot/v2/hook/" + token
+			}
+			urls = append(urls, url)
+		}
+	}
+	return urls, ats
+}
+
+func (fs *FeishuSender) doSend(url string, body feishu) {
+	res, code, err := poster.PostJSON(url, time.Second*5, body, 3)
+	if err != nil {
+		logger.Errorf("feishu_sender: result=fail url=%s code=%d error=%v response=%s", url, code, err, string(res))
+	} else {
+		logger.Infof("feishu_sender: result=succ url=%s code=%d response=%s", url, code, string(res))
 	}
 }

--- a/src/server/common/sender/mm.go
+++ b/src/server/common/sender/mm.go
@@ -1,12 +1,15 @@
 package sender
 
 import (
+	"html/template"
 	"net/url"
 	"strings"
 	"time"
 
-	"github.com/didi/nightingale/v5/src/pkg/poster"
 	"github.com/toolkits/pkg/logger"
+
+	"github.com/didi/nightingale/v5/src/models"
+	"github.com/didi/nightingale/v5/src/pkg/poster"
 )
 
 type MatterMostMessage struct {
@@ -20,12 +23,46 @@ type mm struct {
 	Text     string `json:"text"`
 }
 
-func MapStrToStr(arr []string, fn func(s string) string) []string {
-	var newArray = []string{}
-	for _, it := range arr {
-		newArray = append(newArray, fn(it))
+type MmSender struct {
+	tpl *template.Template
+}
+
+func (ms *MmSender) Send(ctx MessageContext) {
+	if len(ctx.Users) == 0 || ctx.Rule == nil || ctx.Event == nil {
+		return
 	}
-	return newArray
+
+	urls := ms.extract(ctx.Users)
+	if len(urls) == 0 {
+		return
+	}
+	message := BuildTplMessage(ms.tpl, ctx.Event)
+
+	SendMM(MatterMostMessage{
+		Text:   message,
+		Tokens: urls,
+	})
+}
+
+func (ms *MmSender) SendRaw(users []*models.User, title, message string) {
+	urls := ms.extract(users)
+	if len(urls) == 0 {
+		return
+	}
+	SendMM(MatterMostMessage{
+		Text:   message,
+		Tokens: urls,
+	})
+}
+
+func (ms *MmSender) extract(users []*models.User) []string {
+	tokens := make([]string, 0, len(users))
+	for _, user := range users {
+		if token, has := user.ExtractToken("mm"); has {
+			tokens = append(tokens, token)
+		}
+	}
+	return tokens
 }
 
 func SendMM(message MatterMostMessage) {
@@ -70,4 +107,12 @@ func SendMM(message MatterMostMessage) {
 			}
 		}
 	}
+}
+
+func MapStrToStr(arr []string, fn func(s string) string) []string {
+	var newArray = []string{}
+	for _, it := range arr {
+		newArray = append(newArray, fn(it))
+	}
+	return newArray
 }

--- a/src/server/common/sender/plugin.go
+++ b/src/server/common/sender/plugin.go
@@ -1,0 +1,85 @@
+package sender
+
+import (
+	"bytes"
+	"os/exec"
+	"time"
+
+	"github.com/toolkits/pkg/logger"
+
+	"github.com/didi/nightingale/v5/src/notifier"
+	"github.com/didi/nightingale/v5/src/pkg/sys"
+	"github.com/didi/nightingale/v5/src/server/config"
+)
+
+func MayPluginNotify(noticeBytes []byte) {
+	if len(noticeBytes) == 0 {
+		return
+	}
+	alertingCallPlugin(noticeBytes)
+	alertingCallScript(noticeBytes)
+}
+
+func alertingCallScript(stdinBytes []byte) {
+	if !config.C.Alerting.CallScript.Enable {
+		return
+	}
+
+	// no notify.py? do nothing
+	if config.C.Alerting.CallScript.ScriptPath == "" {
+		return
+	}
+
+	if config.C.Alerting.Timeout == 0 {
+		config.C.Alerting.Timeout = 30000
+	}
+
+	fpath := config.C.Alerting.CallScript.ScriptPath
+	cmd := exec.Command(fpath)
+	cmd.Stdin = bytes.NewReader(stdinBytes)
+
+	// combine stdout and stderr
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+
+	err := startCmd(cmd)
+	if err != nil {
+		logger.Errorf("event_notify: run cmd err: %v", err)
+		return
+	}
+
+	err, isTimeout := sys.WrapTimeout(cmd, time.Duration(config.C.Alerting.Timeout)*time.Millisecond)
+
+	if isTimeout {
+		if err == nil {
+			logger.Errorf("event_notify: timeout and killed process %s", fpath)
+		}
+
+		if err != nil {
+			logger.Errorf("event_notify: kill process %s occur error %v", fpath, err)
+		}
+
+		return
+	}
+
+	if err != nil {
+		logger.Errorf("event_notify: exec script %s occur error: %v, output: %s", fpath, err, buf.String())
+		return
+	}
+
+	logger.Infof("event_notify: exec %s output: %s", fpath, buf.String())
+}
+
+// call notify.so via golang plugin build
+// ig. etc/script/notify/notify.so
+func alertingCallPlugin(stdinBytes []byte) {
+	if !config.C.Alerting.CallPlugin.Enable {
+		return
+	}
+
+	logger.Debugf("alertingCallPlugin begin")
+	logger.Debugf("payload:", string(stdinBytes))
+	notifier.Instance.Notify(stdinBytes)
+	logger.Debugf("alertingCallPlugin done")
+}

--- a/src/server/common/sender/plugin.go
+++ b/src/server/common/sender/plugin.go
@@ -21,17 +21,9 @@ func MayPluginNotify(noticeBytes []byte) {
 }
 
 func alertingCallScript(stdinBytes []byte) {
-	if !config.C.Alerting.CallScript.Enable {
+	// not enable or no notify.py? do nothing
+	if !config.C.Alerting.CallScript.Enable || config.C.Alerting.CallScript.ScriptPath == "" {
 		return
-	}
-
-	// no notify.py? do nothing
-	if config.C.Alerting.CallScript.ScriptPath == "" {
-		return
-	}
-
-	if config.C.Alerting.Timeout == 0 {
-		config.C.Alerting.Timeout = 30000
 	}
 
 	fpath := config.C.Alerting.CallScript.ScriptPath

--- a/src/server/common/sender/plugin_cmd_unix.go
+++ b/src/server/common/sender/plugin_cmd_unix.go
@@ -1,7 +1,7 @@
 //go:build !windows
 // +build !windows
 
-package engine
+package sender
 
 import (
 	"os/exec"

--- a/src/server/common/sender/plugin_cmd_windows.go
+++ b/src/server/common/sender/plugin_cmd_windows.go
@@ -1,4 +1,4 @@
-package engine
+package sender
 
 import "os/exec"
 

--- a/src/server/common/sender/redis_pub.go
+++ b/src/server/common/sender/redis_pub.go
@@ -1,0 +1,21 @@
+package sender
+
+import (
+	"context"
+
+	"github.com/toolkits/pkg/logger"
+
+	"github.com/didi/nightingale/v5/src/server/config"
+	"github.com/didi/nightingale/v5/src/storage"
+)
+
+func PublishToRedis(clusterName string, bs []byte) {
+	channelKey := config.C.Alerting.RedisPub.ChannelPrefix + clusterName
+	// pub all alerts to redis
+	if config.C.Alerting.RedisPub.Enable {
+		err := storage.Redis.Publish(context.Background(), channelKey, bs).Err()
+		if err != nil {
+			logger.Errorf("event_notify: redis publish %s err: %v", channelKey, err)
+		}
+	}
+}

--- a/src/server/common/sender/redis_pub.go
+++ b/src/server/common/sender/redis_pub.go
@@ -10,6 +10,9 @@ import (
 )
 
 func PublishToRedis(clusterName string, bs []byte) {
+	if len(bs) == 0 {
+		return
+	}
 	channelKey := config.C.Alerting.RedisPub.ChannelPrefix + clusterName
 	// pub all alerts to redis
 	if config.C.Alerting.RedisPub.Enable {

--- a/src/server/common/sender/sender.go
+++ b/src/server/common/sender/sender.go
@@ -1,0 +1,54 @@
+package sender
+
+import (
+	"bytes"
+	"github.com/didi/nightingale/v5/src/server/config"
+	"github.com/toolkits/pkg/slice"
+	"html/template"
+
+	"github.com/didi/nightingale/v5/src/models"
+)
+
+type MessageContext struct {
+	Users []*models.User
+	Rule  *models.AlertRule
+	Event *models.AlertCurEvent
+}
+
+type Sender interface {
+	Send(ctx MessageContext)
+	SendRaw(users []*models.User, title, message string)
+}
+
+func NewSender(key string, tpls map[string]*template.Template) Sender {
+	if !slice.ContainsString(config.C.Alerting.NotifyBuiltinChannels, key) {
+		return nil
+	}
+
+	switch key {
+	case models.Dingtalk:
+		return &DingtalkSender{tpl: tpls["dingtalk.tpl"]}
+	case models.Wecom:
+		return &WecomSender{tpl: tpls["wecom.tpl"]}
+	case models.Feishu:
+		return &FeishuSender{tpl: tpls["feishu.tpl"]}
+	case models.Email:
+		return &EmailSender{subjectTpl: tpls["subject.tpl"], contentTpl: tpls["mailbody.tpl"]}
+	case models.Mm:
+		return &MmSender{tpl: tpls["mm.tpl"]}
+	case models.Telegram:
+		return &TelegramSender{tpl: tpls["telegram.tpl"]}
+	}
+	return nil
+}
+
+func BuildTplMessage(tpl *template.Template, event *models.AlertCurEvent) string {
+	if tpl == nil {
+		return "tpl for current sender not found, please check configuration"
+	}
+	var body bytes.Buffer
+	if err := tpl.Execute(&body, event); err != nil {
+		return err.Error()
+	}
+	return body.String()
+}

--- a/src/server/common/sender/telegram.go
+++ b/src/server/common/sender/telegram.go
@@ -1,13 +1,14 @@
 package sender
 
 import (
-	"github.com/didi/nightingale/v5/src/models"
 	"html/template"
 	"strings"
 	"time"
 
-	"github.com/didi/nightingale/v5/src/pkg/poster"
 	"github.com/toolkits/pkg/logger"
+
+	"github.com/didi/nightingale/v5/src/models"
+	"github.com/didi/nightingale/v5/src/pkg/poster"
 )
 
 type TelegramMessage struct {

--- a/src/server/common/sender/webhook.go
+++ b/src/server/common/sender/webhook.go
@@ -36,6 +36,10 @@ func SendWebhooks(webhooks []config.Webhook, event *models.AlertCurEvent) {
 
 		if len(conf.Headers) > 0 && len(conf.Headers)%2 == 0 {
 			for i := 0; i < len(conf.Headers); i += 2 {
+				if conf.Headers[i] == "host" {
+					req.Host = conf.Headers[i+1]
+					continue
+				}
 				req.Header.Set(conf.Headers[i], conf.Headers[i+1])
 			}
 		}
@@ -47,7 +51,7 @@ func SendWebhooks(webhooks []config.Webhook, event *models.AlertCurEvent) {
 		var resp *http.Response
 		resp, err = client.Do(req)
 		if err != nil {
-			logger.Warning("alertingWebhook failed to call url, error: ", err)
+			logger.Warningf("WebhookCallError, ruleId: [%d], eventId: [%d], url: [%s], error: [%s]", event.RuleId, event.Id, conf.Url, err)
 			continue
 		}
 

--- a/src/server/common/sender/webhook.go
+++ b/src/server/common/sender/webhook.go
@@ -1,0 +1,62 @@
+package sender
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/toolkits/pkg/logger"
+
+	"github.com/didi/nightingale/v5/src/models"
+	"github.com/didi/nightingale/v5/src/server/config"
+)
+
+func SendWebhooks(webhooks []config.Webhook, event *models.AlertCurEvent) {
+	for _, conf := range webhooks {
+		if conf.Url == "" || !conf.Enable {
+			continue
+		}
+		bs, err := json.Marshal(event)
+		if err != nil {
+			continue
+		}
+
+		bf := bytes.NewBuffer(bs)
+
+		req, err := http.NewRequest("POST", conf.Url, bf)
+		if err != nil {
+			logger.Warning("alertingWebhook failed to new request", err)
+			continue
+		}
+
+		if conf.BasicAuthUser != "" && conf.BasicAuthPass != "" {
+			req.SetBasicAuth(conf.BasicAuthUser, conf.BasicAuthPass)
+		}
+
+		if len(conf.Headers) > 0 && len(conf.Headers)%2 == 0 {
+			for i := 0; i < len(conf.Headers); i += 2 {
+				req.Header.Set(conf.Headers[i], conf.Headers[i+1])
+			}
+		}
+
+		client := http.Client{
+			Timeout: conf.TimeoutDuration,
+		}
+
+		var resp *http.Response
+		resp, err = client.Do(req)
+		if err != nil {
+			logger.Warning("alertingWebhook failed to call url, error: ", err)
+			continue
+		}
+
+		var body []byte
+		if resp.Body != nil {
+			defer resp.Body.Close()
+			body, _ = ioutil.ReadAll(resp.Body)
+		}
+
+		logger.Debugf("alertingWebhook done, url: %s, response code: %d, body: %s", conf.Url, resp.StatusCode, string(body))
+	}
+}

--- a/src/server/common/sender/wecom.go
+++ b/src/server/common/sender/wecom.go
@@ -1,9 +1,11 @@
 package sender
 
 import (
+	"html/template"
 	"strings"
 	"time"
 
+	"github.com/didi/nightingale/v5/src/models"
 	"github.com/didi/nightingale/v5/src/pkg/poster"
 	"github.com/toolkits/pkg/logger"
 )
@@ -22,24 +24,59 @@ type wecom struct {
 	Markdown wecomMarkdown `json:"markdown"`
 }
 
-func SendWecom(message WecomMessage) {
-	for i := 0; i < len(message.Tokens); i++ {
-		url := "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=" + message.Tokens[i]
-		if strings.HasPrefix(message.Tokens[i], "https://") {
-			url = message.Tokens[i]
-		}
+type WecomSender struct {
+	tpl *template.Template
+}
+
+func (ws *WecomSender) Send(ctx MessageContext) {
+	if len(ctx.Users) == 0 || ctx.Rule == nil || ctx.Event == nil {
+		return
+	}
+	urls := ws.extract(ctx.Users)
+	message := BuildTplMessage(ws.tpl, ctx.Event)
+	for _, url := range urls {
 		body := wecom{
 			Msgtype: "markdown",
 			Markdown: wecomMarkdown{
-				Content: message.Text,
+				Content: message,
 			},
 		}
+		ws.doSend(url, body)
+	}
+}
 
-		res, code, err := poster.PostJSON(url, time.Second*5, body, 3)
-		if err != nil {
-			logger.Errorf("wecom_sender: result=fail url=%s code=%d error=%v response=%s", url, code, err, string(res))
-		} else {
-			logger.Infof("wecom_sender: result=succ url=%s code=%d response=%s", url, code, string(res))
+func (ws *WecomSender) SendRaw(users []*models.User, title, message string) {
+	urls := ws.extract(users)
+	for _, url := range urls {
+		body := wecom{
+			Msgtype: "markdown",
+			Markdown: wecomMarkdown{
+				Content: message,
+			},
 		}
+		ws.doSend(url, body)
+	}
+}
+
+func (ws *WecomSender) extract(users []*models.User) []string {
+	urls := make([]string, 0, len(users))
+	for _, user := range users {
+		if token, has := user.ExtractToken("wecom"); has {
+			url := token
+			if !strings.HasPrefix(token, "https://") {
+				url = "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=" + token
+			}
+			urls = append(urls, url)
+		}
+	}
+	return urls
+}
+
+func (ws *WecomSender) doSend(url string, body wecom) {
+	res, code, err := poster.PostJSON(url, time.Second*5, body, 3)
+	if err != nil {
+		logger.Errorf("wecom_sender: result=fail url=%s code=%d error=%v response=%s", url, code, err, string(res))
+	} else {
+		logger.Infof("wecom_sender: result=succ url=%s code=%d response=%s", url, code, string(res))
 	}
 }

--- a/src/server/common/sender/wecom.go
+++ b/src/server/common/sender/wecom.go
@@ -5,15 +5,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/toolkits/pkg/logger"
+
 	"github.com/didi/nightingale/v5/src/models"
 	"github.com/didi/nightingale/v5/src/pkg/poster"
-	"github.com/toolkits/pkg/logger"
 )
-
-type WecomMessage struct {
-	Text   string
-	Tokens []string
-}
 
 type wecomMarkdown struct {
 	Content string `json:"content"`

--- a/src/server/engine/channel.go
+++ b/src/server/engine/channel.go
@@ -1,0 +1,145 @@
+package engine
+
+import (
+	"github.com/didi/nightingale/v5/src/models"
+	"github.com/didi/nightingale/v5/src/server/config"
+)
+
+// NotifyChannels channelKey -> bool
+type NotifyChannels map[string]bool
+
+func NewNotifyChannels(channels []string) NotifyChannels {
+	nc := make(NotifyChannels)
+	for _, ch := range channels {
+		nc[ch] = true
+	}
+	return nc
+}
+
+func (nc NotifyChannels) OrMerge(other NotifyChannels) {
+	if other == nil {
+		return
+	}
+	for k, v := range other {
+		if curV, has := nc[k]; has {
+			nc[k] = curV || v
+		} else {
+			nc[k] = v
+		}
+	}
+}
+
+func (nc NotifyChannels) AndMerge(other NotifyChannels) {
+	if other == nil {
+		return
+	}
+	for k, v := range other {
+		if curV, has := nc[k]; has {
+			nc[k] = curV && v
+		} else {
+			nc[k] = v
+		}
+	}
+}
+
+type Subscription struct {
+	userMap   map[int64]NotifyChannels
+	webhooks  map[string]config.Webhook
+	callbacks map[string]struct{}
+}
+
+func NewSubscription() *Subscription {
+	return &Subscription{
+		userMap:   make(map[int64]NotifyChannels),
+		webhooks:  make(map[string]config.Webhook),
+		callbacks: make(map[string]struct{}),
+	}
+}
+
+func NewSubscriptionFromUsers(users []*models.User) *Subscription {
+	s := NewSubscription()
+	for _, u := range users {
+		if u == nil {
+			continue
+		}
+		for channel, token := range u.ExtractAllToken() {
+			if token == "" {
+				continue
+			}
+			if channelMap, has := s.userMap[u.Id]; has {
+				channelMap[channel] = true
+			} else {
+				channelMap := make(map[string]bool)
+				channelMap[channel] = true
+				s.userMap[u.Id] = channelMap
+			}
+		}
+	}
+	return s
+}
+
+func (s *Subscription) OrMerge(other *Subscription) {
+	if other == nil {
+		return
+	}
+	for k, v := range other.userMap {
+		if curV, has := s.userMap[k]; has {
+			curV.OrMerge(v)
+		} else {
+			s.userMap[k] = v
+		}
+	}
+	for k, v := range other.webhooks {
+		s.webhooks[k] = v
+	}
+	for k, v := range other.callbacks {
+		s.callbacks[k] = v
+	}
+}
+
+func (s *Subscription) AndMerge(other *Subscription) {
+	if other == nil {
+		return
+	}
+	for k, v := range other.userMap {
+		if curV, has := s.userMap[k]; has {
+			curV.AndMerge(v)
+		} else {
+			s.userMap[k] = v
+		}
+	}
+	for k, v := range other.webhooks {
+		s.webhooks[k] = v
+	}
+	for k, v := range other.callbacks {
+		s.callbacks[k] = v
+	}
+}
+
+func (s *Subscription) ToChannelUserMap() map[string][]int64 {
+	m := make(map[string][]int64)
+	for uid, nc := range s.userMap {
+		for ch, send := range nc {
+			if send {
+				m[ch] = append(m[ch], uid)
+			}
+		}
+	}
+	return m
+}
+
+func (s *Subscription) ToCallbackList() []string {
+	callbacks := make([]string, 0, len(s.callbacks))
+	for cb := range s.callbacks {
+		callbacks = append(callbacks, cb)
+	}
+	return callbacks
+}
+
+func (s *Subscription) ToWebhookList() []config.Webhook {
+	webhooks := make([]config.Webhook, 0, len(s.webhooks))
+	for _, wh := range s.webhooks {
+		webhooks = append(webhooks, wh)
+	}
+	return webhooks
+}

--- a/src/server/engine/consume.go
+++ b/src/server/engine/consume.go
@@ -167,11 +167,3 @@ func mapKeys(m map[int64]struct{}) []int64 {
 	}
 	return lst
 }
-
-func StringSetKeys(m map[string]struct{}) []string {
-	lst := make([]string, 0, len(m))
-	for k := range m {
-		lst = append(lst, k)
-	}
-	return lst
-}

--- a/src/server/engine/consume.go
+++ b/src/server/engine/consume.go
@@ -59,9 +59,7 @@ func consumeOne(event *models.AlertCurEvent) {
 		return
 	}
 
-	fillUsers(event)
-	callback(event)
-	notify(event)
+	HandleEventNotify(event, false)
 }
 
 func persist(event *models.AlertCurEvent) {
@@ -146,7 +144,6 @@ func fillUsers(e *models.AlertCurEvent) {
 		if err != nil {
 			continue
 		}
-
 		gids = append(gids, gid)
 	}
 

--- a/src/server/engine/engine.go
+++ b/src/server/engine/engine.go
@@ -20,8 +20,6 @@ func Start(ctx context.Context) error {
 		return err
 	}
 
-	initRouters()
-
 	// start loop consumer
 	go loopConsume(ctx)
 

--- a/src/server/engine/engine.go
+++ b/src/server/engine/engine.go
@@ -20,11 +20,10 @@ func Start(ctx context.Context) error {
 		return err
 	}
 
+	initRouters()
+
 	// start loop consumer
 	go loopConsume(ctx)
-
-	// filter my rules and start worker
-	//go loopFilterRules(ctx)
 
 	go ruleHolder.LoopSyncRules(ctx)
 

--- a/src/server/engine/logger.go
+++ b/src/server/engine/logger.go
@@ -1,8 +1,9 @@
 package engine
 
 import (
-	"github.com/didi/nightingale/v5/src/models"
 	"github.com/toolkits/pkg/logger"
+
+	"github.com/didi/nightingale/v5/src/models"
 )
 
 func LogEvent(event *models.AlertCurEvent, location string, err ...error) {

--- a/src/server/engine/notify.go
+++ b/src/server/engine/notify.go
@@ -19,22 +19,15 @@ var (
 	Senders map[string]sender.Sender
 
 	// 处理事件到subscription关系,处理的subscription用OrMerge进行合并
-	routers []Router
+	routers = []Router{GroupRouter, GlobalWebhookRouter, EventCallbacksRouter}
 	// 额外去掉一些订阅,处理的subscription用AndMerge进行合并, 如设置 channel=false,合并后不通过这个channel发送
+	// 如果实现了相关Router,可以添加到interceptors中
 	interceptors []Router
 
 	// 额外的订阅event逻辑处理
-	subscribeRouters      []Router
+	subscribeRouters      = []Router{GroupRouter}
 	subscribeInterceptors []Router
 )
-
-func initRouters() {
-	routers = []Router{GroupRouter, GlobalWebhookRouter, EventCallbacksRouter}
-	interceptors = []Router{}
-
-	subscribeRouters = []Router{GroupRouter}
-	subscribeInterceptors = []Router{}
-}
 
 func reloadTpls() error {
 	tmpTpls, err := config.C.Alerting.ListTpls()

--- a/src/server/engine/notify.go
+++ b/src/server/engine/notify.go
@@ -4,20 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"html/template"
-	"path"
-	"strings"
 	"sync"
 
-	"github.com/pkg/errors"
-	"github.com/toolkits/pkg/file"
-	"github.com/toolkits/pkg/logger"
-	"github.com/toolkits/pkg/runner"
-
 	"github.com/didi/nightingale/v5/src/models"
-	"github.com/didi/nightingale/v5/src/pkg/tplx"
 	"github.com/didi/nightingale/v5/src/server/common/sender"
 	"github.com/didi/nightingale/v5/src/server/config"
 	"github.com/didi/nightingale/v5/src/server/memsto"
+	"github.com/toolkits/pkg/logger"
 )
 
 var (
@@ -30,62 +23,26 @@ var (
 	routers []Router
 
 	// 额外去掉一些订阅,处理的subscription用AndMerge进行合并, 如设置 channel=false,合并后不通过这个channel发送
-	// 目前还不需要这块的逻辑，暂时注释掉
-	//interceptors []Router
+	interceptors []Router
 
 	// 额外的订阅event逻辑处理
 	subscribeRouters []Router
 
-	//subcribeInterceptors []Router
+	subscribeInterceptors []Router
 )
 
 func initRouters() {
-	routers = make([]Router, 0)
-	routers = append(routers, GroupRouter)
-	routers = append(routers, GlobalWebhookRouter)
-	routers = append(routers, EventCallbacksRouter)
+	routers = []Router{GroupRouter, GlobalWebhookRouter, EventCallbacksRouter}
+	interceptors = []Router{}
 
-	//interceptors = make([]Router, 0)
-
-	subscribeRouters = make([]Router, 0)
-	subscribeRouters = append(subscribeRouters, GroupRouter)
-
-	//subcribeInterceptors = make([]Router, 0)
+	subscribeRouters = []Router{GroupRouter}
+	subscribeInterceptors = []Router{}
 }
 
 func reloadTpls() error {
-	if config.C.Alerting.TemplatesDir == "" {
-		config.C.Alerting.TemplatesDir = path.Join(runner.Cwd, "etc", "template")
-	}
-
-	filenames, err := file.FilesUnder(config.C.Alerting.TemplatesDir)
+	tmpTpls, err := config.C.Alerting.ListTpls()
 	if err != nil {
-		return errors.WithMessage(err, "failed to exec FilesUnder")
-	}
-
-	if len(filenames) == 0 {
-		return errors.New("no tpl files under " + config.C.Alerting.TemplatesDir)
-	}
-
-	tplFiles := make([]string, 0, len(filenames))
-	for i := 0; i < len(filenames); i++ {
-		if strings.HasSuffix(filenames[i], ".tpl") {
-			tplFiles = append(tplFiles, filenames[i])
-		}
-	}
-
-	if len(tplFiles) == 0 {
-		return errors.New("no tpl files under " + config.C.Alerting.TemplatesDir)
-	}
-
-	tmpTpls := make(map[string]*template.Template)
-	for _, tplFile := range tplFiles {
-		tplpath := path.Join(config.C.Alerting.TemplatesDir, tplFile)
-		tpl, err := template.New(tplFile).Funcs(tplx.TemplateFuncMap).ParseFiles(tplpath)
-		if err != nil {
-			return errors.WithMessage(err, "failed to parse tpl: "+tplpath)
-		}
-		tmpTpls[tplFile] = tpl
+		return err
 	}
 
 	senders := map[string]sender.Sender{
@@ -109,31 +66,33 @@ func HandleEventNotify(event *models.AlertCurEvent, isSubscribe bool) {
 	if rule == nil {
 		return
 	}
-	var (
-		handlers []Router
-		//interceptorHandlers []Router
-	)
 	fillUsers(event)
 
+	var (
+		handlers            []Router
+		interceptorHandlers []Router
+	)
 	if isSubscribe {
 		handlers = subscribeRouters
-		//interceptorHandlers = subcribeInterceptors
+		interceptorHandlers = subscribeInterceptors
 	} else {
 		handlers = routers
-		//interceptorHandlers = interceptors
+		interceptorHandlers = interceptors
 	}
 
 	subscription := NewSubscription()
-	// 处理订阅关系
+	// 处理订阅关系使用OrMerge
 	for _, handler := range handlers {
 		subscription.OrMerge(handler(rule, event, subscription))
 	}
 
 	// 处理移除订阅关系的逻辑,比如员工离职，临时静默某个通道的策略等
-	//for _, handler := range interceptorHandlers {
-	//	subscription.AndMerge(handler(rule, event, subscription))
-	//}
-	Send(rule, event, subscription, isSubscribe)
+	for _, handler := range interceptorHandlers {
+		subscription.AndMerge(handler(rule, event, subscription))
+	}
+
+	// 处理事件发送,这里用一个goroutine处理一个event的所有发送事件
+	go Send(rule, event, subscription, isSubscribe)
 
 	// 如果是sub规则出现的event,不用再进行后续的处理
 	if isSubscribe {
@@ -141,16 +100,17 @@ func HandleEventNotify(event *models.AlertCurEvent, isSubscribe bool) {
 	}
 
 	// handle alert subscribes
+	subscribes := make([]*models.AlertSubscribe, 0)
+	// rule specific subscribes
 	if subs, has := memsto.AlertSubscribeCache.Get(rule.Id); has {
-		for _, sub := range subs {
-			handleSub(sub, *event)
-		}
+		subscribes = append(subscribes, subs...)
 	}
-
+	// global subscribes
 	if subs, has := memsto.AlertSubscribeCache.Get(0); has {
-		for _, sub := range subs {
-			handleSub(sub, *event)
-		}
+		subscribes = append(subscribes, subs...)
+	}
+	for _, sub := range subscribes {
+		handleSub(sub, *event)
 	}
 }
 
@@ -162,52 +122,35 @@ func handleSub(sub *models.AlertSubscribe, event models.AlertCurEvent) {
 		return
 	}
 
-	if sub.RedefineSeverity == 1 {
-		event.Severity = sub.NewSeverity
-	}
-
-	if sub.RedefineChannels == 1 {
-		event.NotifyChannels = sub.NewChannels
-		event.NotifyChannelsJSON = strings.Fields(sub.NewChannels)
-	}
-
-	event.NotifyGroups = sub.UserGroupIds
-	event.NotifyGroupsJSON = strings.Fields(sub.UserGroupIds)
-	if len(event.NotifyGroupsJSON) == 0 {
-		return
-	}
-
+	sub.ModifyEvent(&event)
 	LogEvent(&event, "subscribe")
 	HandleEventNotify(&event, true)
 }
 
-func BuildMessageContext(rule *models.AlertRule, event *models.AlertCurEvent, uids []int64) sender.MessageContext {
-	users := memsto.UserCache.GetByUserIds(uids)
-	return sender.MessageContext{
-		Rule:  rule,
-		Event: event,
-		Users: users,
-	}
-}
-
 func Send(rule *models.AlertRule, event *models.AlertCurEvent, subscription *Subscription, isSubscribe bool) {
 	for channel, uids := range subscription.ToChannelUserMap() {
-		ctx := BuildMessageContext(rule, event, uids)
+		ctx := sender.BuildMessageContext(rule, event, uids)
 		rwLock.RLock()
 		s := Senders[channel]
 		rwLock.RUnlock()
 		if s == nil {
-			// todo
+			logger.Warningf("no sender for channel: %s", channel)
 			continue
 		}
-		go s.Send(ctx)
+		s.Send(ctx)
 	}
 
 	// handle event callbacks
-	go sender.SendCallbacks(subscription.ToCallbackList(), event)
+	callbacks := subscription.ToCallbackList()
+	if len(callbacks) > 0 {
+		sender.SendCallbacks(subscription.ToCallbackList(), event)
+	}
 
 	// handle global webhooks
-	go sender.SendWebhooks(subscription.ToWebhookList(), event)
+	webhooks := subscription.ToWebhookList()
+	if len(webhooks) > 0 {
+		sender.SendWebhooks(subscription.ToWebhookList(), event)
+	}
 
 	noticeBytes := genNoticeBytes(event)
 
@@ -216,7 +159,7 @@ func Send(rule *models.AlertRule, event *models.AlertCurEvent, subscription *Sub
 
 	if !isSubscribe {
 		// handle redis pub
-		go sender.PublishToRedis(event.Cluster, noticeBytes)
+		sender.PublishToRedis(event.Cluster, noticeBytes)
 	}
 }
 

--- a/src/server/engine/notify_maintainer.go
+++ b/src/server/engine/notify_maintainer.go
@@ -4,13 +4,12 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/toolkits/pkg/logger"
+
 	"github.com/didi/nightingale/v5/src/models"
 	"github.com/didi/nightingale/v5/src/notifier"
-	"github.com/didi/nightingale/v5/src/server/common/sender"
 	"github.com/didi/nightingale/v5/src/server/config"
 	"github.com/didi/nightingale/v5/src/server/memsto"
-	"github.com/tidwall/gjson"
-	"github.com/toolkits/pkg/logger"
 )
 
 type MaintainMessage struct {
@@ -59,114 +58,16 @@ func notifyMaintainerWithBuiltin(title, msg, triggerTime string, users []*models
 		return
 	}
 
-	emailset := make(map[string]struct{})
-	phoneset := make(map[string]struct{})
-	wecomset := make(map[string]struct{})
-	dingtalkset := make(map[string]struct{})
-	feishuset := make(map[string]struct{})
-	mmset := make(map[string]struct{})
-	telegramset := make(map[string]struct{})
-
-	for _, user := range users {
-		if user.Email != "" {
-			emailset[user.Email] = struct{}{}
-		}
-
-		if user.Phone != "" {
-			phoneset[user.Phone] = struct{}{}
-		}
-
-		bs, err := user.Contacts.MarshalJSON()
-		if err != nil {
-			logger.Errorf("handle_notice: failed to marshal contacts: %v", err)
+	subscription := NewSubscriptionFromUsers(users)
+	for channel, uids := range subscription.ToChannelUserMap() {
+		currentUsers := memsto.UserCache.GetByUserIds(uids)
+		rwLock.RLock()
+		s := Senders[channel]
+		rwLock.RUnlock()
+		if s == nil {
+			// todo
 			continue
 		}
-
-		ret := gjson.GetBytes(bs, "dingtalk_robot_token")
-		if ret.Exists() {
-			dingtalkset[ret.String()] = struct{}{}
-		}
-
-		ret = gjson.GetBytes(bs, "wecom_robot_token")
-		if ret.Exists() {
-			wecomset[ret.String()] = struct{}{}
-		}
-
-		ret = gjson.GetBytes(bs, "feishu_robot_token")
-		if ret.Exists() {
-			feishuset[ret.String()] = struct{}{}
-		}
-
-		ret = gjson.GetBytes(bs, "mm_webhook_url")
-		if ret.Exists() {
-			mmset[ret.String()] = struct{}{}
-		}
-
-		ret = gjson.GetBytes(bs, "telegram_robot_token")
-		if ret.Exists() {
-			telegramset[ret.String()] = struct{}{}
-		}
-	}
-
-	phones := StringSetKeys(phoneset)
-
-	for _, ch := range config.C.Alerting.NotifyBuiltinChannels {
-		switch ch {
-		case "email":
-			if len(emailset) == 0 {
-				continue
-			}
-			content := "Title: " + title + "\nContent: " + msg + "\nTime: " + triggerTime
-			sender.WriteEmail(title, content, StringSetKeys(emailset))
-		case "dingtalk":
-			if len(dingtalkset) == 0 {
-				continue
-			}
-			content := "**Title: **" + title + "\n**Content: **" + msg + "\n**Time: **" + triggerTime
-			sender.SendDingtalk(sender.DingtalkMessage{
-				Title:     title,
-				Text:      content,
-				AtMobiles: phones,
-				Tokens:    StringSetKeys(dingtalkset),
-			})
-		case "wecom":
-			if len(wecomset) == 0 {
-				continue
-			}
-			content := "**Title: **" + title + "\n**Content: **" + msg + "\n**Time: **" + triggerTime
-			sender.SendWecom(sender.WecomMessage{
-				Text:   content,
-				Tokens: StringSetKeys(wecomset),
-			})
-		case "feishu":
-			if len(feishuset) == 0 {
-				continue
-			}
-
-			content := "Title: " + title + "\nContent: " + msg + "\nTime: " + triggerTime
-			sender.SendFeishu(sender.FeishuMessage{
-				Text:      content,
-				AtMobiles: phones,
-				Tokens:    StringSetKeys(feishuset),
-			})
-		case "mm":
-			if len(mmset) == 0 {
-				continue
-			}
-			content := "**Title: **" + title + "\n**Content: **" + msg + "\n**Time: **" + triggerTime
-			sender.SendMM(sender.MatterMostMessage{
-				Text:   content,
-				Tokens: StringSetKeys(mmset),
-			})
-		case "telegram":
-			if len(telegramset) == 0 {
-				continue
-			}
-			content := "**Title: **" + title + "\n**Content: **" + msg + "\n**Time: **" + triggerTime
-			sender.SendTelegram(sender.TelegramMessage{
-				Text:   content,
-				Tokens: StringSetKeys(telegramset),
-			})
-		}
+		go s.SendRaw(currentUsers, "notify maintainer", "Title: "+title+"\nContent: "+msg+"\nTime: "+triggerTime)
 	}
 }

--- a/src/server/engine/route_strategy.go
+++ b/src/server/engine/route_strategy.go
@@ -1,0 +1,55 @@
+package engine
+
+import (
+	"strconv"
+
+	"github.com/didi/nightingale/v5/src/models"
+	"github.com/didi/nightingale/v5/src/server/config"
+	"github.com/didi/nightingale/v5/src/server/memsto"
+)
+
+// Router 抽象由告警事件到订阅者的路由策略
+// rule: 告警规则
+// event: 告警事件
+// prev: 前一次路由结果, Router的实现可以直接修改prev, 也可以返回一个新的Subscription用于AndMerge/OrMerge
+type Router func(rule *models.AlertRule, event *models.AlertCurEvent, prev *Subscription) *Subscription
+
+// GroupRouter 处理告警规则的组订阅关系
+func GroupRouter(rule *models.AlertRule, event *models.AlertCurEvent, prev *Subscription) *Subscription {
+	groupIds := make([]int64, 0, len(event.NotifyGroupsJSON))
+	for _, groupId := range event.NotifyGroupsJSON {
+		gid, err := strconv.ParseInt(groupId, 10, 64)
+		if err != nil {
+			continue
+		}
+		groupIds = append(groupIds, gid)
+	}
+	groups := memsto.UserGroupCache.GetByUserGroupIds(groupIds)
+	subscription := NewSubscription()
+	for _, group := range groups {
+		for _, userId := range group.UserIds {
+			subscription.userMap[userId] = NewNotifyChannels(event.NotifyChannelsJSON)
+		}
+	}
+	return subscription
+}
+
+func GlobalWebhookRouter(rule *models.AlertRule, event *models.AlertCurEvent, prev *Subscription) *Subscription {
+	conf := config.C.Alerting.Webhook
+	if !conf.Enable {
+		return nil
+	}
+	subscription := NewSubscription()
+	subscription.webhooks[conf.Url] = conf
+	return subscription
+}
+
+func EventCallbacksRouter(rule *models.AlertRule, event *models.AlertCurEvent, prev *Subscription) *Subscription {
+	for _, c := range event.CallbacksJSON {
+		if c == "" {
+			continue
+		}
+		prev.callbacks[c] = struct{}{}
+	}
+	return nil
+}

--- a/src/server/engine/sender.go
+++ b/src/server/engine/sender.go
@@ -1,0 +1,7 @@
+package engine
+
+import "github.com/didi/nightingale/v5/src/server/common/sender"
+
+type MessageSender interface {
+	sender.DingtalkMessage
+}

--- a/src/server/engine/sender.go
+++ b/src/server/engine/sender.go
@@ -1,7 +1,0 @@
-package engine
-
-import "github.com/didi/nightingale/v5/src/server/common/sender"
-
-type MessageSender interface {
-	sender.DingtalkMessage
-}

--- a/src/server/engine/subscription.go
+++ b/src/server/engine/subscription.go
@@ -17,31 +17,27 @@ func NewNotifyChannels(channels []string) NotifyChannels {
 }
 
 func (nc NotifyChannels) OrMerge(other NotifyChannels) {
-	if other == nil {
-		return
-	}
-	for k, v := range other {
-		if curV, has := nc[k]; has {
-			nc[k] = curV || v
-		} else {
-			nc[k] = v
-		}
-	}
+	nc.merge(other, func(a, b bool) bool { return a || b })
 }
 
 func (nc NotifyChannels) AndMerge(other NotifyChannels) {
+	nc.merge(other, func(a, b bool) bool { return a && b })
+}
+
+func (nc NotifyChannels) merge(other NotifyChannels, f func(bool, bool) bool) {
 	if other == nil {
 		return
 	}
 	for k, v := range other {
 		if curV, has := nc[k]; has {
-			nc[k] = curV && v
+			nc[k] = f(curV, v)
 		} else {
 			nc[k] = v
 		}
 	}
 }
 
+// Subscription 维护所有需要发送的用户-通道/回调/钩子信息,用map维护的数据结构具有去重功能
 type Subscription struct {
 	userMap   map[int64]NotifyChannels
 	webhooks  map[string]config.Webhook
@@ -56,6 +52,7 @@ func NewSubscription() *Subscription {
 	}
 }
 
+// NewSubscriptionFromUsers 根据用户的token配置,生成订阅信息，用于notifyMaintainer
 func NewSubscriptionFromUsers(users []*models.User) *Subscription {
 	s := NewSubscription()
 	for _, u := range users {
@@ -69,41 +66,37 @@ func NewSubscriptionFromUsers(users []*models.User) *Subscription {
 			if channelMap, has := s.userMap[u.Id]; has {
 				channelMap[channel] = true
 			} else {
-				channelMap := make(map[string]bool)
-				channelMap[channel] = true
-				s.userMap[u.Id] = channelMap
+				s.userMap[u.Id] = map[string]bool{
+					channel: true,
+				}
 			}
 		}
 	}
 	return s
 }
 
+// OrMerge 将channelMap按照or的方式合并,方便实现多种组合的策略,比如根据某个tag进行路由等
 func (s *Subscription) OrMerge(other *Subscription) {
-	if other == nil {
-		return
-	}
-	for k, v := range other.userMap {
-		if curV, has := s.userMap[k]; has {
-			curV.OrMerge(v)
-		} else {
-			s.userMap[k] = v
-		}
-	}
-	for k, v := range other.webhooks {
-		s.webhooks[k] = v
-	}
-	for k, v := range other.callbacks {
-		s.callbacks[k] = v
-	}
+	s.merge(other, NotifyChannels.OrMerge)
 }
 
+// AndMerge 将channelMap中的bool值按照and的逻辑进行合并,可以单独将人/通道维度的通知移除
+// 常用的场景有:
+//
+//		人员离职了不需要发送告警了
+//		某个告警通道进行维护,暂时不需要发送告警了
+//	 业务值班的重定向逻辑，将高等级的告警额外发送给应急人员等,可以结合业务需求自己实现router
 func (s *Subscription) AndMerge(other *Subscription) {
+	s.merge(other, NotifyChannels.AndMerge)
+}
+
+func (s *Subscription) merge(other *Subscription, f func(NotifyChannels, NotifyChannels)) {
 	if other == nil {
 		return
 	}
 	for k, v := range other.userMap {
 		if curV, has := s.userMap[k]; has {
-			curV.AndMerge(v)
+			f(curV, v)
 		} else {
 			s.userMap[k] = v
 		}


### PR DESCRIPTION
告警事件处理模块重构
添加订阅的Subscription抽象，用于维护告警的接收对象
添加router抽象、实现groupRouter等替换原来hardcode的发送逻辑
添加Sender抽象，重写原来的Sender
