### PR TITLE
Implement Automatic LDAP User to Nightingale Role Mapping

### DIFF
--- a/models/user.go
+++ b/models/user.go
@@ -138,6 +138,19 @@ func (u *User) UpdateSsoFields(sso string, nickname, phone, email string) []inte
 	return updatedFields
 }
 
+func (u *User) UpdateSsoFieldsWithRoles(sso string, nickname, phone, email string, roles []string) []interface{} {
+	updatedFields := u.UpdateSsoFields(sso, nickname, phone, email)
+
+	if len(roles) == 0 {
+		return updatedFields
+	}
+
+	u.Roles = strings.Join(roles, " ")
+	u.RolesLst = roles
+
+	return append(updatedFields, "roles")
+}
+
 func (u *User) FullSsoFields(sso, username, nickname, phone, email string, defaultRoles []string) {
 	now := time.Now().Unix()
 

--- a/pkg/ldapx/user_sync.go
+++ b/pkg/ldapx/user_sync.go
@@ -87,8 +87,14 @@ func (s *SsoClient) UserGetAll() (map[string]*models.User, error) {
 		email := entry.GetAttributeValue(attrs.Email)
 		phone := entry.GetAttributeValue(attrs.Phone)
 
+		// Gets the roles and teams for this entry
+		roleTeamMapping := lc.GetUserRolesAndTeams(entry)
+		if len(roleTeamMapping.Roles) == 0 {
+			// No role mapping is configured, the configured default role is used
+			roleTeamMapping.Roles = lc.DefaultRoles
+		}
 		user := new(models.User)
-		user.FullSsoFields("ldap", username, nickname, phone, email, lc.DefaultRoles)
+		user.FullSsoFields("ldap", username, nickname, phone, email, roleTeamMapping.Roles)
 
 		res[entry.GetAttributeValue(attrs.Username)] = user
 	}


### PR DESCRIPTION
### What type of PR is this?
**Feature**

### What this PR does / why we need it:
This PR introduces an automatic mapping of LDAP users to roles in Nightingale, significantly streamlining user management and ensuring that role assignments align with organizational policies. By leveraging LDAP group memberships or attributes, the system automatically assigns predefined roles in Nightingale, reducing the administrative burden and potential for human error.

### Which issue(s) this PR fixes:
N/A

### Special notes for your reviewer:
Please review the included configuration settings below which detail how LDAP groups are mapped to Nightingale roles. Note that while RoleMapping has been implemented, TeamMapping is still pending and will be addressed in future updates.

```toml
Enable = true  # Enable LDAP authentication
Host = '127.0.0.1'  # LDAP server address
Port = 389  # LDAP server port
BaseDn = 'dc=demo,dc=com'  # LDAP base DN
BindUser = 'cn=admin,dc=demo,dc=com'  # LDAP binding user, usually an admin account
BindPass = 'admin'  # Password for the LDAP binding user

# LDAP user login filter
AuthFilter = '(&(cn=%s))'  # '%s' will be replaced by the username
UserFilter = '(&(uid=*))' # Must be configured for user synchronization

CoverAttributes = true  # Overwrite user attributes from LDAP

# TLS configuration
TLS = false  # Keep false if your LDAP server uses an unencrypted connection
StartTLS = false  # Set to true if your LDAP server supports StartTLS and you want to upgrade to an encrypted connection

DefaultRoles = ['Standard']  # Default roles assigned to LDAP users after login

# Synchronize LDAP users
SyncAddUsers = true
# Synchronization interval, defaults to 1 day if not configured, unit is seconds
SyncInterval = 3600

# User attribute mappings
[Attributes]
Nickname = 'cn'  # Nickname attribute in LDAP
Phone = 'mobile'  # Phone number attribute in LDAP
Email = 'mail'  # Email attribute in LDAP

# Role and team mappings

# LDAP g-admin group
[[RoleTeamMapping]]
DN = "cn=g-admin,ou=Group,dc=demo,dc=com"
Roles = ["Admin"]
Teams = [1]

# LDAP ryan.miao user
[[RoleTeamMapping]]
DN = "cn=ryan.miao,ou=backend team,ou=Research and Development Department,ou=People,dc=demo,dc=com"
Roles = ["Admin"]

# LDAP g-users group
[[RoleTeamMapping]]
DN = "cn=g-users,ou=Group,dc=demo,dc=com"
Roles = ["Standard"]
Teams = [2, 3]

# LDAP hr-ryan user
[[RoleTeamMapping]]
DN = "cn=hr-ryan,ou=HR,ou=People,dc=demo,dc=com"
Roles = ["Guest", "Standard"]
Teams = [4]

# LDAP ciusyan2 user
[[RoleTeamMapping]]
DN = "cn=ciusyan2,ou=HR,ou=People,dc=demo,dc=com"
Roles = ["Test", "Guest"]
Teams = [4]

```

This configuration exemplifies the flexibility and automation capabilities introduced by this feature, facilitating seamless role and team integrations between LDAP and Nightingale.