### PR TITLE
fix: prevent incorrect board matches caused by implicit type casting

### DIFF
--- a/center/router/router_board.go
+++ b/center/router/router_board.go
@@ -51,8 +51,13 @@ func (rt *Router) boardAdd(c *gin.Context) {
 
 func (rt *Router) boardGet(c *gin.Context) {
 	bid := ginx.UrlParamStr(c, "bid")
-	board, err := models.BoardGet(rt.Ctx, "id = ? or ident = ?", bid, bid)
+	board, err := models.BoardGet(rt.Ctx, "ident = ?", bid)
 	ginx.Dangerous(err)
+
+	if board == nil {
+		board, err = models.BoardGet(rt.Ctx, "id = ?", bid)
+		ginx.Dangerous(err)
+	}
 
 	if board == nil {
 		ginx.Bomb(http.StatusNotFound, "No such dashboard")


### PR DESCRIPTION
当使用 id 和 ident 混合条件查询 Board 时，如果传入的参数为字符串（如 1abc），SQL 会将字符串隐式转换成整数进行比较，导致错误地查询出不相关的数据（例如输入 1abc 会返回 id=1 的记录）。

解决方案为先查询 indent，如果为空再查询 id
