### PR TITLE
feat: support default notify config for alert rules (#2871)

### DIFF
--- a/alert/dispatch/dispatch.go
+++ b/alert/dispatch/dispatch.go
@@ -215,61 +215,62 @@ func (e *Dispatch) HandleEventWithNotifyRule(eventOrigin *models.AlertCurEvent) 
 				continue
 			}
 
-			sendByConfig := func(cfg *models.NotifyConfig) bool {
-				notifyChannel := e.notifyChannelCache.Get(cfg.ChannelID)
-				messageTemplate := e.messageTemplateCache.Get(cfg.TemplateID)
-				if notifyChannel == nil {
-					sender.NotifyRecord(e.ctx, []*models.AlertCurEvent{eventCopy}, notifyRuleId, fmt.Sprintf("notify_channel_id:%d", cfg.ChannelID), "", "", errors.New("notify_channel not found"))
-					logger.Warningf("notify_id: %d, event:%+v, channel_id:%d, template_id: %d, notify_channel not found", notifyRuleId, eventCopy, cfg.ChannelID, cfg.TemplateID)
-					return false
+			var defaultCfg *models.NotifyConfig
+			if len(notifyRule.NotifyConfigs) > 0 {
+				lastCfg := &notifyRule.NotifyConfigs[len(notifyRule.NotifyConfigs)-1]
+				if lastCfg.IsDefault {
+					defaultCfg = lastCfg
 				}
-
-				if notifyChannel.RequestType != "flashduty" && messageTemplate == nil {
-					logger.Warningf("notify_id: %d, channel_name: %v, event:%+v, template_id: %d, message_template not found", notifyRuleId, notifyChannel.Ident, eventCopy, cfg.TemplateID)
-					sender.NotifyRecord(e.ctx, []*models.AlertCurEvent{eventCopy}, notifyRuleId, notifyChannel.Name, "", "", errors.New("message_template not found"))
-					return false
-				}
-
-				go SendByNotifyRule(e.ctx, e.userCache, e.userGroupCache, e.notifyChannelCache, []*models.AlertCurEvent{eventCopy}, notifyRuleId, cfg, notifyChannel, messageTemplate)
-				return true
 			}
 
 			matched := false
-			defaultIndexes := make([]int, 0)
 
-			for i := range notifyRule.NotifyConfigs {
-				cfg := &notifyRule.NotifyConfigs[i]
-				if cfg.IsDefault {
-					defaultIndexes = append(defaultIndexes, i)
-					continue
-				}
+		for i := range notifyRule.NotifyConfigs {
+			cfg := &notifyRule.NotifyConfigs[i]
+			if cfg == defaultCfg {
+				continue
+			}
 
-				if err := NotifyRuleMatchCheck(cfg, eventCopy); err != nil {
-					logger.Infof("notify_id: %d, event:%+v, channel_id:%d, template_id: %d, notify_config:%+v, match skipped: %v", notifyRuleId, eventCopy, cfg.ChannelID, cfg.TemplateID, cfg, err)
-					continue
-				}
+			if err := NotifyRuleMatchCheck(cfg, eventCopy); err != nil {
+				logger.Infof("notify_id: %d, event:%+v, channel_id:%d, template_id: %d, notify_config:%+v, match skipped: %v", notifyRuleId, eventCopy, cfg.ChannelID, cfg.TemplateID, cfg, err)
+				continue
+			}
 
+			if e.notifyByConfig(eventCopy, notifyRuleId, cfg) {
 				matched = true
-				sendByConfig(cfg)
-			}
-
-			if !matched && len(defaultIndexes) > 0 {
-				for _, idx := range defaultIndexes {
-					cfg := &notifyRule.NotifyConfigs[idx]
-					if err := NotifyRuleMatchCheck(cfg, eventCopy); err != nil {
-						logger.Warningf("notify_id: %d, event:%+v, default notify_config:%+v, err:%v", notifyRuleId, eventCopy, cfg, err)
-						continue
-					}
-					matched = true
-					sendByConfig(cfg)
-				}
-			}
-
-			if !matched {
-				logger.Errorf("notify_id: %d, event:%+v, no notify_config matched", notifyRuleId, eventCopy)
 			}
 		}
+
+		if !matched && defaultCfg != nil {
+			if e.notifyByConfig(eventCopy, notifyRuleId, defaultCfg) {
+				matched = true
+			}
+		}
+
+		if !matched {
+			logger.Errorf("notify_id: %d, event:%+v, no notify_config matched", notifyRuleId, eventCopy)
+		}
+		}
 	}
+}
+
+func (e *Dispatch) notifyByConfig(event *models.AlertCurEvent, notifyRuleId int64, cfg *models.NotifyConfig) bool {
+	notifyChannel := e.notifyChannelCache.Get(cfg.ChannelID)
+	messageTemplate := e.messageTemplateCache.Get(cfg.TemplateID)
+	if notifyChannel == nil {
+		sender.NotifyRecord(e.ctx, []*models.AlertCurEvent{event}, notifyRuleId, fmt.Sprintf("notify_channel_id:%d", cfg.ChannelID), "", "", errors.New("notify_channel not found"))
+		logger.Warningf("notify_id: %d, event:%+v, channel_id:%d, template_id: %d, notify_channel not found", notifyRuleId, event, cfg.ChannelID, cfg.TemplateID)
+		return false
+	}
+
+	if notifyChannel.RequestType != "flashduty" && messageTemplate == nil {
+		logger.Warningf("notify_id: %d, channel_name: %v, event:%+v, template_id: %d, message_template not found", notifyRuleId, notifyChannel.Ident, event, cfg.TemplateID)
+		sender.NotifyRecord(e.ctx, []*models.AlertCurEvent{event}, notifyRuleId, notifyChannel.Name, "", "", errors.New("message_template not found"))
+		return false
+	}
+
+	go SendByNotifyRule(e.ctx, e.userCache, e.userGroupCache, e.notifyChannelCache, []*models.AlertCurEvent{event}, notifyRuleId, cfg, notifyChannel, messageTemplate)
+	return true
 }
 
 func shouldSkipNotify(ctx *ctx.Context, event *models.AlertCurEvent, notifyRuleId int64) bool {

--- a/models/notify_rule.go
+++ b/models/notify_rule.go
@@ -44,6 +44,7 @@ type NotifyConfig struct {
 	TemplateID int64                  `json:"template_id"` // 通知模板
 	Params     map[string]interface{} `json:"params"`      // 通知参数
 	Type       string                 `json:"type"`
+	IsDefault  bool                   `json:"is_default"` // 缺省通知配置
 
 	Severities []int        `json:"severities"`  // 适用级别(一级告警、二级告警、三级告警)
 	TimeRanges []TimeRanges `json:"time_ranges"` // 适用时段
@@ -53,7 +54,7 @@ type NotifyConfig struct {
 
 func (n *NotifyConfig) Hash() string {
 	hash := sha256.New()
-	hash.Write([]byte(fmt.Sprintf("%d%d%v%s%v%v%v%v", n.ChannelID, n.TemplateID, n.Params, n.Type, n.Severities, n.TimeRanges, n.LabelKeys, n.Attributes)))
+	hash.Write([]byte(fmt.Sprintf("%d%d%v%s%t%v%v%v%v", n.ChannelID, n.TemplateID, n.Params, n.Type, n.IsDefault, n.Severities, n.TimeRanges, n.LabelKeys, n.Attributes)))
 	return hex.EncodeToString(hash.Sum(nil))
 }
 
@@ -136,10 +137,17 @@ func (r *NotifyRule) Verify() error {
 	// 	return errors.New("notify configs cannot be empty")
 	// }
 
+	defaultCount := 0
 	for _, config := range r.NotifyConfigs {
+		if config.IsDefault {
+			defaultCount++
+		}
 		if err := config.Verify(); err != nil {
 			return err
 		}
+	}
+	if defaultCount > 1 {
+		return errors.New("only one default notify config is allowed")
 	}
 
 	return nil

--- a/models/notify_rule.go
+++ b/models/notify_rule.go
@@ -137,17 +137,21 @@ func (r *NotifyRule) Verify() error {
 	// 	return errors.New("notify configs cannot be empty")
 	// }
 
-	defaultCount := 0
-	for _, config := range r.NotifyConfigs {
+	defaultSeen := false
+	for idx := range r.NotifyConfigs {
+		config := r.NotifyConfigs[idx]
 		if config.IsDefault {
-			defaultCount++
+			if defaultSeen {
+				return errors.New("only one default notify config is allowed")
+			}
+			if idx != len(r.NotifyConfigs)-1 {
+				return errors.New("default notify config must be the last entry")
+			}
+			defaultSeen = true
 		}
 		if err := config.Verify(); err != nil {
 			return err
 		}
-	}
-	if defaultCount > 1 {
-		return errors.New("only one default notify config is allowed")
 	}
 
 	return nil


### PR DESCRIPTION
**What type of PR is this?**

feature

**What this PR does / why we need it**:

This PR implements support for default notify configurations in alert notification rules. 

currently, when an alert is triggered, if none of the notify configs match the alert's conditions (severity, time range, etc.), no notification is sent. This can lead to missed alerts in edge cases.

This PR adds an `IsDefault` field to NotifyConfig, allowing users to designate one config as a fallback. The new logic works as follows:
1. Try to match all non-default notify configs first
2. If no match is found, fall back to the default config(s)
3. Log an error if still no config matches

This ensures critical alerts are neevr silently dropped due to misconfigured matching rules.

**Which issue(s) this PR fixes**:

Fixes #2871
