### PR TITLE
fix: host tag is overridden by ident

### DIFF
--- a/src/server/router/router_prom.go
+++ b/src/server/router/router_prom.go
@@ -104,12 +104,10 @@ func remoteWrite(c *gin.Context) {
 
 		// find ident label
 		for j := 0; j < len(req.Timeseries[i].Labels); j++ {
-			if req.Timeseries[i].Labels[j].Name == "host" {
-				req.Timeseries[i].Labels[j].Name = "ident"
-			}
-
 			if req.Timeseries[i].Labels[j].Name == "ident" {
 				ident = req.Timeseries[i].Labels[j].Value
+			} else if req.Timeseries[i].Labels[j].Name == "host" {
+				req.Timeseries[i].Labels[j].Name = "ident"
 			}
 
 			if req.Timeseries[i].Labels[j].Name == "__name__" {

--- a/src/server/router/router_prom.go
+++ b/src/server/router/router_prom.go
@@ -107,7 +107,7 @@ func remoteWrite(c *gin.Context) {
 			if req.Timeseries[i].Labels[j].Name == "ident" {
 				ident = req.Timeseries[i].Labels[j].Value
 			} else if req.Timeseries[i].Labels[j].Name == "host" {
-				req.Timeseries[i].Labels[j].Name = "ident"
+				ident = req.Timeseries[i].Labels[j].Value
 			}
 
 			if req.Timeseries[i].Labels[j].Name == "__name__" {


### PR DESCRIPTION
当原始指标同时存在host和ident标签或只存在host标签时，host会被ident重写
如下图：
![image](https://user-images.githubusercontent.com/71972802/212677825-d17db122-3ba5-4cd9-a3d8-e4ba162f3761.png)
