### PR TITLE
add static ttf file route

### DIFF
--- a/center/router/router.go
+++ b/center/router/router.go
@@ -106,7 +106,7 @@ func (rt *Router) configNoRoute(r *gin.Engine, fs *http.FileSystem) {
 		suffix := arr[len(arr)-1]
 
 		switch suffix {
-		case "png", "jpeg", "jpg", "svg", "ico", "gif", "css", "js", "html", "htm", "gz", "zip", "map":
+		case "png", "jpeg", "jpg", "svg", "ico", "gif", "css", "js", "html", "htm", "gz", "zip", "map", "ttf":
 			if !rt.Center.UseFileAssets {
 				c.FileFromFS(c.Request.URL.Path, *fs)
 			} else {


### PR DESCRIPTION
静态文件路由缺少了 ttf 类型的,导致本地开发会出现个错误
![image](https://github.com/ccfos/nightingale/assets/27064164/5467429b-86eb-4270-98d4-38184d3c183d)
![Screenshot_20230720_165942](https://github.com/ccfos/nightingale/assets/27064164/775ba73a-e94d-41b1-802b-4d4719a35ecd)
