### PR TITLE
fix: allow valid Go template as rule name

### DIFF
--- a/models/alert_rule.go
+++ b/models/alert_rule.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"text/template"
 	"time"
 
 	"github.com/ccfos/nightingale/v6/pkg/ctx"
@@ -465,12 +466,12 @@ func (ar *AlertRule) Verify() error {
 	//	ar.DatasourceIdsJson = []int64{0}
 	//}
 
-	if str.Dangerous(ar.Name) {
-		return errors.New("Name has invalid characters")
-	}
-
+	ar.Name = strings.TrimSpace(ar.Name)
 	if ar.Name == "" {
 		return errors.New("name is blank")
+	}
+	if _, err := template.New("test").Parse(ar.Name); err != nil {
+		return errors.New("Name has invalid characters")
 	}
 
 	if ar.Prod == "" {

--- a/models/alert_rule.go
+++ b/models/alert_rule.go
@@ -480,7 +480,7 @@ func (ar *AlertRule) Verify() error {
 	for _, node := range t.Tree.Root.Nodes {
 		if tn := node.(*parse.TextNode); tn != nil {
 			if str.Dangerous(tn.String()) {
-				return errors.New("Name has invalid characters")
+				return fmt.Errorf("Name has invalid characters: %s", tn.String())
 			}
 		}
 	}

--- a/models/alert_rule.go
+++ b/models/alert_rule.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 	"text/template"
+	"text/template/parse"
 	"time"
 
 	"github.com/ccfos/nightingale/v6/pkg/ctx"
@@ -470,8 +471,18 @@ func (ar *AlertRule) Verify() error {
 	if ar.Name == "" {
 		return errors.New("name is blank")
 	}
-	if _, err := template.New("test").Parse(ar.Name); err != nil {
+
+	t, err := template.New("test").Parse(ar.Name)
+	if err != nil {
 		return errors.New("Name has invalid characters")
+	}
+
+	for _, node := range t.Tree.Root.Nodes {
+		if tn := node.(*parse.TextNode); tn != nil {
+			if str.Dangerous(tn.String()) {
+				return errors.New("Name has invalid characters")
+			}
+		}
 	}
 
 	if ar.Prod == "" {


### PR DESCRIPTION
**What type of PR is this?**
fix (IMO)

**What this PR does / why we need it**:
This PR removes the existing `str.Dangerous` validation on rule names since it will reject valid Go templates because they may contain `"`. As an alternative, we will trim and try to compile the input as a template and reject if the compilation failed.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or "Fixes (paste link of issue)"
-->
Fixes #
 
**Special notes for your reviewer**:
In a typical Elasticsearch use case, the tags and metrics are all JSON paths, which contains multiple `.` for nested access. This forbids us from accessing it via syntax like `{{$labels.host.name}}`, and we need to use `{{index $labels "host.name"}}`.