### PR TITLE
fix alert rule worker severity

### DIFF
--- a/alert/eval/eval.go
+++ b/alert/eval/eval.go
@@ -231,7 +231,7 @@ func (arw *AlertRuleWorker) Stop() {
 
 func (arw *AlertRuleWorker) GetPromAnomalyPoint(ruleConfig string) ([]models.AnomalyPoint, error) {
 	var lst []models.AnomalyPoint
-	var severity int
+	severity := models.SeverityLowest
 
 	var rule *models.PromRuleConfig
 	if err := json.Unmarshal([]byte(ruleConfig), &rule); err != nil {
@@ -260,6 +260,7 @@ func (arw *AlertRuleWorker) GetPromAnomalyPoint(ruleConfig string) ([]models.Ano
 	for i, query := range rule.Queries {
 		if query.Severity < severity {
 			arw.Severity = query.Severity
+			severity = query.Severity
 		}
 
 		readerClient := arw.PromClients.GetCli(arw.DatasourceId)
@@ -721,7 +722,7 @@ func combine(paramKeys []string, paraMap map[string][]string, index int, current
 
 func (arw *AlertRuleWorker) GetHostAnomalyPoint(ruleConfig string) ([]models.AnomalyPoint, error) {
 	var lst []models.AnomalyPoint
-	var severity int
+	severity := models.SeverityLowest
 
 	var rule *models.HostRuleConfig
 	if err := json.Unmarshal([]byte(ruleConfig), &rule); err != nil {
@@ -751,6 +752,7 @@ func (arw *AlertRuleWorker) GetHostAnomalyPoint(ruleConfig string) ([]models.Ano
 	for _, trigger := range rule.Triggers {
 		if trigger.Severity < severity {
 			arw.Severity = trigger.Severity
+			severity = trigger.Severity
 		}
 
 		switch trigger.Type {

--- a/alert/eval/eval.go
+++ b/alert/eval/eval.go
@@ -35,7 +35,6 @@ type AlertRuleWorker struct {
 	DatasourceId int64
 	Quit         chan struct{}
 	Inhibit      bool
-	Severity     int
 
 	Rule *models.AlertRule
 
@@ -231,7 +230,6 @@ func (arw *AlertRuleWorker) Stop() {
 
 func (arw *AlertRuleWorker) GetPromAnomalyPoint(ruleConfig string) ([]models.AnomalyPoint, error) {
 	var lst []models.AnomalyPoint
-	severity := models.SeverityLowest
 
 	var rule *models.PromRuleConfig
 	if err := json.Unmarshal([]byte(ruleConfig), &rule); err != nil {
@@ -258,11 +256,6 @@ func (arw *AlertRuleWorker) GetPromAnomalyPoint(ruleConfig string) ([]models.Ano
 
 	arw.Inhibit = rule.Inhibit
 	for i, query := range rule.Queries {
-		if query.Severity < severity {
-			arw.Severity = query.Severity
-			severity = query.Severity
-		}
-
 		readerClient := arw.PromClients.GetCli(arw.DatasourceId)
 
 		if readerClient == nil {
@@ -722,7 +715,6 @@ func combine(paramKeys []string, paraMap map[string][]string, index int, current
 
 func (arw *AlertRuleWorker) GetHostAnomalyPoint(ruleConfig string) ([]models.AnomalyPoint, error) {
 	var lst []models.AnomalyPoint
-	severity := models.SeverityLowest
 
 	var rule *models.HostRuleConfig
 	if err := json.Unmarshal([]byte(ruleConfig), &rule); err != nil {
@@ -750,11 +742,6 @@ func (arw *AlertRuleWorker) GetHostAnomalyPoint(ruleConfig string) ([]models.Ano
 	arw.Inhibit = rule.Inhibit
 	now := time.Now().Unix()
 	for _, trigger := range rule.Triggers {
-		if trigger.Severity < severity {
-			arw.Severity = trigger.Severity
-			severity = trigger.Severity
-		}
-
 		switch trigger.Type {
 		case "target_miss":
 			t := now - int64(trigger.Duration)

--- a/alert/process/process.go
+++ b/alert/process/process.go
@@ -436,8 +436,8 @@ func (p *Processor) RecoverSingle(byRecover bool, hash string, now int64, value 
 
 func (p *Processor) handleEvent(events []*models.AlertCurEvent) {
 	var fireEvents []*models.AlertCurEvent
-	// severity 初始为 4, 一定为遇到比自己优先级高的事件
-	severity := 4
+	// severity 初始为最低优先级, 一定为遇到比自己优先级高的事件
+	severity := models.SeverityLowest
 	for _, event := range events {
 		if event == nil {
 			continue

--- a/models/alert_rule.go
+++ b/models/alert_rule.go
@@ -47,6 +47,13 @@ const (
 	AlertRuleRecoverDuration0Sec = 0
 )
 
+const (
+	SeverityEmergency = 1
+	SeverityWarning   = 2
+	SeverityNotice    = 3
+	SeverityLowest    = 4
+)
+
 type AlertRule struct {
 	Id                    int64                  `json:"id" gorm:"primaryKey"`
 	GroupId               int64                  `json:"group_id"` // busi group id


### PR DESCRIPTION
# Severity 变量未正确赋值

`alert/eval/eval.go` 中的 `severity` 变量默认值为 `0`，但从定义之后一直没有变更。按照上下文的逻辑，`severity` 的初始值应该设为 `4`，即最低优先级，然后在循环中如果碰到更高的优先级，则更新 `arw.Severity` 和 `severity`。

另外我发现 `arw.Severity` 变量一直没有使用，是否可以整个删除？还是有别的用处？

```go
func (arw *AlertRuleWorker) GetPromAnomalyPoint(ruleConfig string) ([]models.AnomalyPoint, error) {
	var lst []models.AnomalyPoint
	var severity int
        // ......
	arw.Inhibit = rule.Inhibit
	for i, query := range rule.Queries {
		if query.Severity < severity {
			arw.Severity = query.Severity
		}
        // ......
        }
```

## 改动点

在 `model/alert_rule.go` 中定义 Severity 常量。

```go
const (
	SeverityEmergency = 1
	SeverityWarning   = 2
	SeverityNotice    = 3
	SeverityLowest    = 4
)
```

修改 `alert/eval/eval.go` 中 `severity` 变量的初始化和变更逻辑。

```go
func (arw *AlertRuleWorker) GetPromAnomalyPoint(ruleConfig string) ([]models.AnomalyPoint, error) {
	var lst []models.AnomalyPoint
	severity := models.SeverityLowest
        // ......
	arw.Inhibit = rule.Inhibit
	for i, query := range rule.Queries {
		if query.Severity < severity {
			arw.Severity = query.Severity
			severity = query.Severity
		}
        // ......
        }
```

顺手替换 `alert/process/process.go` 中的魔法数字。

```go
func (p *Processor) handleEvent(events []*models.AlertCurEvent) {
	var fireEvents []*models.AlertCurEvent
	// severity 初始为最低优先级, 一定为遇到比自己优先级高的事件
	severity := models.SeverityLowest
        // ......
}
```

## 更新

已删除没用的 `severity` 变量和相关逻辑，保留了 `severity` 常量的定义，用于替代魔法数字 `4`。