### PR TITLE
Compute statistics for alert_cur_events

### DIFF
--- a/center/router/router.go
+++ b/center/router/router.go
@@ -311,6 +311,7 @@ func (rt *Router) Config(r *gin.Engine) {
 		pages.POST("/alert-cur-events/card/details", rt.auth(), rt.alertCurEventsCardDetails)
 		pages.GET("/alert-his-events/list", rt.auth(), rt.alertHisEventsList)
 		pages.DELETE("/alert-cur-events", rt.auth(), rt.user(), rt.perm("/alert-cur-events/del"), rt.alertCurEventDel)
+		pages.GET("/alert-cur-events/stats", rt.auth(), rt.alertCurEventsStatistics)
 
 		pages.GET("/alert-aggr-views", rt.auth(), rt.alertAggrViewGets)
 		pages.DELETE("/alert-aggr-views", rt.auth(), rt.user(), rt.alertAggrViewDel)

--- a/center/router/router_alert_cur_event.go
+++ b/center/router/router_alert_cur_event.go
@@ -219,8 +219,5 @@ func (rt *Router) alertCurEventGet(c *gin.Context) {
 
 func (rt *Router) alertCurEventsStatistics(c *gin.Context) {
 
-	res, err := models.AlertCurEventStatistics(rt.Ctx, time.Now())
-	ginx.Dangerous(err)
-
-	ginx.NewRender(c).Data(res, nil)
+	ginx.NewRender(c).Data(models.AlertCurEventStatistics(rt.Ctx, time.Now()), nil)
 }

--- a/center/router/router_alert_cur_event.go
+++ b/center/router/router_alert_cur_event.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/ccfos/nightingale/v6/models"
 
@@ -214,4 +215,12 @@ func (rt *Router) alertCurEventGet(c *gin.Context) {
 	}
 
 	ginx.NewRender(c).Data(event, nil)
+}
+
+func (rt *Router) alertCurEventsStatistics(c *gin.Context) {
+
+	res, err := models.AlertCurEventStatistics(rt.Ctx, time.Now())
+	ginx.Dangerous(err)
+
+	ginx.NewRender(c).Data(res, nil)
 }

--- a/models/alert_cur_event.go
+++ b/models/alert_cur_event.go
@@ -596,8 +596,8 @@ func AlertCurEventStatistics(ctx *ctx.Context, stime time.Time) (res struct {
 	stime24HoursAgoUnix := stime.Add(-24 * time.Hour).Unix()
 	//Beginning of today
 	stimeMidnightUnix := time.Date(stime.Year(), stime.Month(), stime.Day(), 0, 0, 0, 0, stime.Location()).Unix()
-	///Beginning of this week(Monday) at 00:00
-	daysToMonday := (int(stime.Weekday()) - 1 + 7) % 7 // (dayOfWeek - Monday(1) + aWeekDays(7))/aWeekDays(7)
+	///Monday of the current week, starting at 00:00
+	daysToMonday := (int(stime.Weekday()) - 1 + 7) % 7 // (DayOfTheWeek - Monday(1) + DaysAWeek(7))/DaysAWeek(7)
 	stimeOneWeekAgoUnix := time.Date(stime.Year(), stime.Month(), stime.Day()-daysToMonday, 0, 0, 0, 0, stime.Location()).Unix()
 
 	err := DB(ctx).Model(&AlertCurEvent{}).Count(&res.Total).Error


### PR DESCRIPTION
**What type of PR is this?**
Compute statistics for alert_cur_event & alert_his_event

**What this PR does / why we need it**:
Compute statistics for ‘Unresolved  alert events(total)’, ‘Alert events unresolved for more than 24 hours(total_24_ago)‘,
’Alert events received today(total_today, beginning of today)‘ and ‘Alert events received this week(total_week, monday of the current week, starting at 00:00)’

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
