### PR TITLE
set target_ident when cache is not sync

### DIFF
--- a/alert/process/process.go
+++ b/alert/process/process.go
@@ -428,7 +428,13 @@ func (p *Processor) mayHandleIdent() {
 		if target, exists := p.TargetCache.Get(ident); exists {
 			p.target = target.Ident
 			p.targetNote = target.Note
+		} else {
+			p.target = ident
+			p.targetNote = ""
 		}
+	} else {
+		p.target = ""
+		p.targetNote = ""
 	}
 }
 


### PR DESCRIPTION
目前Targets cache刷新间隔默认9s
假如机器上报完成，9s之内 立刻有个告警触发，
此时获取缓存失败，*Processor.target  还是之前的target
