### PR TITLE
prom: fix dropped errors

### DIFF
--- a/prom/reader.go
+++ b/prom/reader.go
@@ -43,6 +43,10 @@ func (pc *PromClientMap) loadFromDatabase() {
 	var err error
 	if !pc.ctx.IsCenter {
 		datasources, err = poster.GetByUrls[[]*models.Datasource](pc.ctx, "/v1/n9e/datasources?typ="+models.PROMETHEUS)
+		if err != nil {
+			logger.Errorf("failed to get datasources, error: %v", err)
+			return
+		}
 		lokiDatasource, err := poster.GetByUrls[[]*models.Datasource](pc.ctx, "/v1/n9e/datasources?typ="+models.LOKI)
 		datasources = append(datasources, lokiDatasource...)
 		if err != nil {
@@ -54,6 +58,10 @@ func (pc *PromClientMap) loadFromDatabase() {
 		}
 	} else {
 		datasources, err = models.GetDatasourcesGetsBy(pc.ctx, models.PROMETHEUS, "", "", "")
+		if err != nil {
+			logger.Errorf("failed to get datasources, error: %v", err)
+			return
+		}
 		lokiDatasource, err := models.GetDatasourcesGetsBy(pc.ctx, models.LOKI, "", "", "")
 		datasources = append(datasources, lokiDatasource...)
 		if err != nil {


### PR DESCRIPTION
This fixes two dropped `err` variables in the `prom` package.