### PR TITLE
修复请求ES"跳过SSL验证"不生效问题

### DIFF
--- a/center/router/router_proxy.go
+++ b/center/router/router_proxy.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"context"
+	"crypto/tls"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -139,7 +140,8 @@ func (rt *Router) dsProxy(c *gin.Context) {
 	}
 
 	transport := &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: ds.HTTPJson.TLS.SkipTlsVerify},
+		Proxy:           http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
 			Timeout: time.Duration(ds.HTTPJson.DialTimeout) * time.Millisecond,
 		}).DialContext,


### PR DESCRIPTION
**What type of PR is this?**
修复请求ES “跳过SSL验证” 选项勾选后没有生效的问题
**What this PR does / why we need it**:
增加了 TLSClientConfig 选项, 用于设置是否在http请求过程中验证证书

**Which issue(s) this PR fixes**:
Fixes #1452 
 
**Special notes for your reviewer**: 已经在最新版本测试, 确认修改后, 可以正常查看ES数据
