### PR TITLE
feat: add mute preview and an option to delete the active alerts

### DIFF
--- a/alert/mute/mute.go
+++ b/alert/mute/mute.go
@@ -1,7 +1,6 @@
 package mute
 
 import (
-	"encoding/json"
 	"strconv"
 	"strings"
 	"time"
@@ -150,12 +149,7 @@ func CurEventMatchMuteStrategyFilter(events []*models.AlertCurEvent, mute *model
 		if events[i].TagsMap == nil {
 			events[i].DB2Mem()
 		}
-		b := common.MatchTags(events[i].TagsMap, mute.ITags)
-		logger.Debugf("event Tags match(%t): rule_id=%d %s", b, events[i].RuleId, events[i].Hash)
-		if b {
-			//for fe
-			json.Unmarshal([]byte(events[i].Annotations), &events[i].AnnotationsJSON)
-			json.Unmarshal([]byte(events[i].RuleConfig), &events[i].RuleConfigJson)
+		if b := common.MatchTags(events[i].TagsMap, mute.ITags); b {
 			res = append(res, events[i])
 		}
 	}

--- a/alert/mute/mute.go
+++ b/alert/mute/mute.go
@@ -136,6 +136,25 @@ func EventMuteStrategy(event *models.AlertCurEvent, alertMuteCache *memsto.Alert
 	return false
 }
 
+// CurEventMatchMuteStrategyFilter return the events where is match the mute strategy
+func CurEventMatchMuteStrategyFilter(events []*models.AlertCurEvent, mute *models.AlertMute) []*models.AlertCurEvent {
+	res := make([]*models.AlertCurEvent, 0, len(events))
+	if mute == nil {
+		return events
+	}
+	for i := range events {
+		if events[i] == nil {
+			continue
+		}
+		b := matchMute(events[i], mute)
+		logger.Debugf("match(%t) event_muted: rule_id=%d %s", b, events[i].RuleId, events[i].Hash)
+		if b {
+			res = append(res, events[i])
+		}
+	}
+	return res
+}
+
 // matchMute 如果传入了clock这个可选参数，就表示使用这个clock表示的时间，否则就从event的字段中取TriggerTime
 func matchMute(event *models.AlertCurEvent, mute *models.AlertMute, clock ...int64) bool {
 	if mute.Disabled == 1 {

--- a/alert/mute/mute.go
+++ b/alert/mute/mute.go
@@ -136,26 +136,6 @@ func EventMuteStrategy(event *models.AlertCurEvent, alertMuteCache *memsto.Alert
 	return false
 }
 
-// CurEventMatchMuteStrategyFilter return the events where is match the mute strategy
-func CurEventMatchMuteStrategyFilter(events []*models.AlertCurEvent, mute *models.AlertMute) []*models.AlertCurEvent {
-	res := make([]*models.AlertCurEvent, 0, len(events))
-	if mute == nil {
-		return events
-	}
-	for i := range events {
-		if events[i] == nil || mute.ITags == nil {
-			continue
-		}
-		if events[i].TagsMap == nil {
-			events[i].DB2Mem()
-		}
-		if b := common.MatchTags(events[i].TagsMap, mute.ITags); b {
-			res = append(res, events[i])
-		}
-	}
-	return res
-}
-
 // matchMute 如果传入了clock这个可选参数，就表示使用这个clock表示的时间，否则就从event的字段中取TriggerTime
 func matchMute(event *models.AlertCurEvent, mute *models.AlertMute, clock ...int64) bool {
 	if mute.Disabled == 1 {

--- a/center/router/router.go
+++ b/center/router/router.go
@@ -285,6 +285,7 @@ func (rt *Router) Config(r *gin.Engine) {
 		pages.PUT("/busi-group/:id/recording-rules/fields", rt.auth(), rt.user(), rt.perm("/recording-rules/put"), rt.recordingRulePutFields)
 
 		pages.GET("/busi-group/:id/alert-mutes", rt.auth(), rt.user(), rt.perm("/alert-mutes"), rt.bgro(), rt.alertMuteGetsByBG)
+		pages.POST("/busi-group/:id/alert-mutes/preview", rt.auth(), rt.user(), rt.perm("/alert-mutes/add"), rt.bgrw(), rt.alertMutePreview)
 		pages.POST("/busi-group/:id/alert-mutes", rt.auth(), rt.user(), rt.perm("/alert-mutes/add"), rt.bgrw(), rt.alertMuteAdd)
 		pages.DELETE("/busi-group/:id/alert-mutes", rt.auth(), rt.user(), rt.perm("/alert-mutes/del"), rt.bgrw(), rt.alertMuteDel)
 		pages.PUT("/busi-group/:id/alert-mute/:amid", rt.auth(), rt.user(), rt.perm("/alert-mutes/put"), rt.alertMutePutByFE)

--- a/center/router/router_alert_cur_event.go
+++ b/center/router/router_alert_cur_event.go
@@ -182,13 +182,19 @@ func (rt *Router) alertCurEventDel(c *gin.Context) {
 	ginx.BindJSON(c, &f)
 	f.Verify()
 
+	rt.checkCurEventBusiGroupRWPermission(c, f.Ids)
+
+	ginx.NewRender(c).Message(models.AlertCurEventDel(rt.Ctx, f.Ids))
+}
+
+func (rt *Router) checkCurEventBusiGroupRWPermission(c *gin.Context, ids []int64) {
 	set := make(map[int64]struct{})
 
 	// event group id is 0, ignore perm check
 	set[0] = struct{}{}
 
-	for i := 0; i < len(f.Ids); i++ {
-		event, err := models.AlertCurEventGetById(rt.Ctx, f.Ids[i])
+	for i := 0; i < len(ids); i++ {
+		event, err := models.AlertCurEventGetById(rt.Ctx, ids[i])
 		ginx.Dangerous(err)
 
 		if _, has := set[event.GroupId]; !has {
@@ -196,8 +202,6 @@ func (rt *Router) alertCurEventDel(c *gin.Context) {
 			set[event.GroupId] = struct{}{}
 		}
 	}
-
-	ginx.NewRender(c).Message(models.AlertCurEventDel(rt.Ctx, f.Ids))
 }
 
 func (rt *Router) alertCurEventGet(c *gin.Context) {

--- a/center/router/router_mute.go
+++ b/center/router/router_mute.go
@@ -5,9 +5,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ccfos/nightingale/v6/alert/mute"
 	"github.com/ccfos/nightingale/v6/models"
-	"github.com/ccfos/nightingale/v6/pkg/ctx"
 
 	"github.com/gin-gonic/gin"
 	"github.com/toolkits/pkg/ginx"
@@ -53,19 +51,8 @@ func (rt *Router) alertMutePreview(c *gin.Context) {
 	f.GroupId = ginx.UrlParamInt64(c, "id")
 	ginx.Dangerous(f.Verify()) //verify and parse tags json to ITags
 
-	events := matchMuteEvents(rt.Ctx, &f)
+	ginx.NewRender(c).Data(models.AlertCurEventGetsFromAlertMute(rt.Ctx, &f))
 
-	ginx.NewRender(c).Data(events, nil)
-
-}
-
-//Retrieve the current events based on specific criteria and filter out the events that match the mute strategy.
-func matchMuteEvents(ctx *ctx.Context, alertMute *models.AlertMute) []*models.AlertCurEvent {
-
-	events, err := models.AlertCurEventGetsFromAlertMute(ctx, alertMute)
-	ginx.Dangerous(err)
-
-	return mute.CurEventMatchMuteStrategyFilter(events, alertMute)
 }
 
 func (rt *Router) alertMuteAddByService(c *gin.Context) {

--- a/center/router/router_mute.go
+++ b/center/router/router_mute.go
@@ -55,16 +55,14 @@ func (rt *Router) alertMutePreview(c *gin.Context) {
 
 	events := matchMuteEvents(rt.Ctx, &f)
 
-	ginx.NewRender(c).Data(gin.H{
-		"list": events,
-	}, nil)
+	ginx.NewRender(c).Data(events, nil)
 
 }
 
 //Retrieve the current events based on specific criteria and filter out the events that match the mute strategy.
 func matchMuteEvents(ctx *ctx.Context, alertMute *models.AlertMute) []*models.AlertCurEvent {
 
-	events, err := models.AlertCurEventGetsFromAlertMute(ctx, alertMute, 0)
+	events, err := models.AlertCurEventGetsFromAlertMute(ctx, alertMute)
 	ginx.Dangerous(err)
 
 	return mute.CurEventMatchMuteStrategyFilter(events, alertMute)

--- a/models/alert_cur_event.go
+++ b/models/alert_cur_event.go
@@ -560,3 +560,25 @@ func AlertCurEventUpgradeToV6(ctx *ctx.Context, dsm map[string]Datasource) error
 	}
 	return nil
 }
+
+func AlertCurEventTotalMap(ctx *ctx.Context, where map[string]interface{}) (int64, error) {
+
+	return Count(DB(ctx).Model(&AlertCurEvent{}).Where(where))
+}
+
+func AlertCurEventGetsMap(ctx *ctx.Context, where map[string]interface{}, limit int) ([]*AlertCurEvent, error) {
+	var lst []*AlertCurEvent
+	tx := DB(ctx).Where(where).Order("id desc")
+	if limit != 0 {
+		tx.Limit(limit)
+	}
+	err := tx.Find(&lst).Error
+
+	if err == nil {
+		for i := 0; i < len(lst); i++ {
+			lst[i].DB2FE()
+		}
+	}
+
+	return lst, err
+}

--- a/models/alert_cur_event.go
+++ b/models/alert_cur_event.go
@@ -310,7 +310,7 @@ func (e *AlertCurEvent) FillNotifyGroups(ctx *ctx.Context, cache map[int64]*User
 
 func AlertCurEventTotal(ctx *ctx.Context, prods []string, bgid, stime, etime int64, severity int, dsIds []int64, cates []string, query string) (int64, error) {
 	session := DB(ctx).Model(&AlertCurEvent{})
-	if stime == 0 || etime == 0 {
+	if stime != 0 && etime != 0 {
 		session.Where("trigger_time between ? and ?", stime, etime)
 	}
 	if len(prods) != 0 {
@@ -346,7 +346,7 @@ func AlertCurEventTotal(ctx *ctx.Context, prods []string, bgid, stime, etime int
 
 func AlertCurEventGets(ctx *ctx.Context, prods []string, bgid, stime, etime int64, severity int, dsIds []int64, cates []string, query string, limit, offset int) ([]AlertCurEvent, error) {
 	session := DB(ctx).Model(&AlertCurEvent{})
-	if stime == 0 || etime == 0 {
+	if stime != 0 && etime != 0 {
 		session.Where("trigger_time between ? and ?", stime, etime)
 	}
 	if len(prods) != 0 {

--- a/models/alert_cur_event.go
+++ b/models/alert_cur_event.go
@@ -588,8 +588,8 @@ func AlertCurEventGetsFromAlertMute(ctx *ctx.Context, alertMute *AlertMute) ([]*
 
 	var matchEvents []*AlertCurEvent
 	for i := 0; i < len(lst); i++ {
+		lst[i].DB2Mem()
 		if common.MatchTags(lst[i].TagsMap, alertMute.ITags) {
-			lst[i].DB2FE()
 			matchEvents = append(matchEvents,lst[i])
 		}
 	}

--- a/models/alert_cur_event.go
+++ b/models/alert_cur_event.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ccfos/nightingale/v6/pkg/ctx"
 	"github.com/ccfos/nightingale/v6/pkg/poster"
 	"github.com/ccfos/nightingale/v6/pkg/tplx"
+
 	"github.com/toolkits/pkg/logger"
 )
 
@@ -582,17 +583,5 @@ func AlertCurEventGetsFromAlertMute(ctx *ctx.Context, alertMute *AlertMute) ([]*
 	}
 
 	err := tx.Order("id desc").Find(&lst).Error
-	if err != nil {
-		return err 
-	}
-
-	var matchEvents []*AlertCurEvent
-	for i := 0; i < len(lst); i++ {
-		lst[i].DB2Mem()
-		if common.MatchTags(lst[i].TagsMap, alertMute.ITags) {
-			matchEvents = append(matchEvents,lst[i])
-		}
-	}
-
-	return matchEvents, err
+	return lst, err
 }


### PR DESCRIPTION
**What type of PR is this?**
feat: add mute preview and an option to delete the active alerts

**What this PR does / why we need it**:
When creating a mute rule, allow a preview of the active alerts that will be matched, and provide an option to delete these active alerts with one click

**Which issue(s) this PR fixes**:

Fixes [#1646](https://github.com/ccfos/nightingale/issues/1646)
 
**Special notes for your reviewer**: