### PR TITLE
fix: remove stats code that could cause panic

### DIFF
--- a/alert/eval/eval.go
+++ b/alert/eval/eval.go
@@ -123,7 +123,6 @@ func (arw *AlertRuleWorker) Eval() {
 
 	if arw.processor == nil {
 		logger.Warningf("rule_eval:%s processor is nil", arw.Key())
-		arw.processor.Stats.CounterRuleEvalErrorTotal.WithLabelValues(fmt.Sprintf("%v", arw.processor.DatasourceId()), GET_PROCESSOR).Inc()
 		return
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

fix bug

**What this PR does / why we need it**:
<!--
"Nice to have" "You need it" is not a good reason. :)
-->

这段代码引用了一个nil的变量的方法，可能导致程序panic

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or "Fixes (paste link of issue)"
-->

Fixes #
 
**Special notes for your reviewer**:

可能需要把 astats 变量提升到 AlertRuleWorker 上来实现完整的指标统计