### PR TITLE
fix:get configcache return nil need exit

### DIFF
--- a/center/sso/init.go
+++ b/center/sso/init.go
@@ -1,6 +1,7 @@
 package sso
 
 import (
+	"fmt"
 	"log"
 	"time"
 
@@ -145,7 +146,7 @@ func Init(center cconf.Center, ctx *ctx.Context, configCache *memsto.ConfigCache
 		}
 	}
 	if configCache == nil {
-		logger.Error("configCache is nil, sso initialization failed")
+		log.Fatalln(fmt.Errorf("configCache is nil, sso initialization failed"))
 	}
 	ssoClient.configCache = configCache
 	userVariableMap := configCache.Get()


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
**What this PR does / why we need it**:
When configCache is nil, in addition to printing the log, you also need to , otherwise the Get method will trigger a panic

**Which issue(s) this PR fixes**:
Fixes #
 
**Special notes for your reviewer**: