### PR TITLE
use config skip init integration

### DIFF
--- a/center/integration/init.go
+++ b/center/integration/init.go
@@ -22,6 +22,14 @@ func Init(ctx *ctx.Context, builtinIntegrationsDir string) {
 		return
 	}
 
+	if res, err := models.ConfigsSelectByCkey(ctx, "disable_integration_init"); err != nil {
+		logger.Error("fail to get value 'disable_integration_init' from configs", err)
+		return
+	} else if len(res) != 0 {
+		logger.Info("disable_integration_init is set, skip integration init")
+		return
+	}
+
 	fp := builtinIntegrationsDir
 	if fp == "" {
 		fp = path.Join(runner.Cwd, "integrations")


### PR DESCRIPTION
允许用户设置变量 'disable_integration_init'，如果用户设置了这个变量，就会跳过 integration 初始化