### PR TITLE
对 prometheus 2.50.0 版本引入的 NewPossibleNonCounterInfo warnings 做适配

### DIFF
--- a/alert/eval/eval.go
+++ b/alert/eval/eval.go
@@ -192,7 +192,6 @@ func (arw *AlertRuleWorker) GetPromAnomalyPoint(ruleConfig string) []common.Anom
 			logger.Errorf("rule_eval:%s promql:%s, warnings:%v", arw.Key(), promql, warnings)
 			arw.processor.Stats.CounterQueryDataErrorTotal.WithLabelValues(fmt.Sprintf("%d", arw.datasourceId)).Inc()
 			arw.processor.Stats.CounterRuleEvalErrorTotal.WithLabelValues(fmt.Sprintf("%v", arw.processor.DatasourceId()), QUERY_DATA).Inc()
-			continue
 		}
 
 		logger.Debugf("rule_eval:%s query:%+v, value:%v", arw.Key(), query, value)


### PR DESCRIPTION
**对 prometheus 2.50.0 版本引入的 NewPossibleNonCounterInfo warnings 机制做适配**

https://github.com/prometheus/prometheus/pull/13022

可避免由于prom新版本对 metric name 的"软"规范问题 导致 夜莺跳过后续告警逻辑判定，从而导致预期外的异常 case；