### PR TITLE
fix(notify): http callback retry interval in millisecond

### DIFF
--- a/models/notify_channel.go
+++ b/models/notify_channel.go
@@ -545,7 +545,7 @@ func (ncc *NotifyChannelConfig) SendHTTP(events []*AlertCurEvent, tpl map[string
 		if err != nil {
 			logger.Errorf("send_http: failed to send http notify. url=%s request_body=%s error=%v", url, string(body), err)
 			lastErrorMessage = err.Error()
-			time.Sleep(time.Duration(httpConfig.RetryInterval) * time.Second)
+			time.Sleep(time.Duration(httpConfig.RetryInterval) * time.Millisecond)
 			continue
 		}
 		defer resp.Body.Close()


### PR DESCRIPTION
**What type of PR is this?**
Bug fix
**What this PR does / why we need it**:
Fix wrong timeunit in http callback retry interval.
It should be in ms. (at least that's what it shows on frontend)

**Which issue(s) this PR fixes**:
None
 
**Special notes for your reviewer**:
None