### PR TITLE
feat:  support event list view only by  business group

### DIFF
--- a/center/cconf/conf.go
+++ b/center/cconf/conf.go
@@ -12,6 +12,7 @@ type Center struct {
 	AnonymousAccess        AnonymousAccess
 	UseFileAssets          bool
 	FlashDuty              FlashDuty
+	EventHistoryGroupView  bool
 }
 
 type Plugin struct {

--- a/center/router/router_alert_cur_event.go
+++ b/center/router/router_alert_cur_event.go
@@ -43,7 +43,6 @@ func (rt *Router) alertCurEventsCard(c *gin.Context) {
 	stime, etime := getTimeRange(c)
 	severity := ginx.QueryInt(c, "severity", -1)
 	query := ginx.QueryStr(c, "query", "")
-	busiGroupId := ginx.QueryInt64(c, "bgid", 0)
 	dsIds := queryDatasourceIds(c)
 	rules := parseAggrRules(c)
 
@@ -62,8 +61,11 @@ func (rt *Router) alertCurEventsCard(c *gin.Context) {
 		cates = strings.Split(cate, ",")
 	}
 
+	bgids, err := rt.getBusinessGroupIds(c)
+	ginx.Dangerous(err)
+
 	// 最多获取50000个，获取太多也没啥意义
-	list, err := models.AlertCurEventGets(rt.Ctx, prods, busiGroupId, stime, etime, severity, dsIds, cates, query, 50000, 0)
+	list, err := models.AlertCurEventGets(rt.Ctx, prods, bgids, stime, etime, severity, dsIds, cates, query, 50000, 0)
 	ginx.Dangerous(err)
 
 	cardmap := make(map[string]*AlertCard)
@@ -142,7 +144,6 @@ func (rt *Router) alertCurEventsList(c *gin.Context) {
 	severity := ginx.QueryInt(c, "severity", -1)
 	query := ginx.QueryStr(c, "query", "")
 	limit := ginx.QueryInt(c, "limit", 20)
-	busiGroupId := ginx.QueryInt64(c, "bgid", 0)
 	dsIds := queryDatasourceIds(c)
 
 	prod := ginx.QueryStr(c, "prods", "")
@@ -161,10 +162,13 @@ func (rt *Router) alertCurEventsList(c *gin.Context) {
 		cates = strings.Split(cate, ",")
 	}
 
-	total, err := models.AlertCurEventTotal(rt.Ctx, prods, busiGroupId, stime, etime, severity, dsIds, cates, query)
+	bgids, err := rt.getBusinessGroupIds(c)
 	ginx.Dangerous(err)
 
-	list, err := models.AlertCurEventGets(rt.Ctx, prods, busiGroupId, stime, etime, severity, dsIds, cates, query, limit, ginx.Offset(c, limit))
+	total, err := models.AlertCurEventTotal(rt.Ctx, prods, bgids, stime, etime, severity, dsIds, cates, query)
+	ginx.Dangerous(err)
+
+	list, err := models.AlertCurEventGets(rt.Ctx, prods, bgids, stime, etime, severity, dsIds, cates, query, limit, ginx.Offset(c, limit))
 	ginx.Dangerous(err)
 
 	cache := make(map[int64]*models.UserGroup)

--- a/docker/compose-postgres/initsql_for_postgres/a-n9e-for-Postgres.sql
+++ b/docker/compose-postgres/initsql_for_postgres/a-n9e-for-Postgres.sql
@@ -832,3 +832,22 @@ COMMENT ON COLUMN builtin_metrics.created_at IS 'create time';
 COMMENT ON COLUMN builtin_metrics.created_by IS 'creator';
 COMMENT ON COLUMN builtin_metrics.updated_at IS 'update time';
 COMMENT ON COLUMN builtin_metrics.updated_by IS 'updater';
+
+CREATE TABLE metric_filter (
+  id BIGSERIAL PRIMARY KEY,
+  name VARCHAR(191) NOT NULL,
+  configs VARCHAR(4096) NOT NULL,
+  groups_perm TEXT,
+  create_at BIGINT NOT NULL DEFAULT 0,
+  create_by VARCHAR(191) NOT NULL DEFAULT '',
+  update_at BIGINT NOT NULL DEFAULT 0,
+  update_by VARCHAR(191) NOT NULL DEFAULT ''
+);
+
+CREATE INDEX idx_name ON metric_filter (name);
+
+CREATE TABLE board_busigroup (
+  busi_group_id BIGINT NOT NULL DEFAULT 0,
+  board_id BIGINT NOT NULL DEFAULT 0,
+  PRIMARY KEY (busi_group_id, board_id)
+);

--- a/docker/initsql/a-n9e.sql
+++ b/docker/initsql/a-n9e.sql
@@ -502,6 +502,12 @@ CREATE TABLE `alert_his_event` (
     KEY (`trigger_time`, `group_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET = utf8mb4;
 
+CREATE TABLE `board_busigroup` (
+  `busi_group_id` bigint(20) NOT NULL DEFAULT '0' COMMENT 'busi group id',
+  `board_id` bigint(20) NOT NULL DEFAULT '0' COMMENT 'board id',
+  PRIMARY KEY (`busi_group_id`, `board_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 CREATE TABLE `task_tpl`
 (
     `id`        int unsigned NOT NULL AUTO_INCREMENT,

--- a/docker/migratesql/migrate.sql
+++ b/docker/migratesql/migrate.sql
@@ -32,3 +32,10 @@ CREATE TABLE `metric_filter` (
   PRIMARY KEY (`id`),
   KEY `idx_name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+
+CREATE TABLE `board_busigroup` (
+  `busi_group_id` bigint(20) NOT NULL DEFAULT '0' COMMENT 'busi group id',
+  `board_id` bigint(20) NOT NULL DEFAULT '0' COMMENT 'board id',
+  PRIMARY KEY (`busi_group_id`, `board_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/spaolacci/murmur3 v1.1.0
 	github.com/tidwall/gjson v1.14.0
 	github.com/toolkits/pkg v1.3.6
+	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1
 	golang.org/x/oauth2 v0.10.0
 	gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df
 	gopkg.in/yaml.v2 v2.4.0
@@ -90,7 +91,6 @@ require (
 	go.uber.org/automaxprocs v1.5.2 // indirect
 	golang.org/x/arch v0.3.0 // indirect
 	golang.org/x/crypto v0.21.0 // indirect
-	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1 // indirect
 	golang.org/x/image v0.13.0 // indirect
 	golang.org/x/net v0.23.0 // indirect
 	golang.org/x/sys v0.18.0 // indirect

--- a/models/alert_cur_event.go
+++ b/models/alert_cur_event.go
@@ -346,7 +346,7 @@ func (e *AlertCurEvent) FillNotifyGroups(ctx *ctx.Context, cache map[int64]*User
 	return nil
 }
 
-func AlertCurEventTotal(ctx *ctx.Context, prods []string, bgid, stime, etime int64, severity int, dsIds []int64, cates []string, query string) (int64, error) {
+func AlertCurEventTotal(ctx *ctx.Context, prods []string, bgids []int64, stime, etime int64, severity int, dsIds []int64, cates []string, query string) (int64, error) {
 	session := DB(ctx).Model(&AlertCurEvent{})
 	if stime != 0 && etime != 0 {
 		session = session.Where("trigger_time between ? and ?", stime, etime)
@@ -355,8 +355,8 @@ func AlertCurEventTotal(ctx *ctx.Context, prods []string, bgid, stime, etime int
 		session = session.Where("rule_prod in ?", prods)
 	}
 
-	if bgid > 0 {
-		session = session.Where("group_id = ?", bgid)
+	if len(bgids) > 0 {
+		session = session.Where("group_id in ?", bgids)
 	}
 
 	if severity >= 0 {
@@ -382,7 +382,7 @@ func AlertCurEventTotal(ctx *ctx.Context, prods []string, bgid, stime, etime int
 	return Count(session)
 }
 
-func AlertCurEventGets(ctx *ctx.Context, prods []string, bgid, stime, etime int64, severity int, dsIds []int64, cates []string, query string, limit, offset int) ([]AlertCurEvent, error) {
+func AlertCurEventGets(ctx *ctx.Context, prods []string, bgids []int64, stime, etime int64, severity int, dsIds []int64, cates []string, query string, limit, offset int) ([]AlertCurEvent, error) {
 	session := DB(ctx).Model(&AlertCurEvent{})
 	if stime != 0 && etime != 0 {
 		session = session.Where("trigger_time between ? and ?", stime, etime)
@@ -391,8 +391,8 @@ func AlertCurEventGets(ctx *ctx.Context, prods []string, bgid, stime, etime int6
 		session = session.Where("rule_prod in ?", prods)
 	}
 
-	if bgid > 0 {
-		session = session.Where("group_id = ?", bgid)
+	if len(bgids) > 0 {
+		session = session.Where("group_id in ?", bgids)
 	}
 
 	if severity >= 0 {

--- a/models/alert_his_event.go
+++ b/models/alert_his_event.go
@@ -114,15 +114,15 @@ func (e *AlertHisEvent) FillNotifyGroups(ctx *ctx.Context, cache map[int64]*User
 	return nil
 }
 
-func AlertHisEventTotal(ctx *ctx.Context, prods []string, bgid, stime, etime int64, severity int, recovered int, dsIds []int64, cates []string, query string) (int64, error) {
+func AlertHisEventTotal(ctx *ctx.Context, prods []string, bgids []int64, stime, etime int64, severity int, recovered int, dsIds []int64, cates []string, query string) (int64, error) {
 	session := DB(ctx).Model(&AlertHisEvent{}).Where("last_eval_time between ? and ?", stime, etime)
 
 	if len(prods) > 0 {
 		session = session.Where("rule_prod in ?", prods)
 	}
 
-	if bgid > 0 {
-		session = session.Where("group_id = ?", bgid)
+	if len(bgids) > 0 {
+		session = session.Where("group_id in ?", bgids)
 	}
 
 	if severity >= 0 {
@@ -152,15 +152,15 @@ func AlertHisEventTotal(ctx *ctx.Context, prods []string, bgid, stime, etime int
 	return Count(session)
 }
 
-func AlertHisEventGets(ctx *ctx.Context, prods []string, bgid, stime, etime int64, severity int, recovered int, dsIds []int64, cates []string, query string, limit, offset int) ([]AlertHisEvent, error) {
+func AlertHisEventGets(ctx *ctx.Context, prods []string, bgids []int64, stime, etime int64, severity int, recovered int, dsIds []int64, cates []string, query string, limit, offset int) ([]AlertHisEvent, error) {
 	session := DB(ctx).Where("last_eval_time between ? and ?", stime, etime)
 
 	if len(prods) != 0 {
 		session = session.Where("rule_prod in ?", prods)
 	}
 
-	if bgid > 0 {
-		session = session.Where("group_id = ?", bgid)
+	if len(bgids) > 0 {
+		session = session.Where("group_id in ?", bgids)
 	}
 
 	if severity >= 0 {


### PR DESCRIPTION
**What type of PR is this?**
optimize

**What this PR does / why we need it**:
This PR enhances the functionality of the alert event filtering by allowing the use of multiple business group IDs. It includes logic to ensure that users can only view events for the business groups they belong to when the "view own business group events only" setting is enabled. This enhancement is necessary to provide more flexible and precise filtering options for alert events, improving the user experience and aligning with business requirements.

**Which issue(s) this PR fixes**:
 
**Special notes for your reviewer**:
- The `getBusinessGroupIds` function has been updated to handle the filtering logic based on user business group membership and the `bgid` parameter from the frontend.
- This PR ensures that if a `bgid` is provided and valid, it is used for filtering; otherwise, it falls back to the user's business groups if the "view own business group events only" setting is enabled.
- Please verify the changes in the `alertCurEventsCard` and `alertCurEventsList` methods to ensure the filtering logic works as expected.