### PR TITLE
docs: fix wrong table name about 'WriteRelabels'

### DIFF
--- a/etc/config.toml
+++ b/etc/config.toml
@@ -165,7 +165,7 @@ MaxIdleConnsPerHost = 100
 # TLSCert = "/etc/n9e/cert.pem"
 # TLSKey = "/etc/n9e/key.pem"
 # InsecureSkipVerify = false
-# [[Writers.WriteRelabels]]
+# [[Pushgw.Writers.WriteRelabels]]
 # Action = "replace"
 # SourceLabels = ["__address__"]
 # Regex = "([^:]+)(?::\\d+)?"


### PR DESCRIPTION
A slight errir that causes failure to set WriteRelabels.