### PR TITLE
fix: prometheus job n9e's targets wrong

### DIFF
--- a/docker/prometc/targets.json
+++ b/docker/prometc/targets.json
@@ -1,7 +1,7 @@
 [
   {
     "targets": [
-      "nwebapi:18000","nserver:19000"
+      "n9e:17000"
     ]
   }
 ]


### PR DESCRIPTION
"nwebapi:18000","nserver:19000" -> "n9e:17000"

**What type of PR is this?**

**What this PR does / why we need it**:
<!--
"Nice to have" "You need it" is not a good reason. :)
-->

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or "Fixes (paste link of issue)"
-->
Fixes #
 
**Special notes for your reviewer**: