### PR TITLE
feat: add MongoDB datasource support (#2754)

### DIFF
--- a/center/cconf/plugin.go
+++ b/center/cconf/plugin.go
@@ -55,4 +55,10 @@ var Plugins = []Plugin{
 		Type:     "opensearch",
 		TypeName: "OpenSearch",
 	},
+	{
+		Id:       10,
+		Category: "timeseries",
+		Type:     "mongodb",
+		TypeName: "MongoDB",
+	},
 }

--- a/datasource/datasource.go
+++ b/datasource/datasource.go
@@ -67,6 +67,13 @@ func init() {
 		PluginType:     "pgsql",
 		PluginTypeName: "PostgreSQL",
 	}
+
+	DatasourceTypes[7] = DatasourceType{
+		Id:             7,
+		Category:       "timeseries",
+		PluginType:     "mongodb",
+		PluginTypeName: "MongoDB",
+	}
 }
 
 type NewDatasrouceFn func(settings map[string]interface{}) (Datasource, error)

--- a/datasource/mongodb/mongodb.go
+++ b/datasource/mongodb/mongodb.go
@@ -1,0 +1,413 @@
+package mongodb
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/ccfos/nightingale/v6/datasource"
+	mongodsk "github.com/ccfos/nightingale/v6/dskit/mongodb"
+	"github.com/ccfos/nightingale/v6/dskit/sqlbase"
+	"github.com/ccfos/nightingale/v6/dskit/types"
+	"github.com/ccfos/nightingale/v6/models"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/toolkits/pkg/logger"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+const (
+	MongoDBType = "mongodb"
+)
+
+func init() {
+	datasource.RegisterDatasource(MongoDBType, new(MongoDB))
+}
+
+type MongoDB struct {
+	mongodsk.MongoDB `json:",inline" mapstructure:",squash"`
+}
+
+type BaseQuery struct {
+	Database   string                   `json:"database" mapstructure:"database"`
+	Collection string                   `json:"collection" mapstructure:"collection"`
+	Pipeline   []map[string]interface{} `json:"pipeline" mapstructure:"pipeline"`
+	Filter     map[string]interface{}   `json:"filter" mapstructure:"filter"`
+	Projection map[string]interface{}   `json:"projection" mapstructure:"projection"`
+	Sort       map[string]interface{}   `json:"sort" mapstructure:"sort"`
+	Limit      int64                    `json:"limit" mapstructure:"limit"`
+	Skip       int64                    `json:"skip" mapstructure:"skip"`
+	TimeField  string                   `json:"time_field" mapstructure:"time_field"`
+	From       int64                    `json:"from" mapstructure:"from"`
+	To         int64                    `json:"to" mapstructure:"to"`
+}
+
+type QueryParam struct {
+	BaseQuery `mapstructure:",squash"`
+	Ref       string          `json:"ref" mapstructure:"ref"`
+	Keys      datasource.Keys `json:"keys" mapstructure:"keys"`
+}
+
+type LogQueryParam struct {
+	BaseQuery `mapstructure:",squash"`
+	Ref       string `json:"ref" mapstructure:"ref"`
+}
+
+func (m *MongoDB) Init(settings map[string]interface{}) (datasource.Datasource, error) {
+	newest := new(MongoDB)
+	err := mapstructure.WeakDecode(settings, newest)
+	return newest, err
+}
+
+func (m *MongoDB) InitClient() error {
+	if _, err := m.NewClient(context.TODO()); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *MongoDB) Validate(ctx context.Context) error {
+	shard, err := m.firstShard()
+	if err != nil {
+		return err
+	}
+
+	if shard.URI == "" && len(shard.Hosts) == 0 {
+		return fmt.Errorf("mongodb uri is invalid, please check datasource setting")
+	}
+
+	return nil
+}
+
+func (m *MongoDB) Equal(p datasource.Datasource) bool {
+	other, ok := p.(*MongoDB)
+	if !ok {
+		logger.Errorf("unexpected plugin type, expected mongodb")
+		return false
+	}
+
+	if len(m.Shards) == 0 || len(other.Shards) == 0 {
+		return false
+	}
+
+	a := m.Shards[0]
+	b := other.Shards[0]
+
+	if a.URI != b.URI {
+		return false
+	}
+
+	if strings.Join(a.Hosts, ",") != strings.Join(b.Hosts, ",") {
+		return false
+	}
+
+	if a.User != b.User {
+		return false
+	}
+
+	if a.Password != b.Password {
+		return false
+	}
+
+	if a.AuthSource != b.AuthSource {
+		return false
+	}
+
+	if a.ReplicaSet != b.ReplicaSet {
+		return false
+	}
+
+	if a.Database != b.Database {
+		return false
+	}
+
+	if a.Timeout != b.Timeout {
+		return false
+	}
+
+	if a.MaxPoolSize != b.MaxPoolSize {
+		return false
+	}
+
+	if a.TLSEnable != b.TLSEnable {
+		return false
+	}
+
+	if a.TLSSkipVerify != b.TLSSkipVerify {
+		return false
+	}
+
+	if !reflect.DeepEqual(sortedParams(a.Params), sortedParams(b.Params)) {
+		return false
+	}
+
+	return true
+}
+
+func sortedParams(m map[string]string) map[string]string {
+	if len(m) == 0 {
+		return map[string]string{}
+	}
+
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[strings.ToLower(k)] = v
+	}
+	return out
+}
+
+func (m *MongoDB) MakeLogQuery(ctx context.Context, query interface{}, eventTags []string, start, end int64) (interface{}, error) {
+	return nil, nil
+}
+
+func (m *MongoDB) MakeTSQuery(ctx context.Context, query interface{}, eventTags []string, start, end int64) (interface{}, error) {
+	return nil, nil
+}
+
+func (m *MongoDB) QueryMapData(ctx context.Context, query interface{}) ([]map[string]string, error) {
+	return nil, nil
+}
+
+func (m *MongoDB) QueryData(ctx context.Context, query interface{}) ([]models.DataResp, error) {
+	param := new(QueryParam)
+	if err := mapstructure.WeakDecode(query, param); err != nil {
+		return nil, err
+	}
+
+	if param.Collection == "" {
+		return nil, errors.New("collection is required")
+	}
+
+	if param.Keys.ValueKey == "" {
+		return nil, errors.New("valueKey is required")
+	}
+
+	database := param.Database
+	if database == "" {
+		shard, _ := m.firstShard()
+		database = shard.Database
+	}
+
+	if database == "" {
+		return nil, errors.New("database is required")
+	}
+
+	pipeline, err := buildAggregatePipeline(&param.BaseQuery)
+	if err != nil {
+		return nil, err
+	}
+
+	items, err := m.Aggregate(ctx, database, param.Collection, pipeline)
+	if err != nil {
+		logger.Warningf("query:%+v get data err:%v", param, err)
+		return []models.DataResp{}, err
+	}
+
+	metrics := sqlbase.FormatMetricValues(types.Keys{
+		ValueKey:   param.Keys.ValueKey,
+		LabelKey:   param.Keys.LabelKey,
+		TimeKey:    param.Keys.TimeKey,
+		TimeFormat: param.Keys.TimeFormat,
+	}, items)
+
+	resp := make([]models.DataResp, 0, len(metrics))
+	for _, metric := range metrics {
+		resp = append(resp, models.DataResp{
+			Ref:    param.Ref,
+			Metric: metric.Metric,
+			Values: metric.Values,
+		})
+	}
+
+	return resp, nil
+}
+
+func (m *MongoDB) QueryLog(ctx context.Context, query interface{}) ([]interface{}, int64, error) {
+	param := new(LogQueryParam)
+	if err := mapstructure.WeakDecode(query, param); err != nil {
+		return nil, 0, err
+	}
+
+	if param.Collection == "" {
+		return nil, 0, errors.New("collection is required")
+	}
+
+	database := param.Database
+	if database == "" {
+		shard, _ := m.firstShard()
+		database = shard.Database
+	}
+
+	if database == "" {
+		return nil, 0, errors.New("database is required")
+	}
+
+	var (
+		data []map[string]interface{}
+		err  error
+	)
+
+	if len(param.Pipeline) > 0 || len(param.Filter) > 0 || len(param.Sort) > 0 || len(param.Projection) > 0 || param.Limit > 0 || param.Skip > 0 || param.TimeField != "" {
+		pipeline, buildErr := buildAggregatePipeline(&param.BaseQuery)
+		if buildErr != nil {
+			return nil, 0, buildErr
+		}
+		data, err = m.Aggregate(ctx, database, param.Collection, pipeline)
+	} else {
+		filter, opts := buildFindRequest(&param.BaseQuery)
+		data, err = m.Find(ctx, database, param.Collection, filter, opts)
+	}
+
+	if err != nil {
+		logger.Warningf("query:%+v get log err:%v", param, err)
+		return []interface{}{}, 0, err
+	}
+
+	logs := make([]interface{}, len(data))
+	for i := range data {
+		logs[i] = data[i]
+	}
+
+	return logs, int64(len(logs)), nil
+}
+
+func buildFindRequest(param *BaseQuery) (interface{}, *options.FindOptions) {
+	filter := cloneMap(param.Filter)
+	filter = mergeTimeFilter(filter, param)
+	normalized := mongodsk.NormalizeValue(filter)
+	filterMap, ok := normalized.(map[string]interface{})
+	if !ok {
+		filterMap = map[string]interface{}{}
+	}
+
+	opts := options.Find()
+	if len(param.Sort) > 0 {
+		opts.SetSort(mongodsk.NormalizeValue(param.Sort))
+	}
+	if len(param.Projection) > 0 {
+		opts.SetProjection(mongodsk.NormalizeValue(param.Projection))
+	}
+	if param.Limit > 0 {
+		opts.SetLimit(param.Limit)
+	}
+	if param.Skip > 0 {
+		opts.SetSkip(param.Skip)
+	}
+
+	return filterMap, opts
+}
+
+func buildAggregatePipeline(param *BaseQuery) (mongo.Pipeline, error) {
+	if len(param.Pipeline) > 0 {
+		return mongodsk.ConvertPipeline(param.Pipeline)
+	}
+
+	match := mergeTimeFilter(cloneMap(param.Filter), param)
+	stageMatch := map[string]interface{}{}
+	if len(match) > 0 {
+		stageMatch = match
+	}
+
+	stages := []map[string]interface{}{
+		{"$match": stageMatch},
+	}
+
+	if len(param.Sort) > 0 {
+		stages = append(stages, map[string]interface{}{"$sort": mongodsk.NormalizeValue(param.Sort)})
+	}
+
+	if param.Skip > 0 {
+		stages = append(stages, map[string]interface{}{"$skip": param.Skip})
+	}
+
+	if param.Limit > 0 {
+		stages = append(stages, map[string]interface{}{"$limit": param.Limit})
+	}
+
+	if len(param.Projection) > 0 {
+		stages = append(stages, map[string]interface{}{"$project": mongodsk.NormalizeValue(param.Projection)})
+	}
+
+	return mongodsk.ConvertPipeline(stages)
+}
+
+func mergeTimeFilter(filter map[string]interface{}, param *BaseQuery) map[string]interface{} {
+	if filter == nil {
+		filter = make(map[string]interface{})
+	}
+
+	if param.TimeField == "" {
+		return filter
+	}
+
+	rangeCond := map[string]interface{}{}
+
+	if param.From > 0 {
+		if ts, ok := toTime(param.From); ok {
+			rangeCond["$gte"] = ts
+		} else {
+			rangeCond["$gte"] = param.From
+		}
+	}
+
+	if param.To > 0 {
+		if ts, ok := toTime(param.To); ok {
+			rangeCond["$lte"] = ts
+		} else {
+			rangeCond["$lte"] = param.To
+		}
+	}
+
+	if len(rangeCond) == 0 {
+		return filter
+	}
+
+	if existing, ok := filter[param.TimeField]; ok {
+		if existingMap, ok := existing.(map[string]interface{}); ok {
+			for k, v := range rangeCond {
+				existingMap[k] = v
+			}
+			filter[param.TimeField] = existingMap
+			return filter
+		}
+	}
+
+	filter[param.TimeField] = rangeCond
+	return filter
+}
+
+func toTime(ts int64) (time.Time, bool) {
+	if ts <= 0 {
+		return time.Time{}, false
+	}
+
+	if ts > 1e12 {
+		return time.UnixMilli(ts), true
+	}
+
+	return time.Unix(ts, 0), true
+}
+
+func (m *MongoDB) firstShard() (*mongodsk.Shard, error) {
+	if len(m.Shards) == 0 {
+		return nil, errors.New("empty mongodb shards")
+	}
+
+	return &m.Shards[0], nil
+}
+
+func cloneMap(m map[string]interface{}) map[string]interface{} {
+	if len(m) == 0 {
+		return make(map[string]interface{})
+	}
+
+	cp := make(map[string]interface{}, len(m))
+	for k, v := range m {
+		cp[k] = v
+	}
+	return cp
+}

--- a/dscache/sync.go
+++ b/dscache/sync.go
@@ -10,6 +10,7 @@ import (
 	_ "github.com/ccfos/nightingale/v6/datasource/ck"
 	_ "github.com/ccfos/nightingale/v6/datasource/doris"
 	"github.com/ccfos/nightingale/v6/datasource/es"
+	_ "github.com/ccfos/nightingale/v6/datasource/mongodb"
 	_ "github.com/ccfos/nightingale/v6/datasource/mysql"
 	_ "github.com/ccfos/nightingale/v6/datasource/opensearch"
 	_ "github.com/ccfos/nightingale/v6/datasource/postgresql"

--- a/dskit/mongodb/mongodb.go
+++ b/dskit/mongodb/mongodb.go
@@ -1,0 +1,276 @@
+package mongodb
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/ccfos/nightingale/v6/dskit/pool"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/mongo/readpref"
+)
+
+type MongoDB struct {
+	Shards []Shard `json:"mongodb.shards" mapstructure:"mongodb.shards"`
+}
+
+type Shard struct {
+	URI           string            `json:"mongodb.uri" mapstructure:"mongodb.uri"`
+	Hosts         []string          `json:"mongodb.hosts" mapstructure:"mongodb.hosts"`
+	User          string            `json:"mongodb.user" mapstructure:"mongodb.user"`
+	Password      string            `json:"mongodb.password" mapstructure:"mongodb.password"`
+	AuthSource    string            `json:"mongodb.auth_source" mapstructure:"mongodb.auth_source"`
+	ReplicaSet    string            `json:"mongodb.replica_set" mapstructure:"mongodb.replica_set"`
+	Database      string            `json:"mongodb.database" mapstructure:"mongodb.database"`
+	Timeout       int               `json:"mongodb.timeout" mapstructure:"mongodb.timeout"` // seconds
+	MaxPoolSize   uint64            `json:"mongodb.max_pool_size" mapstructure:"mongodb.max_pool_size"`
+	TLSEnable     bool              `json:"mongodb.tls_enable" mapstructure:"mongodb.tls_enable"`
+	TLSSkipVerify bool              `json:"mongodb.tls_skip_verify" mapstructure:"mongodb.tls_skip_verify"`
+	Params        map[string]string `json:"mongodb.params" mapstructure:"mongodb.params"`
+}
+
+func (m *MongoDB) firstShard() (*Shard, error) {
+	if len(m.Shards) == 0 {
+		return nil, errors.New("empty mongodb shards")
+	}
+
+	return &m.Shards[0], nil
+}
+
+func (m *MongoDB) NewClient(ctx context.Context) (*mongo.Client, error) {
+	shard, err := m.firstShard()
+	if err != nil {
+		return nil, err
+	}
+
+	uri := shard.URI
+	if uri == "" {
+		if len(shard.Hosts) == 0 {
+			return nil, errors.New("empty mongodb uri or hosts")
+		}
+
+		uri = "mongodb://" + strings.Join(shard.Hosts, ",")
+	}
+
+	clientKey := []string{uri, shard.User, shard.Password, shard.AuthSource, shard.ReplicaSet}
+	cachedKey := strings.Join(clientKey, "|")
+	if cli, ok := pool.PoolClient.Load(cachedKey); ok {
+		return cli.(*mongo.Client), nil
+	}
+
+	clientOpts := options.Client().ApplyURI(uri)
+
+	if shard.User != "" {
+		clientOpts.Auth = &options.Credential{
+			Username:   shard.User,
+			Password:   shard.Password,
+			AuthSource: shard.AuthSource,
+		}
+	}
+
+	if shard.ReplicaSet != "" {
+		clientOpts.SetReplicaSet(shard.ReplicaSet)
+	}
+
+	if shard.MaxPoolSize > 0 {
+		clientOpts.SetMaxPoolSize(shard.MaxPoolSize)
+	}
+
+	if shard.TLSEnable {
+		clientOpts.SetTLSConfig(&tls.Config{
+			InsecureSkipVerify: shard.TLSSkipVerify,
+		})
+	}
+
+	for k, v := range shard.Params {
+		switch strings.ToLower(k) {
+		case "appname":
+			clientOpts.SetAppName(v)
+		case "direct":
+			if strings.EqualFold(v, "true") {
+				clientOpts.SetDirect(true)
+			}
+		}
+	}
+
+	timeout := shard.Timeout
+	if timeout <= 0 {
+		timeout = 60
+	}
+
+	timeoutCtx, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
+	defer cancel()
+
+	client, err := mongo.Connect(timeoutCtx, clientOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := client.Ping(timeoutCtx, readpref.Primary()); err != nil {
+		return nil, err
+	}
+
+	pool.PoolClient.Store(cachedKey, client)
+	return client, nil
+}
+
+func (m *MongoDB) Aggregate(ctx context.Context, database, collection string, pipeline mongo.Pipeline) ([]map[string]interface{}, error) {
+	shard, err := m.firstShard()
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := m.NewClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if database == "" {
+		database = shard.Database
+	}
+
+	if database == "" {
+		return nil, errors.New("empty mongodb database")
+	}
+
+	if collection == "" {
+		return nil, errors.New("empty mongodb collection")
+	}
+
+	timeout := shard.Timeout
+	if timeout <= 0 {
+		timeout = 60
+	}
+
+	timeoutCtx, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
+	defer cancel()
+
+	cursor, err := client.Database(database).Collection(collection).Aggregate(timeoutCtx, pipeline)
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(timeoutCtx)
+
+	var rows []map[string]interface{}
+	if err := cursor.All(timeoutCtx, &rows); err != nil {
+		return nil, err
+	}
+
+	return normalizeDocuments(rows), nil
+}
+
+func (m *MongoDB) Find(ctx context.Context, database, collection string, filter interface{}, opts *options.FindOptions) ([]map[string]interface{}, error) {
+	shard, err := m.firstShard()
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := m.NewClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if database == "" {
+		database = shard.Database
+	}
+
+	if database == "" {
+		return nil, errors.New("empty mongodb database")
+	}
+
+	if collection == "" {
+		return nil, errors.New("empty mongodb collection")
+	}
+
+	timeout := shard.Timeout
+	if timeout <= 0 {
+		timeout = 60
+	}
+
+	timeoutCtx, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
+	defer cancel()
+
+	cursor, err := client.Database(database).Collection(collection).Find(timeoutCtx, filter, opts)
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(timeoutCtx)
+
+	var rows []map[string]interface{}
+	if err := cursor.All(timeoutCtx, &rows); err != nil {
+		return nil, err
+	}
+
+	return normalizeDocuments(rows), nil
+}
+
+func normalizeDocuments(items []map[string]interface{}) []map[string]interface{} {
+	out := make([]map[string]interface{}, len(items))
+	for i := range items {
+		out[i] = NormalizeValue(items[i]).(map[string]interface{})
+	}
+	return out
+}
+
+func NormalizeValue(v interface{}) interface{} {
+	switch val := v.(type) {
+	case map[string]interface{}:
+		res := make(map[string]interface{}, len(val))
+		for k, inner := range val {
+			res[k] = NormalizeValue(inner)
+		}
+		return res
+	case []interface{}:
+		res := make([]interface{}, len(val))
+		for i := range val {
+			res[i] = NormalizeValue(val[i])
+		}
+		return res
+	case float64:
+		if math.Mod(val, 1) == 0 {
+			if val <= math.MaxInt32 && val >= math.MinInt32 {
+				return int32(val)
+			}
+			if val <= math.MaxInt64 && val >= math.MinInt64 {
+				return int64(val)
+			}
+		}
+		return val
+	default:
+		return val
+	}
+}
+
+func ConvertPipeline(stages []map[string]interface{}) (mongo.Pipeline, error) {
+	pipeline := make(mongo.Pipeline, 0, len(stages))
+	for _, stage := range stages {
+		normalized := NormalizeValue(stage)
+		doc, ok := normalized.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("invalid pipeline stage: %v", stage)
+		}
+
+		stageDoc := bson.D{}
+		keys := make([]string, 0, len(doc))
+		for k := range doc {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+
+		for _, k := range keys {
+			stageDoc = append(stageDoc, bson.E{Key: k, Value: doc[k]})
+		}
+
+		pipeline = append(pipeline, stageDoc)
+	}
+
+	return pipeline, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/tidwall/gjson v1.14.2
 	github.com/toolkits/pkg v1.3.8
+	go.mongodb.org/mongo-driver v1.15.0
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
 	golang.org/x/oauth2 v0.27.0
 	gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df
@@ -91,11 +92,16 @@ require (
 	github.com/jcmturner/gofork v1.7.6 // indirect
 	github.com/jcmturner/gokrb5/v8 v8.4.4 // indirect
 	github.com/jcmturner/rpc/v2 v2.0.3 // indirect
+	github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rogpeppe/go-internal v1.13.1 // indirect
 	github.com/valyala/fastrand v1.1.0 // indirect
 	github.com/valyala/histogram v1.2.0 // indirect
+	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
+	github.com/xdg-go/scram v1.1.2 // indirect
+	github.com/xdg-go/stringprep v1.0.4 // indirect
+	github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d // indirect
 	github.com/yuin/gopher-lua v1.1.1 // indirect
 	golang.org/x/sync v0.10.0 // indirect
 	modernc.org/libc v1.22.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -254,6 +254,7 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/mojocn/base64Captcha v1.3.6 h1:gZEKu1nsKpttuIAQgWHO+4Mhhls8cAKyiV2Ew03H+Tw=
 github.com/mojocn/base64Captcha v1.3.6/go.mod h1:i5CtHvm+oMbj1UzEPXaA8IH/xHFZ3DGY3Wh3dBpZ28E=
+github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe h1:iruDEfMl2E6fbMZ9s0scYfZQ84/6SPL6zC8ACM2oIL0=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
@@ -357,9 +358,15 @@ github.com/valyala/fastrand v1.1.0 h1:f+5HkLW4rsgzdNoleUOB69hyT9IlD2ZQh9GyDMfb5G
 github.com/valyala/fastrand v1.1.0/go.mod h1:HWqCzkrkg6QXT8V2EXWvXCoow7vLwOFN002oeRzjapQ=
 github.com/valyala/histogram v1.2.0 h1:wyYGAZZt3CpwUiIb9AU/Zbllg1llXyrtApRS815OLoQ=
 github.com/valyala/histogram v1.2.0/go.mod h1:Hb4kBwb4UxsaNbbbh+RRz8ZR6pdodR57tzWUS3BUzXY=
+github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.1.1/go.mod h1:RaEWvsqvNKKvBPvcKeFjrG2cJqOkHTiyTpzz23ni57g=
+github.com/xdg-go/scram v1.1.2 h1:FHX5I5B4i4hKRVRBCFRxq1iQRej7WO3hhBuJf+UUySY=
+github.com/xdg-go/scram v1.1.2/go.mod h1:RT/sEzTbU5y00aCK8UOx6R7YryM0iF1N2MOmC3kKLN4=
 github.com/xdg-go/stringprep v1.0.3/go.mod h1:W3f5j4i+9rC0kuIEJL0ky1VpHXQU3ocBgklLGvcBnW8=
+github.com/xdg-go/stringprep v1.0.4 h1:XLI/Ng3O1Atzq0oBs3TWm+5ZVgkq2aqdlvP9JtoZ6c8=
+github.com/xdg-go/stringprep v1.0.4/go.mod h1:mPGuuIYwz7CmR2bT9j4GbQqutWS1zV24gijq1dTyGkM=
+github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d h1:splanxYIlg+5LfHAM6xpdFEAYOk8iySO56hMFq6uLyA=
 github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d/go.mod h1:rHwXgn7JulP+udvsHwJoVG1YGAP6VLg4y9I5dyZdqmA=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -367,6 +374,8 @@ github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5t
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
 github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 go.mongodb.org/mongo-driver v1.11.4/go.mod h1:PTSz5yu21bkT/wXpkS7WR5f0ddqw5quethTUn9WM+2g=
+go.mongodb.org/mongo-driver v1.15.0 h1:rJCKC8eEliewXjZGf0ddURtl7tTVy1TK3bfl0gkUSLc=
+go.mongodb.org/mongo-driver v1.15.0/go.mod h1:Vzb0Mk/pa7e6cWw85R4F/endUC3u0U9jGcNU603k65c=
 go.opentelemetry.io/otel v1.32.0 h1:WnBN+Xjcteh0zdk01SVqV55d/m62NJLJdIyb4y/WO5U=
 go.opentelemetry.io/otel v1.32.0/go.mod h1:00DCVSB0RQcnzlwyTfqtxSm+DRr9hpYrHjNGiBHVQIg=
 go.opentelemetry.io/otel/trace v1.32.0 h1:WIC9mYrXf8TmY/EXuULKc8hR17vE+Hjv2cssQDe03fM=

--- a/models/alert_rule.go
+++ b/models/alert_rule.go
@@ -32,6 +32,7 @@ const (
 	POSTGRESQL    = "pgsql"
 	DORIS         = "doris"
 	OPENSEARCH    = "opensearch"
+	MONGODB       = "mongodb"
 
 	CLICKHOUSE = "ck"
 )


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What this PR does / why we need it**:

This PR adds MongoDB as a new datasource type to Nightingale, enabling users to query and monitor data from MongoDB databases.

**Which issue(s) this PR fixes**:

Fixes #2754
 
**Special notes for your reviewer**:

- the MongoDB datasource follows the same pattern as other datasources (MySQL, PostgreSQL, ClickHouse, etc.)
- connection pooling is implemented using the existing `pool.PoolClient` pattern
- all MongoDB-specific settings are prefixed with `mongodb.` for clarity;
- time range filters are automatically merged with user-provided filters when a time field is specified