### PR TITLE
alert mute retain

### DIFF
--- a/center/router/router_mute.go
+++ b/center/router/router_mute.go
@@ -50,7 +50,8 @@ func (rt *Router) alertMuteGets(c *gin.Context) {
 	prods := strings.Fields(ginx.QueryStr(c, "prods", ""))
 	bgid := ginx.QueryInt64(c, "bgid", -1)
 	query := ginx.QueryStr(c, "query", "")
-	lst, err := models.AlertMuteGets(rt.Ctx, prods, bgid, query)
+	disabled := ginx.QueryInt(c, "disabled", -1)
+	lst, err := models.AlertMuteGets(rt.Ctx, prods, bgid, disabled, query)
 
 	ginx.NewRender(c).Data(lst, err)
 }


### PR DESCRIPTION
1. 告警屏蔽规则过期后不再清理，便于后续查看
2. 告警屏蔽规则同步时仅同步启用的规则