### PR TITLE
non buf channel happens-before

### DIFF
--- a/alert/sender/email.go
+++ b/alert/sender/email.go
@@ -123,7 +123,7 @@ func InitEmailSender(ctx *ctx.Context, ncc *memsto.NotifyConfigCacheType) {
 	mailch = make(chan *EmailContext, 100000)
 	go updateSmtp(ctx, ncc)
 	smtpConfig = ncc.GetSMTP()
-	startEmailSender(ctx, smtpConfig)
+	go startEmailSender(ctx, smtpConfig)
 }
 
 func updateSmtp(ctx *ctx.Context, ncc *memsto.NotifyConfigCacheType) {
@@ -143,6 +143,7 @@ func startEmailSender(ctx *ctx.Context, smtp aconf.SMTPConfig) {
 	conf := smtp
 	if conf.Host == "" || conf.Port == 0 {
 		logger.Warning("SMTP configurations invalid")
+		<-mailQuit
 		return
 	}
 	logger.Infof("start email sender... conf.Host:%+v,conf.Port:%+v", conf.Host, conf.Port)


### PR DESCRIPTION
修复新部署的服务修改 smtp 配置之后告警无法发送到邮箱的问题：

1. 旧 startEmailSender 需要等待新 startEmailSender 的信号再退出