### PR TITLE
feat: add expired filter for alert mute rules

### DIFF
--- a/center/router/router_mute.go
+++ b/center/router/router_mute.go
@@ -20,7 +20,8 @@ func (rt *Router) alertMuteGetsByBG(c *gin.Context) {
 	bgid := ginx.UrlParamInt64(c, "id")
 	prods := strings.Fields(ginx.QueryStr(c, "prods", ""))
 	query := ginx.QueryStr(c, "query", "")
-	lst, err := models.AlertMuteGets(rt.Ctx, prods, bgid, -1, query)
+	expired := ginx.QueryInt(c, "expired", -1)
+	lst, err := models.AlertMuteGets(rt.Ctx, prods, bgid, -1, expired, query)
 
 	ginx.NewRender(c).Data(lst, err)
 }
@@ -55,7 +56,8 @@ func (rt *Router) alertMuteGets(c *gin.Context) {
 	bgid := ginx.QueryInt64(c, "bgid", -1)
 	query := ginx.QueryStr(c, "query", "")
 	disabled := ginx.QueryInt(c, "disabled", -1)
-	lst, err := models.AlertMuteGets(rt.Ctx, prods, bgid, disabled, query)
+	expired := ginx.QueryInt(c, "expired", -1)
+	lst, err := models.AlertMuteGets(rt.Ctx, prods, bgid, disabled, expired, query)
 
 	ginx.NewRender(c).Data(lst, err)
 }

--- a/models/alert_mute.go
+++ b/models/alert_mute.go
@@ -230,7 +230,7 @@ func AlertMuteGet(ctx *ctx.Context, where string, args ...interface{}) (*AlertMu
 	return lst[0], err
 }
 
-func AlertMuteGets(ctx *ctx.Context, prods []string, bgid int64, disabled int, query string) (lst []AlertMute, err error) {
+func AlertMuteGets(ctx *ctx.Context, prods []string, bgid int64, disabled int, expired int, query string) (lst []AlertMute, err error) {
 	session := DB(ctx)
 
 	if bgid != -1 {
@@ -246,6 +246,15 @@ func AlertMuteGets(ctx *ctx.Context, prods []string, bgid int64, disabled int, q
 			session = session.Where("disabled = 0")
 		} else {
 			session = session.Where("disabled = 1")
+		}
+	}
+
+	if expired != -1 {
+		now := time.Now().Unix()
+		if expired == 1 {
+			session = session.Where("mute_time_type = ? AND etime < ?", TimeRange, now)
+		} else {
+			session = session.Where("(mute_time_type = ? AND etime >= ?) OR mute_time_type = ?", TimeRange, now, Periodic)
 		}
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What this PR does / why we need it**:

To add a "whether expired" filter function to the alert suppression rule list, allowing users to filter expired or non-expired suppression rules through the `expired` parameter.

**Which issue(s) this PR fixes**:

Fixes #2901
 
**Special notes for your reviewer**:

This feature is backward compatible, and by default returns all rules when the `expired` parameter is not passed.