### PR TITLE
fix: error when RecordingRule CronPattern saved

### DIFF
--- a/models/recording_rule.go
+++ b/models/recording_rule.go
@@ -151,7 +151,7 @@ func (re *RecordingRule) Verify() error {
 	}
 
 	if re.CronPattern == "" {
-		re.CronPattern = "@every 60s"
+		re.CronPattern = fmt.Sprintf("@every %ds", re.PromEvalInterval)
 	}
 
 	re.AppendTags = strings.TrimSpace(re.AppendTags)


### PR DESCRIPTION
"cron_pattern" in DB recording_rule table will be always "@every 60s" and  inconsistent with "prom_eval_interval", which will result in the record working period always being 60s.