### PR TITLE
heartbeat  update target table  update_at field

### DIFF
--- a/center/center.go
+++ b/center/center.go
@@ -80,7 +80,7 @@ func Initialize(configDir string, cryptoKey string) (func(), error) {
 	writers := writer.NewWriters(config.Pushgw)
 
 	alertrtRouter := alertrt.New(config.HTTP, config.Alert, alertMuteCache, targetCache, busiGroupCache, alertStats, ctx, externalProcessors)
-	centerRouter := centerrt.New(config.HTTP, config.Center, cconf.Operations, dsCache, notifyConfigCache, promClients, redis, sso, ctx, metas, targetCache)
+	centerRouter := centerrt.New(config.HTTP, config.Center, cconf.Operations, dsCache, notifyConfigCache, promClients, redis, sso, ctx, metas,idents, targetCache)
 	pushgwRouter := pushgwrt.New(config.HTTP, config.Pushgw, targetCache, busiGroupCache, idents, writers, ctx)
 
 	r := httpx.GinEngine(config.Global.RunMode, config.HTTP)

--- a/center/router/router.go
+++ b/center/router/router.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ccfos/nightingale/v6/pkg/httpx"
 	"github.com/ccfos/nightingale/v6/prom"
 	"github.com/ccfos/nightingale/v6/storage"
+	"github.com/ccfos/nightingale/v6/pushgw/idents"
 
 	"github.com/gin-gonic/gin"
 	"github.com/rakyll/statik/fs"
@@ -35,13 +36,14 @@ type Router struct {
 	PromClients       *prom.PromClientMap
 	Redis             storage.Redis
 	MetaSet           *metas.Set
+	IdentSet           *idents.Set
 	TargetCache       *memsto.TargetCacheType
 	Sso               *sso.SsoClient
 	Ctx               *ctx.Context
 }
 
 func New(httpConfig httpx.Config, center cconf.Center, operations cconf.Operation, ds *memsto.DatasourceCacheType, ncc *memsto.NotifyConfigCacheType,
-	pc *prom.PromClientMap, redis storage.Redis, sso *sso.SsoClient, ctx *ctx.Context, metaSet *metas.Set, tc *memsto.TargetCacheType) *Router {
+	pc *prom.PromClientMap, redis storage.Redis, sso *sso.SsoClient, ctx *ctx.Context, metaSet *metas.Set, idents *idents.Set, tc *memsto.TargetCacheType) *Router {
 	return &Router{
 		HTTP:              httpConfig,
 		Center:            center,
@@ -51,6 +53,7 @@ func New(httpConfig httpx.Config, center cconf.Center, operations cconf.Operatio
 		PromClients:       pc,
 		Redis:             redis,
 		MetaSet:           metaSet,
+		IdentSet:          idents,
 		TargetCache:       tc,
 		Sso:               sso,
 		Ctx:               ctx,

--- a/center/router/router_heartbeat.go
+++ b/center/router/router_heartbeat.go
@@ -45,6 +45,9 @@ func (rt *Router) heartbeat(c *gin.Context) {
 	}
 
 	rt.MetaSet.Set(req.Hostname, req)
+	var items = make(map[string]struct{})
+	items[req.Hostname] = struct{}{}
+	rt.IdentSet.MSet(items)
 
 	gid := ginx.QueryInt64(c, "gid", 0)
 


### PR DESCRIPTION
**心跳上报时，增加更新update_at字段功能，使告警更加灵敏**

issue: [[关于心跳和机器失联告警的一些疑问](https://github.com/ccfos/nightingale/issues/1589#top)](https://github.com/ccfos/nightingale/issues/1589)



