### PR TITLE
fix: skip processing pagerduty_integration_ids in GetNotifyConfigParams

### DIFF
--- a/alert/dispatch/dispatch.go
+++ b/alert/dispatch/dispatch.go
@@ -437,7 +437,11 @@ func GetNotifyConfigParams(notifyConfig *models.NotifyConfig, contactKey string,
 					}
 				}
 			}
-		case "pagerduty_integration_keys":
+		case "pagerduty_integration_keys", "pagerduty_integration_ids":
+			if key == "pagerduty_integration_ids" {
+				// 不处理ids，直接跳过，这个字段只给前端标记用
+				continue
+			}
 			if data, err := json.Marshal(value); err == nil {
 				var keys []string
 				if json.Unmarshal(data, &keys) == nil {


### PR DESCRIPTION
修复：pagerduty_integration_ids: []string没有在上面的case被处理，导致它走到了switch的default分支，然后类型断言失败导致的，会导致程序panic退出