### PR TITLE
[fix](getTimeRange) when query param `hours` set not zero，etime is now unix timestamp.

### DIFF
--- a/center/router/router_alert_his_event.go
+++ b/center/router/router_alert_his_event.go
@@ -22,11 +22,11 @@ func getTimeRange(c *gin.Context) (stime, etime int64) {
 	now := time.Now().Unix()
 	if hours != 0 {
 		stime = now - 3600*hours
-		etime = now + 3600*24
+		etime = now
 	}
 
 	if stime != 0 && etime == 0 {
-		etime = now + 3600*24
+		etime = now
 	}
 	return
 }


### PR DESCRIPTION

**What type of PR is this?**

**What this PR does / why we need it**:
<!--
"Nice to have" "You need it" is not a good reason. :)
-->

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or "Fixes (paste link of issue)"
-->
Fixes #
 
**Special notes for your reviewer**: