### PR TITLE
fix(llm): normalize DeepSeek root domain URL to /v1/chat/completions

### DIFF
--- a/aiagent/llm/openai.go
+++ b/aiagent/llm/openai.go
@@ -28,7 +28,7 @@ func NewOpenAI(cfg *Config, client *http.Client) (*OpenAI, error) {
 	if cfg.BaseURL == "" {
 		cfg.BaseURL = DefaultOpenAIURL
 	} else {
-		cfg.BaseURL = normalizeOpenAIURL(cfg.BaseURL)
+		cfg.BaseURL = NormalizeOpenAIURL(cfg.BaseURL)
 	}
 	return &OpenAI{
 		config: cfg,
@@ -36,16 +36,22 @@ func NewOpenAI(cfg *Config, client *http.Client) (*OpenAI, error) {
 	}, nil
 }
 
-// normalizeOpenAIURL 归一化 OpenAI 兼容端点：
+// NormalizeOpenAIURL 归一化 OpenAI 兼容端点：
 // 用户常见填法包括 `https://host/v1` 或 `https://host/compatible-mode/v1`，
 // 这里自动补 `/chat/completions`，避免漏路径时返回 404。
-func normalizeOpenAIURL(rawURL string) string {
+// 对于已知需要 /v1/chat/completions 路径的提供商（如 DeepSeek），
+// 当用户只填写了根域名时自动补全完整路径。
+func NormalizeOpenAIURL(rawURL string) string {
 	u := strings.TrimRight(rawURL, "/")
 	if strings.HasSuffix(u, "/chat/completions") {
 		return u
 	}
 	if strings.HasSuffix(u, "/v1") {
 		return u + "/chat/completions"
+	}
+	// DeepSeek 使用标准 OpenAI 兼容路径，用户填写根域名时自动补全
+	if u == "https://api.deepseek.com" || u == "http://api.deepseek.com" {
+		return u + "/v1/chat/completions"
 	}
 	return u
 }

--- a/aiagent/llmconfig/probe.go
+++ b/aiagent/llmconfig/probe.go
@@ -47,12 +47,7 @@ func Test(p *models.AILLMConfig) error {
 
 	switch p.APIType {
 	case "openai", "ollama":
-		base := strings.TrimRight(p.APIURL, "/")
-		if strings.HasSuffix(base, "/chat/completions") {
-			reqURL = base
-		} else {
-			reqURL = base + "/chat/completions"
-		}
+		reqURL = llm.NormalizeOpenAIURL(p.APIURL)
 		reqBody, _ = json.Marshal(map[string]interface{}{
 			"model":      p.Model,
 			"messages":   []map[string]string{{"role": "user", "content": "Hi"}},


### PR DESCRIPTION
When users configure the DeepSeek API URL as https://api.deepseek.com (the root domain shown on DeepSeek's website), requests fail with HTTP 404 because the path /v1/chat/completions is missing.

- Export normalizeOpenAIURL as NormalizeOpenAIURL so it can be reused
- Add DeepSeek domain special-case: https://api.deepseek.com is automatically normalized to https://api.deepseek.com/v1/chat/completions
- Refactor probe.go openai/ollama URL building to reuse NormalizeOpenAIURL, keeping test-connection behavior consistent with the actual request path

**What type of PR is this?**

**What this PR does / why we need it**:
<!--
"Nice to have" "You need it" is not a good reason. :)
-->

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or "Fixes (paste link of issue)"
-->
Fixes #
 
**Special notes for your reviewer**: