### PR TITLE
Fix an exception situation where the prod and cate fields cannot be updated

### DIFF
--- a/center/router/router_alert_subscribe.go
+++ b/center/router/router_alert_subscribe.go
@@ -83,6 +83,9 @@ func (rt *Router) alertSubscribePut(c *gin.Context) {
 			rt.Ctx,
 			"name",
 			"disabled",
+			"prod",
+			"cate",
+			"datasource_ids",
 			"cluster",
 			"rule_id",
 			"tags",
@@ -96,7 +99,6 @@ func (rt *Router) alertSubscribePut(c *gin.Context) {
 			"webhooks",
 			"for_duration",
 			"redefine_webhooks",
-			"datasource_ids",
 		))
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
Fix the issue of partial fields failing to be updated in the alert subscription.

**What this PR does / why we need it**:
When I tried to update an incorrect alert subscription by clicking on the edit button, it seemed that there was an exceptional situation where the fields "prod" and "cate" were showing their previous values.
Add fields for updating subscription in func alertSubscribePut.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:  
None