### PR TITLE
feature: the alert response event supports query recovery values

### DIFF
--- a/alert/alert.go
+++ b/alert/alert.go
@@ -106,7 +106,7 @@ func Start(alertc aconf.Alert, pushgwc pconf.Pushgw, syncStats *memsto.Stats, al
 		busiGroupCache, alertMuteCache, datasourceCache, promClients, tdendgineClients, naming, ctx, alertStats)
 
 	dp := dispatch.NewDispatch(alertRuleCache, userCache, userGroupCache, alertSubscribeCache, targetCache, notifyConfigCache, taskTplsCache, alertc.Alerting, ctx, alertStats)
-	consumer := dispatch.NewConsumer(alertc.Alerting, ctx, dp)
+	consumer := dispatch.NewConsumer(alertc.Alerting, ctx, dp, promClients)
 
 	go dp.ReloadTpls()
 	go consumer.LoopConsume()

--- a/alert/dispatch/consume.go
+++ b/alert/dispatch/consume.go
@@ -1,14 +1,19 @@
 package dispatch
 
 import (
+	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/ccfos/nightingale/v6/alert/aconf"
+	"github.com/ccfos/nightingale/v6/alert/common"
 	"github.com/ccfos/nightingale/v6/alert/queue"
 	"github.com/ccfos/nightingale/v6/models"
 	"github.com/ccfos/nightingale/v6/pkg/ctx"
 	"github.com/ccfos/nightingale/v6/pkg/poster"
+	promsdk "github.com/ccfos/nightingale/v6/pkg/prom"
+	"github.com/ccfos/nightingale/v6/prom"
 
 	"github.com/toolkits/pkg/concurrent/semaphore"
 	"github.com/toolkits/pkg/logger"
@@ -18,15 +23,17 @@ type Consumer struct {
 	alerting aconf.Alerting
 	ctx      *ctx.Context
 
-	dispatch *Dispatch
+	dispatch    *Dispatch
+	promClients *prom.PromClientMap
 }
 
 // 创建一个 Consumer 实例
-func NewConsumer(alerting aconf.Alerting, ctx *ctx.Context, dispatch *Dispatch) *Consumer {
+func NewConsumer(alerting aconf.Alerting, ctx *ctx.Context, dispatch *Dispatch, promClients *prom.PromClientMap) *Consumer {
 	return &Consumer{
-		alerting: alerting,
-		ctx:      ctx,
-		dispatch: dispatch,
+		alerting:    alerting,
+		ctx:         ctx,
+		dispatch:    dispatch,
+		promClients: promClients,
 	}
 }
 
@@ -84,6 +91,8 @@ func (e *Consumer) consumeOne(event *models.AlertCurEvent) {
 		event.AnnotationsJSON["error"] = event.Annotations
 	}
 
+	e.queryRecoveryVal(event)
+
 	e.persist(event)
 
 	if event.IsRecovered && event.NotifyRecovered == 0 {
@@ -114,4 +123,61 @@ func (e *Consumer) persist(event *models.AlertCurEvent) {
 		logger.Errorf("event%+v persist err:%v", event, err)
 		e.dispatch.Astats.CounterRuleEvalErrorTotal.WithLabelValues(fmt.Sprintf("%v", event.DatasourceId), "persist_event").Inc()
 	}
+}
+
+func (e *Consumer) queryRecoveryVal(event *models.AlertCurEvent) {
+	if !event.IsRecovered {
+		return
+	}
+
+	// If the event is a recovery event, execute the recovery_promql query
+	promql, ok := event.AnnotationsJSON["recovery_promql"]
+	if !ok {
+		return
+	}
+
+	promql = strings.TrimSpace(promql)
+	if promql == "" {
+		logger.Warningf("rule_eval:%s promql is blank", getKey(event))
+		return
+	}
+
+	if e.promClients.IsNil(event.DatasourceId) {
+		logger.Warningf("rule_eval:%s error reader client is nil", getKey(event))
+		return
+	}
+
+	readerClient := e.promClients.GetCli(event.DatasourceId)
+
+	var warnings promsdk.Warnings
+	value, warnings, err := readerClient.Query(e.ctx.Ctx, promql, time.Now())
+	if err != nil {
+		logger.Errorf("rule_eval:%s promql:%s, error:%v", getKey(event), promql, err)
+		return
+	}
+
+	if len(warnings) > 0 {
+		logger.Errorf("rule_eval:%s promql:%s, warnings:%v", getKey(event), promql, warnings)
+	}
+
+	anomalyPoints := common.ConvertAnomalyPoints(value)
+	if len(anomalyPoints) == 0 {
+		logger.Warningf("rule_eval:%s promql:%s, result is empty", getKey(event), promql)
+		return
+	}
+
+	// Put the query results into AnnotationsJSON
+	event.AnnotationsJSON["recovery_value"] = fmt.Sprintf("%v", anomalyPoints[0].Value)
+
+	b, err := json.Marshal(event.AnnotationsJSON)
+	if err != nil {
+		event.AnnotationsJSON = make(map[string]string)
+		event.AnnotationsJSON["error"] = fmt.Sprintf("failed to parse annotations: %v", err)
+	} else {
+		event.Annotations = string(b)
+	}
+}
+
+func getKey(event *models.AlertCurEvent) string {
+	return common.RuleKey(event.DatasourceId, event.RuleId)
 }


### PR DESCRIPTION
**What type of PR is this?**

- [x] Enhancement

**What this PR does / why we need it**:

This PR enhances the `consumeOne` method to handle the `recovery_promql` configuration. When an alert recovery event is detected, it parses the `recovery_promql` and executes the query to retrieve the corresponding recovery value. This value is then stored in the `AnnotationsJSON` field under the key `recovery_value`. This feature allows for more detailed and accurate alert recovery handling, providing important recovery metrics for further analysis.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
The implementation involves:
- Parsing the `recovery_promql` from `AnnotationsJSON` and filling in the parameters.
- Executing the `recovery_promql` query when a recovery event is detected.
- Storing the query result in `AnnotationsJSON` under `recovery_value`.
- Utilizing the `ConvertAnomalyPoints` method to extract the numerical value from the query result.

Please review the changes in the `consumeOne` method to ensure proper handling of the `recovery_promql` parsing and query execution logic.