### PR TITLE
sso_login_defaultGroups:cas,oauth2

### DIFF
--- a/center/router/router_login.go
+++ b/center/router/router_login.go
@@ -354,6 +354,15 @@ func (rt *Router) loginCallbackCas(c *gin.Context) {
 		user.FullSsoFields("cas", ret.Username, ret.Nickname, ret.Phone, ret.Email, rt.Sso.CAS.DefaultRoles)
 		// create user from cas
 		ginx.Dangerous(user.Add(rt.Ctx))
+
+		if len(rt.Sso.CAS.DefaultTeams) > 0 {
+			for _, gid := range rt.Sso.CAS.DefaultTeams {
+				err = models.UserGroupMemberAdd(rt.Ctx, gid, user.Id)
+				if err != nil {
+					logger.Errorf("user:%v UserGroupMemberAdd: %s", user, err)
+				}
+			}
+		}
 	}
 
 	// set user login state
@@ -430,6 +439,15 @@ func (rt *Router) loginCallbackOAuth(c *gin.Context) {
 		user.FullSsoFields("oauth2", ret.Username, ret.Nickname, ret.Phone, ret.Email, rt.Sso.OAuth2.DefaultRoles)
 		// create user from oidc
 		ginx.Dangerous(user.Add(rt.Ctx))
+
+		if len(rt.Sso.OAuth2.DefaultTeams) > 0 {
+			for _, gid := range rt.Sso.OAuth2.DefaultTeams {
+				err = models.UserGroupMemberAdd(rt.Ctx, gid, user.Id)
+				if err != nil {
+					logger.Errorf("user:%v UserGroupMemberAdd: %s", user, err)
+				}
+			}
+		}
 	}
 
 	// set user login state

--- a/pkg/cas/cas.go
+++ b/pkg/cas/cas.go
@@ -33,6 +33,7 @@ type Config struct {
 		Email    string
 	}
 	DefaultRoles []string
+	DefaultTeams []int64
 }
 
 type SsoClient struct {
@@ -49,6 +50,7 @@ type SsoClient struct {
 		Email    string
 	}
 	DefaultRoles    []string
+	DefaultTeams    []int64
 	CoverAttributes bool
 	HTTPClient      *http.Client
 	sync.RWMutex
@@ -103,6 +105,7 @@ func (s *SsoClient) Reload(cf Config) {
 	s.Attributes.Phone = cf.Attributes.Phone
 	s.Attributes.Email = cf.Attributes.Email
 	s.DefaultRoles = cf.DefaultRoles
+	s.DefaultTeams = cf.DefaultTeams
 	s.CoverAttributes = cf.CoverAttributes
 
 	if cf.SkipTlsVerify {

--- a/pkg/oauth2x/oauth2x.go
+++ b/pkg/oauth2x/oauth2x.go
@@ -38,6 +38,7 @@ type SsoClient struct {
 	UserinfoIsArray bool
 	UserinfoPrefix  string
 	DefaultRoles    []string
+	DefaultTeams    []int64
 
 	Ctx context.Context
 	sync.RWMutex
@@ -62,7 +63,9 @@ type Config struct {
 		Phone    string
 		Email    string
 	}
-	DefaultRoles    []string
+	DefaultRoles []string
+	DefaultTeams []int64
+
 	UserinfoIsArray bool
 	UserinfoPrefix  string
 	Scopes          []string
@@ -100,6 +103,7 @@ func (s *SsoClient) Reload(cf Config) {
 	s.UserinfoIsArray = cf.UserinfoIsArray
 	s.UserinfoPrefix = cf.UserinfoPrefix
 	s.DefaultRoles = cf.DefaultRoles
+	s.DefaultTeams = cf.DefaultTeams
 
 	s.Ctx = context.Background()
 


### PR DESCRIPTION
# sso_login_defaultGroups:cas,oauth2

## cas和oath2的单点登录中添加默认组划分，会将用户划分到yaml描述提供的组