### PR TITLE
Resolve a problem of pushgw  WriteRrelabel not working actually

### DIFF
--- a/pushgw/writer/stats.go
+++ b/pushgw/writer/stats.go
@@ -56,5 +56,6 @@ func init() {
 		CounterWirteTotal,
 		CounterWirteErrorTotal,
 		CounterPushQueueErrorTotal,
+		GaugeSampleQueueSize,
 	)
 }

--- a/pushgw/writer/writer.go
+++ b/pushgw/writer/writer.go
@@ -33,6 +33,7 @@ func (w WriterType) writeRelabel(items []prompb.TimeSeries) []prompb.TimeSeries 
 		if len(lbls) == 0 {
 			continue
 		}
+		item.Labels = lbls
 		ritems = append(ritems, item)
 	}
 	return ritems


### PR DESCRIPTION
**fix: the relabeled labels were not updated to timeSeries, so pushgw's WriteRelabe does not work actually**
