### PR TITLE
pkg/secu: fix dropped error

### DIFF
--- a/pkg/secu/rsa.go
+++ b/pkg/secu/rsa.go
@@ -15,8 +15,9 @@ func Decrypt(cipherText string, privateKeyByte []byte, password string) (decrypt
 	//pem解码
 	block, _ := pem.Decode(privateKeyByte)
 	var privateKey *rsa.PrivateKey
+	var decryptedPrivateKeyBytes []byte
 	if password != "" {
-		decryptedPrivateKeyBytes, err := x509.DecryptPEMBlock(block, []byte(password))
+		decryptedPrivateKeyBytes, err = x509.DecryptPEMBlock(block, []byte(password))
 		if err != nil {
 			logger.Error("Failed to DecryptPEMBlock:", err)
 			return "", err


### PR DESCRIPTION
This fixes an`err` variable clobbered by an `:=` inside an `if` block in `pkg/secu`.