### PR TITLE
fix: sendmm run ok with illegal token

### DIFF
--- a/alert/sender/mm.go
+++ b/alert/sender/mm.go
@@ -59,6 +59,7 @@ func SendMM(message MatterMostMessage) {
 		u, err := url.Parse(message.Tokens[i])
 		if err != nil {
 			logger.Errorf("mm_sender: failed to parse error=%v", err)
+			continue
 		}
 
 		v, err := url.ParseQuery(u.RawQuery)


### PR DESCRIPTION
**What type of PR is this?**

```
fix code
```

**What this PR does / why we need it**:

```
SendMM() may panic with illegal user token, just skip it.

Detail: illegal token makes url to nil, and url.RawQuery will panic.
```

**Which issue(s) this PR fixes**:

```
no
```
 
**Special notes for your reviewer**:

```
no
```