### PR TITLE
feat: username query param for /api/n9e/users

### DIFF
--- a/center/router/router_user.go
+++ b/center/router/router_user.go
@@ -47,12 +47,16 @@ func (rt *Router) userGets(c *gin.Context) {
 	query := ginx.QueryStr(c, "query", "")
 	order := ginx.QueryStr(c, "order", "username")
 	desc := ginx.QueryBool(c, "desc", false)
+	usernames := strings.Split(ginx.QueryStr(c, "usernames", ""), ",")
+	if len(usernames) == 1 && usernames[0] == "" {
+		usernames = []string{}
+	}
 
 	go rt.UserCache.UpdateUsersLastActiveTime()
 	total, err := models.UserTotal(rt.Ctx, query, stime, etime)
 	ginx.Dangerous(err)
 
-	list, err := models.UserGets(rt.Ctx, query, limit, ginx.Offset(c, limit), stime, etime, order, desc)
+	list, err := models.UserGets(rt.Ctx, query, limit, ginx.Offset(c, limit), stime, etime, order, desc, usernames...)
 	ginx.Dangerous(err)
 
 	user := c.MustGet("user").(*models.User)

--- a/models/user.go
+++ b/models/user.go
@@ -531,7 +531,7 @@ func UserTotal(ctx *ctx.Context, query string, stime, etime int64) (num int64, e
 }
 
 func UserGets(ctx *ctx.Context, query string, limit, offset int, stime, etime int64,
-	order string, desc bool) ([]User, error) {
+	order string, desc bool, usernames ...string) ([]User, error) {
 
 	session := DB(ctx)
 
@@ -546,6 +546,10 @@ func UserGets(ctx *ctx.Context, query string, limit, offset int, stime, etime in
 	}
 
 	session = session.Order(order)
+
+	if len(usernames) > 0 {
+		session = session.Where("username in (?)", usernames)
+	}
 
 	if query != "" {
 		q := "%" + query + "%"


### PR DESCRIPTION
**What type of PR is this?**

**What this PR does / why we need it**:
This PR introduces an optional `username` query parameter to the `GET /api/n9e/users` endpoint.
- If the `username` parameter is provided, the API returns only the user(s) matching the given username(s).
- Multiple usernames can be queried by providing a comma-separated string (e.g., `?username=admin,root`).

**Which issue(s) this PR fixes**:
 
**Special notes for your reviewer**: