### PR TITLE
fix: fix alert mute error for pg

### DIFF
--- a/docker/experience_pg_vm/initsql_for_postgres/a-n9e-for-Postgres.sql
+++ b/docker/experience_pg_vm/initsql_for_postgres/a-n9e-for-Postgres.sql
@@ -331,7 +331,7 @@ CREATE TABLE alert_mute (
     cate varchar(128) not null,
     cluster varchar(128) not null,
     datasource_ids varchar(255) not null default '' ,
-    tags varchar(4096) not null default '' ,
+    tags jsonb NOT NULL ,
     cause varchar(255) not null default '',
     btime bigint not null default 0 ,
     etime bigint not null default 0 ,


### PR DESCRIPTION
fix: fix alert mute error for pg

fix error for "Scan error on column index 6, name "tags": Failed to unmarshal JSONB value"

修复告警屏蔽列表报错