### PR TITLE
fix:add an if condition to the old event send  function

### DIFF
--- a/alert/dispatch/dispatch.go
+++ b/alert/dispatch/dispatch.go
@@ -632,6 +632,9 @@ func (e *Dispatch) handleSub(sub *models.AlertSubscribe, event models.AlertCurEv
 }
 
 func (e *Dispatch) Send(rule *models.AlertRule, event *models.AlertCurEvent, notifyTarget *NotifyTarget, isSubscribe bool) {
+	if len(event.NotifyRuleIds) > 0 {
+		return
+	}
 	needSend := e.BeforeSenderHook(event)
 	if needSend {
 		for channel, uids := range notifyTarget.ToChannelUserMap() {


### PR DESCRIPTION
## 描述
修复 #2857 中报告的问题：when config the alert_rule with notifyrule which is send by python script, the alert event will be send twice.

## 问题原因
因为事件生成后分别会通过旧的send函数和sendV2函数发送通知，即使只配置了通知规则中通过脚本执行的通知媒介或者其他媒介，旧的通知脚本也会被执行

## 解决方案
- 优化dispatch.go中的send函数逻辑，在send函数前面加上判断逻辑，通过判断event.NotifyRuleIds的长度是否大于0判断是否需要执行旧的告警通知函数

## 测试验证
- [x] 代码修改后再次测试通过通知规则告警代码不会执行旧的通知脚本，没有脚本执行错误相关日志

## 相关issue
Fixes #2857