### PR TITLE
有道更新，支持告警升级

### DIFF
--- a/alert/common/conv.go
+++ b/alert/common/conv.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"fmt"
+	"github.com/ccfos/nightingale/v6/models"
 	"math"
 	"strings"
 
@@ -13,8 +14,9 @@ type AnomalyPoint struct {
 	Labels    model.Metric `json:"labels"`
 	Timestamp int64        `json:"timestamp"`
 	Value     float64      `json:"value"`
-	Severity  int          `json:"severity"`
-	Triggered bool         `json:"triggered"`
+	//Severity  int          `json:"severity"`
+	Triggered bool             `json:"triggered"`
+	Promquery models.PromQuery `json:"promquery"` //有道添加，用来后续规则判断
 }
 
 func NewAnomalyPoint(key string, labels map[string]string, ts int64, value float64, severity int) AnomalyPoint {
@@ -28,7 +30,7 @@ func NewAnomalyPoint(key string, labels map[string]string, ts int64, value float
 		Labels:    anomalyPointLabels,
 		Timestamp: ts,
 		Value:     value,
-		Severity:  severity,
+		//Severity:  severity,
 	}
 }
 

--- a/alert/dispatch/consume.go
+++ b/alert/dispatch/consume.go
@@ -58,6 +58,12 @@ func (e *Consumer) consume(events []interface{}, sema *semaphore.Semaphore) {
 }
 
 func (e *Consumer) consumeOne(event *models.AlertCurEvent) {
+	defer func() {
+		if err := recover(); err != nil {
+			logger.Errorf("dispatch.consumeOne.panic: %v", err)
+		}
+	}()
+
 	LogEvent(event, "consume")
 
 	if err := event.ParseRule("rule_name"); err != nil {

--- a/alert/eval/eval.go
+++ b/alert/eval/eval.go
@@ -162,7 +162,9 @@ func (arw *AlertRuleWorker) GetPromAnomalyPoint(ruleConfig string) []common.Anom
 		logger.Debugf("rule_eval:%s query:%+v, value:%v", arw.Key(), query, value)
 		points := common.ConvertAnomalyPoints(value)
 		for i := 0; i < len(points); i++ {
-			points[i].Severity = query.Severity
+			//points[i].Severity = query.Severity
+			points[i].Promquery = query
+
 		}
 		lst = append(lst, points...)
 	}

--- a/alert/mute/mute.go
+++ b/alert/mute/mute.go
@@ -38,6 +38,29 @@ func TimeNonEffectiveMuteStrategy(rule *models.AlertRule, event *models.AlertCur
 		return true
 	}
 
+	//var allRuleDisabled = 1
+	// todo: unmarsha rule.RuleConfig to struct
+	//if rule.Cate == models.PROMETHEUS {
+	//	var ruleConfig models.PromRuleConfig
+	//	if err := json.Unmarshal([]byte(rule.RuleConfig), &ruleConfig); err == nil {
+	//		alertConfigs := ruleConfig.AlertConfigs
+	//		for _, query := range ruleConfig.Queries {
+	//			if query.Default == 1 {
+	//				allRuleDisabled &= rule.Disabled
+	//			} else {
+	//				cfg, ok := alertConfigs[query.Severity]
+	//				if !ok {
+	//					continue
+	//				}
+	//				allRuleDisabled &= cfg.Disabled
+	//			}
+	//		}
+	//	}
+	//	if allRuleDisabled == 1 {
+	//		return true
+	//	}
+	//}
+
 	tm := time.Unix(event.TriggerTime, 0)
 	triggerTime := tm.Format("15:04")
 	triggerWeek := strconv.Itoa(int(tm.Weekday()))

--- a/center/router/router.go
+++ b/center/router/router.go
@@ -256,9 +256,12 @@ func (rt *Router) Config(r *gin.Engine) {
 		if rt.Center.AnonymousAccess.AlertDetail {
 			pages.GET("/alert-cur-event/:eid", rt.alertCurEventGet)
 			pages.GET("/alert-his-event/:eid", rt.alertHisEventGet)
+			pages.GET("/alert-event/:hash", rt.alertEventGet)
 		} else {
 			pages.GET("/alert-cur-event/:eid", rt.auth(), rt.alertCurEventGet)
 			pages.GET("/alert-his-event/:eid", rt.auth(), rt.alertHisEventGet)
+			pages.PUT("/alert-his-event/:eid", rt.auth(), rt.alertHisEventPut)
+			pages.GET("/alert-event/:hash", rt.auth(), rt.alertEventGet)
 		}
 
 		// card logic

--- a/center/router/router_target.go
+++ b/center/router/router_target.go
@@ -80,7 +80,8 @@ func (rt *Router) targetGets(c *gin.Context) {
 			}
 
 			for i := 0; i < len(list); i++ {
-				if now.Unix()-list[i].UpdateAt < 120 {
+				// FIXME: 120s hardcode, change to 1 hour
+				if now.Unix()-list[i].UpdateAt < 3600 {
 					list[i].TargetUp = 1
 				}
 

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/koding/multiconfig v0.0.0-20171124222453-69c27309b2d7
 	github.com/mailru/easyjson v0.7.7
 	github.com/mattn/go-isatty v0.0.17
+	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
 	github.com/pelletier/go-toml/v2 v2.0.6
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -210,6 +210,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=
+github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/pelletier/go-toml/v2 v2.0.1/go.mod h1:r9LEWfGN8R5k0VXJ+0BkIe7MYkRdwZOjgMj2KwnJFUo=
 github.com/pelletier/go-toml/v2 v2.0.6 h1:nrzqCb7j9cDFj2coyLNLaZuJTLjWjlaz6nvTvIwycIU=
 github.com/pelletier/go-toml/v2 v2.0.6/go.mod h1:eumQOmlWiOPt5WriQQqoM5y18pDHwha2N+QD+EUNTek=

--- a/models/alert_cur_event.go
+++ b/models/alert_cur_event.go
@@ -57,6 +57,7 @@ type AlertCurEvent struct {
 	LastSentTime       int64             `json:"last_sent_time" gorm:"-"`   // 上次发送时间
 	NotifyCurNumber    int               `json:"notify_cur_number"`         // notify: current number
 	FirstTriggerTime   int64             `json:"first_trigger_time"`        // 连续告警的首次告警时间
+	CustomNotify       bool              `json:"-" gorm:"-"`
 }
 
 func (e *AlertCurEvent) TableName() string {

--- a/models/alert_his_event.go
+++ b/models/alert_his_event.go
@@ -10,6 +10,7 @@ import (
 	"github.com/toolkits/pkg/logger"
 )
 
+// todo: 可以新增一个Title字段
 type AlertHisEvent struct {
 	Id                 int64             `json:"id" gorm:"primaryKey"`
 	Cate               string            `json:"cate"`
@@ -191,7 +192,7 @@ func AlertHisEventGets(ctx *ctx.Context, prods []string, bgid, stime, etime int6
 
 func AlertHisEventGet(ctx *ctx.Context, where string, args ...interface{}) (*AlertHisEvent, error) {
 	var lst []*AlertHisEvent
-	err := DB(ctx).Where(where, args...).Find(&lst).Error
+	err := DB(ctx).Where(where, args...).Order("id desc").Find(&lst).Error
 	if err != nil {
 		return nil, err
 	}
@@ -209,7 +210,9 @@ func AlertHisEventGet(ctx *ctx.Context, where string, args ...interface{}) (*Ale
 func AlertHisEventGetById(ctx *ctx.Context, id int64) (*AlertHisEvent, error) {
 	return AlertHisEventGet(ctx, "id=?", id)
 }
-
+func AlertHisEventGetByHash(ctx *ctx.Context, hash string) (*AlertHisEvent, error) {
+	return AlertHisEventGet(ctx, "hash=?", hash)
+}
 func (m *AlertHisEvent) UpdateFieldsMap(ctx *ctx.Context, fields map[string]interface{}) error {
 	return DB(ctx).Model(m).Updates(fields).Error
 }


### PR DESCRIPTION
**What type of PR is this?**
解决告警升级功能
**What this PR does / why we need it**:
用来解决运维监控下，告警升级定制功能。除了可以通过订阅来实现持续时长的升级，还能支持不同阈值的告警升级。基于现在的告警抑制功能，我们在同一个规则下配置相同条件不同阈值，并且设置不同的告警级别，这样可以满足需求，但是希望不同级别的告警可以定制发送方式，比如说一级告警非常紧急必须电话通知，二级、三级简单通知即可，所以进行了定制。改动如下
* 支持为每个查询条件设置描述信息、生效时间、通知媒介、告警接收组、留观时长、重复发送间隔、最大发送次数等配置项
* 每个查询条件下增加一键查询数据源的功能，方面管理员配置规则前进行查询，减少误报
* 增加内置告警详情页，/alert-events/:hash，以便在告警消息中应用，打开实时查看。(现在的alert-cur-event和alert-his-event使用的id查询，每次都会生成新事件，id会变，对用户不友好)

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or "Fixes (paste link of issue)"
-->
Fixes #
 #1470 #1314 
希望能合并到社区版本，让夜莺v6版本功能更丰富，让监控功能更强大