### PR TITLE
修复获取告警规则列表 FillSeverities方法中的数组越界问题

### DIFF
--- a/models/alert_rule.go
+++ b/models/alert_rule.go
@@ -375,7 +375,7 @@ func (ar *AlertRule) FillSeverities() error {
 			if err := json.Unmarshal([]byte(ar.RuleConfig), &rule); err != nil {
 				return err
 			}
-			for i := range rule.Queries {
+			for i := range rule.Triggers {
 				ar.Severities = append(ar.Severities, rule.Triggers[i].Severity)
 			}
 		} else {


### PR DESCRIPTION
**What type of PR is this?**
host告警规则中，多个机器筛选条件，单个告警条件后，告警规则列表接口500

**What this PR does / why we need it**:
修复host告警规则中，queries多于triggers，FillSeverities方法中的数组越界导致panic的bug

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or "Fixes (paste link of issue)"
-->
Fixes #
 
**Special notes for your reviewer**: