### PR TITLE
update docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,4 @@
-FROM python:2.7.8-slim
-#FROM python:2
+FROM python:3-slim
 #FROM ubuntu:21.04
 
 WORKDIR /app

--- a/docker/Dockerfile.goreleaser
+++ b/docker/Dockerfile.goreleaser
@@ -1,9 +1,10 @@
-FROM --platform=$BUILDPLATFORM python:2.7.8-slim
+FROM --platform=$BUILDPLATFORM python:3-slim
 
 
 WORKDIR /app
 ADD n9e /app
 ADD etc /app
+ADD inegrations /app
 ADD http://download.flashcat.cloud/wait /wait
 RUN mkdir -p /app/pub && chmod +x /wait
 ADD pub /app/pub/


### PR DESCRIPTION
**What type of PR is this?**

**What this PR does / why we need it**:

1.  python2 的基础镜像太老了，确少基础工具curl wget lsof，而且安装不便。python:3-slim 是基于 debian bullseye,安装基础工具方便，体积也不大
2.  integrations打包到基础镜像中，helm不需要通过configmap挂载icon等非txt格式的文件

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or "Fixes (paste link of issue)"
-->
Fixes #
 
**Special notes for your reviewer**: