### PR TITLE
update: oom_kill alert rule

### DIFF
--- a/integrations/Linux/alerts/常用中文告警规则-采集器Categraf.json
+++ b/integrations/Linux/alerts/常用中文告警规则-采集器Categraf.json
@@ -1425,7 +1425,7 @@
         "rule_config": {
             "queries": [
                 {
-                    "prom_ql": "kernel_vmstat_oom_kill != 0",
+                    "prom_ql": "increase(kernel_vmstat_oom_kill[2m]) > 0",
                     "severity": 2
                 }
             ]

--- a/integrations/Linux/metrics/categraf-base.json
+++ b/integrations/Linux/metrics/categraf-base.json
@@ -263,7 +263,7 @@
         "unit": "none",
         "note": "取自 `/proc/vmstat`，需要较高版本的内核，没记错的话应该是 4.13 以上版本",
         "lang": "zh_CN",
-        "expression": "kernel_vmstat_oom_kill",
+        "expression": "increase(kernel_vmstat_oom_kill[2m]) > 0",
         "created_at": 0,
         "created_by": "",
         "updated_at": 0,


### PR DESCRIPTION
**What type of PR is this?**
更新默认报警规则中OOM 的检测语句。

**What this PR does / why we need it**:
<!--
"Nice to have" "You need it" is not a good reason. :)
-->

kernel_vmstat_oom_kill 是一个累计值，系统启动后出现的OOM次数持续累计，原规则中的语句会导致持续报警，按increase更加合适。
间隔时间为2m，和 https://github.com/ccfos/nightingale/blob/f1259d1dffc2a6f247c99e3e8ef91d29fffe59c7/integrations/Linux/dashboards/host_generic_categraf.json#L1362 保持一致。

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or "Fixes (paste link of issue)"
-->
Fixes #
 
**Special notes for your reviewer**: