### PR TITLE
修复cas登录无法获取用户属性

### DIFF
--- a/src/pkg/cas/cas.go
+++ b/src/pkg/cas/cas.go
@@ -86,7 +86,15 @@ func wrapStateKey(key string) string {
 
 func (cli *ssoClient) genRedirectURL(state string) string {
 	var buf bytes.Buffer
-	buf.WriteString(cli.ssoAddr + "login")
+
+	ssoAddr, err := url.Parse(cli.config.SsoAddr)
+	ssoAddr.Path = "login"
+	if err != nil {
+		logger.Error(err)
+		return buf.String()
+	}
+
+	buf.WriteString(ssoAddr.String())
 	v := url.Values{
 		"service": {cli.callbackAddr},
 	}


### PR DESCRIPTION
解决cas3.0无法获取用户属性问题。
之前的代码加上path会变成 https://sso.xxx.cn/p3/login 导致无法登录。
```
[CAS]
Enable = true
DisplayName = "SSO登录"
SsoAddr = "https://sso.xxx.cn/p3" # cas3.0
RedirectURL = "https://test-monitor.xxx.cn/callback/cas"
CoverAttributes = true
# cas user default roles
DefaultRoles = ["Standard"]

[CAS.Attributes]
Nickname = "chinese_name"
Phone = "phone"
Email = "email"
```