### PR TITLE
feature: Implement the team mapping function

### DIFF
--- a/pkg/ldapx/user_sync.go
+++ b/pkg/ldapx/user_sync.go
@@ -24,16 +24,24 @@ func (s *SsoClient) SyncAddAndDelUsers(ctx *ctx.Context) error {
 		return err
 	}
 
-	usersToBeAdd := getExtraUsers(usersFromDb, usersFromSso)
+	usersToBeAdd, usersExists := partitionAndUpdateUsers(usersFromDb, usersFromSso)
+	// Incremental users synchronize both user information and group information
 	for _, user := range usersToBeAdd {
-		if err := user.Add(ctx); err != nil {
+		if err = user.AddUserAndGroups(ctx, s.CoverTeams); err != nil {
+			logger.Warningf("failed to sync add user[%v] to db, err: %v", *user, err)
+		}
+	}
+
+	// Existing users synchronize group information only
+	for _, user := range usersExists {
+		if err = models.UserGroupMemberSyncByUser(ctx, user, s.CoverTeams); err != nil {
 			logger.Warningf("failed to sync add user[%v] to db, err: %v", *user, err)
 		}
 	}
 
 	var usersToBeDel []*models.User
 	if s.SyncDel {
-		usersToBeDel = getExtraUsers(usersFromSso, usersFromDb)
+		usersToBeDel, _ = partitionAndUpdateUsers(usersFromSso, usersFromDb)
 		if len(usersToBeDel) > 0 {
 			delIds := make([]int64, 0, len(usersToBeDel))
 			for _, user := range usersToBeDel {
@@ -94,7 +102,8 @@ func (s *SsoClient) UserGetAll() (map[string]*models.User, error) {
 			roleTeamMapping.Roles = lc.DefaultRoles
 		}
 		user := new(models.User)
-		user.FullSsoFields("ldap", username, nickname, phone, email, roleTeamMapping.Roles)
+		user.FullSsoFieldsWithTeams("ldap", username, nickname, phone, email, roleTeamMapping.Roles,
+			roleTeamMapping.Teams, lc.CoverTeams)
 
 		res[entry.GetAttributeValue(attrs.Username)] = user
 	}
@@ -102,11 +111,18 @@ func (s *SsoClient) UserGetAll() (map[string]*models.User, error) {
 	return res, nil
 }
 
-// in m not in base
-func getExtraUsers(base, m map[string]*models.User) (extraUsers []*models.User) {
-	for username, user := range m {
-		if _, exist := base[username]; !exist {
-			extraUsers = append(extraUsers, user)
+// newExtraUsers: in newUsers not in base
+// updatedUsers: in newUsers and in base, update the user.TeamsLst data
+func partitionAndUpdateUsers(base, newUsers map[string]*models.User) (newExtraUsers, updatedUsers []*models.User) {
+	for username, user := range newUsers {
+		if baseUser, exist := base[username]; !exist {
+			newExtraUsers = append(newExtraUsers, user)
+		} else {
+			if len(baseUser.TeamsLst) == 0 {
+				// Need to pass on the team message
+				baseUser.TeamsLst = user.TeamsLst
+			}
+			updatedUsers = append(updatedUsers, baseUser)
 		}
 	}
 	return


### PR DESCRIPTION
**What type of PR is this?**  
Feature

**What this PR does / why we need it:**  
This PR expands on the previously introduced LDAP-to-role mapping feature in Nightingale by implementing TeamMapping. This enhancement facilitates the automatic mapping of LDAP users not only to roles but also to specific teams based on their LDAP group memberships or attributes. It simplifies user and team management further, ensuring that both role and team assignments are consistent with organizational policies, thus reducing the administrative workload and minimizing human error.

**Which issue(s) this PR fixes:**  
N/A

**Special notes for your reviewer:**  
Please review the updated configuration settings below which now include detailed mappings for how LDAP groups and individual users are mapped to both Nightingale roles and teams. This update completes the integration of LDAP with Nightingale, offering a comprehensive management solution that leverages existing organizational structures for user authentication and authorization.

**Configuration Settings:**

```plaintext
Enable = true  # Enable LDAP authentication
Host = '127.0.0.1'  # LDAP server address
Port = 389  # LDAP server port
BaseDn = 'dc=demo,dc=com'  # LDAP base DN
BindUser = 'cn=admin,dc=demo,dc=com'  # LDAP binding user, usually an admin account
BindPass = 'admin'  # Password for the LDAP binding user

# LDAP user login filter
AuthFilter = '(&(cn=%s))'  # '%s' will be replaced by the username
UserFilter = '(&(uid=*))' # Must be configured for user synchronization

CoverAttributes = true  # Overwrite user attributes from LDAP

# TLS configuration
TLS = false  # Keep false if your LDAP server uses an unencrypted connection
StartTLS = false  # Set to true if your LDAP server supports StartTLS and you want to upgrade to an encrypted connection

DefaultRoles = ['Standard']  # Default roles assigned to LDAP users after login

# Synchronize LDAP users
SyncAddUsers = true
# Synchronization interval, defaults to 1 day if not configured, unit is seconds
SyncInterval = 3600

# User attribute mappings
[Attributes]
Nickname = 'cn'  # Nickname attribute in LDAP
Phone = 'mobile'  # Phone number attribute in LDAP
Email = 'mail'  # Email attribute in LDAP

# Complete Role and Team Mappings

# LDAP g-admin group
[[RoleTeamMapping]]
DN = "cn=g-admin,ou=Group,dc=demo,dc=com"
Roles = ["Admin"]
Teams = [1]

# LDAP ryan.miao user
[[RoleTeamMapping]]
DN = "cn=ryan.miao,ou=backend team,ou=Research and Development Department,ou=People,dc=demo,dc=com"
Roles = ["Admin"]
Teams = [1]

# LDAP g-users group
[[RoleTeamMapping]]
DN = "cn=g-users,ou=Group,dc=demo,dc=com"
Roles = ["Standard"]
Teams = [2, 3]

# LDAP hr-ryan user
[[RoleTeamMapping]]
DN = "cn=hr-ryan,ou=HR,ou=People,dc=demo,dc=com"
Roles = ["Guest", "Standard"]
Teams = [4]

# LDAP ciusyan2 user
[[RoleTeamMapping]]
DN = "cn=ciusyan2,ou=HR,ou=People,dc=demo,dc=com"
Roles = ["Test", "Guest"]
Teams = [4]
```

This configuration underscores the complete integration of LDAP with Nightingale’s role and team structures, enhancing automation and flexibility in managing access controls.
