### PR TITLE
fix: resolve format string injection vulnerabilities and unify i18n translation layer

### DIFF
--- a/aiagent/llmconfig/probe.go
+++ b/aiagent/llmconfig/probe.go
@@ -4,13 +4,9 @@
 package llmconfig
 
 import (
-	"bytes"
-	"crypto/tls"
-	"encoding/json"
+	"context"
 	"fmt"
-	"io"
-	"net/http"
-	"net/url"
+	"regexp"
 	"strings"
 	"time"
 
@@ -18,108 +14,185 @@ import (
 	"github.com/ccfos/nightingale/v6/models"
 )
 
-// Test 向目标 LLM 提供方发送一次最小探针请求，用于验证连通性与凭证是否可用。
-// 出错时返回具体错误信息（例如 HTTP 状态码 + 截断后的响应体），成功则返回 nil。
-func Test(p *models.AILLMConfig) error {
-	extra := p.ExtraConfig
+type ProbeErrorKind string
 
-	// Build HTTP client with ExtraConfig settings
+const (
+	ProbeErrorAuth               ProbeErrorKind = "auth"
+	ProbeErrorEndpointNotFound   ProbeErrorKind = "endpoint_not_found"
+	ProbeErrorRateLimited        ProbeErrorKind = "rate_limited"
+	ProbeErrorRequestFailed      ProbeErrorKind = "request_failed"
+	ProbeErrorUnexpectedResponse ProbeErrorKind = "unexpected_response"
+	ProbeErrorModel              ProbeErrorKind = "model"
+	ProbeErrorNoContent          ProbeErrorKind = "no_content"
+)
+
+// ProbeError is the structured domain error returned by LLM connectivity tests.
+// It keeps provider and transport details separate from any i18n presentation logic.
+type ProbeError struct {
+	Kind       ProbeErrorKind
+	StatusCode int
+	APIURL     string
+	Model      string
+	Detail     string
+	Cause      error
+}
+
+func (e *ProbeError) Error() string {
+	parts := []string{"llm probe failed", "kind=" + string(e.Kind)}
+	if e.StatusCode > 0 {
+		parts = append(parts, fmt.Sprintf("status=%d", e.StatusCode))
+	}
+	if e.Model != "" {
+		parts = append(parts, "model="+e.Model)
+	}
+	if e.Detail != "" {
+		parts = append(parts, "detail="+e.Detail)
+	}
+	if e.Cause != nil {
+		parts = append(parts, "cause="+e.Cause.Error())
+	}
+	return strings.Join(parts, ", ")
+}
+
+func (e *ProbeError) Unwrap() error {
+	return e.Cause
+}
+
+// Test sends a real chat request to the target LLM provider to verify connectivity,
+// credentials, and model availability. Returns a ProbeError for classified failures.
+func Test(p *models.AILLMConfig) error {
+	client, err := llm.New(buildLLMConfig(p))
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), probeTimeout(p.ExtraConfig))
+	defer cancel()
+
+	maxTokens := 5
+	resp, err := client.Generate(ctx, &llm.GenerateRequest{
+		Messages:  []llm.Message{{Role: llm.RoleUser, Content: "Hi"}},
+		MaxTokens: &maxTokens,
+	})
+	if err != nil {
+		return classifyProbeError(p, err)
+	}
+	if resp == nil || strings.TrimSpace(resp.Content) == "" {
+		return &ProbeError{Kind: ProbeErrorNoContent, Model: p.Model}
+	}
+	return nil
+}
+
+var providerStatusErrPattern = regexp.MustCompile(`(?i)^(?:[a-z0-9_ -]+) API error \(status (\d+)\):\s*(.*)$`)
+
+func buildLLMConfig(p *models.AILLMConfig) *llm.Config {
+	return &llm.Config{
+		Provider:      p.APIType,
+		BaseURL:       p.APIURL,
+		APIKey:        p.APIKey,
+		Model:         p.Model,
+		Headers:       cloneStringMap(p.ExtraConfig.CustomHeaders),
+		Timeout:       int(probeTimeout(p.ExtraConfig) / time.Millisecond),
+		SkipSSLVerify: p.ExtraConfig.SkipTLSVerify,
+		Proxy:         p.ExtraConfig.Proxy,
+		Temperature:   p.ExtraConfig.Temperature,
+		MaxTokens:     p.ExtraConfig.MaxTokens,
+		ExtraBody:     p.ExtraConfig.CustomParams,
+	}
+}
+
+func probeTimeout(extra models.LLMExtraConfig) time.Duration {
 	timeout := 30 * time.Second
 	if extra.TimeoutSeconds > 0 {
 		timeout = time.Duration(extra.TimeoutSeconds) * time.Second
 	}
+	return timeout
+}
 
-	transport := &http.Transport{}
-	if extra.SkipTLSVerify {
-		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-	}
-	if extra.Proxy != "" {
-		if proxyURL, err := url.Parse(extra.Proxy); err == nil {
-			transport.Proxy = http.ProxyURL(proxyURL)
-		}
+func classifyProbeError(p *models.AILLMConfig, err error) error {
+	msg := err.Error()
+	if statusCode, raw, ok := parseProviderStatusError(msg); ok {
+		return formatHTTPError(statusCode, p.APIURL, raw)
 	}
 
-	client := &http.Client{Timeout: timeout, Transport: transport}
+	if strings.Contains(msg, "failed to parse response") {
+		return &ProbeError{
+			Kind:   ProbeErrorUnexpectedResponse,
+			APIURL: p.APIURL,
+			Detail: truncate(msg, 200),
+			Cause:  err,
+		}
+	}
 
-	var reqURL string
-	var reqBody []byte
-	hdrs := map[string]string{"Content-Type": "application/json"}
+	if strings.Contains(msg, "no response from OpenAI") {
+		return &ProbeError{Kind: ProbeErrorNoContent, Model: p.Model, Cause: err}
+	}
 
-	switch p.APIType {
-	case "openai", "ollama":
-		reqURL = llm.NormalizeOpenAIURL(p.APIURL)
-		reqBody, _ = json.Marshal(map[string]interface{}{
-			"model":      p.Model,
-			"messages":   []map[string]string{{"role": "user", "content": "Hi"}},
-			"max_tokens": 5,
-		})
-		if p.APIKey != "" {
-			hdrs["Authorization"] = "Bearer " + p.APIKey
+	if providerMsg, ok := extractProviderMessage(msg); ok {
+		return &ProbeError{
+			Kind:   ProbeErrorModel,
+			Model:  p.Model,
+			Detail: providerMsg,
+			Cause:  err,
 		}
-	case "kimi":
-		// Kimi Code uses Anthropic Claude-compatible Messages API
-		base := strings.TrimRight(p.APIURL, "/")
-		if strings.HasSuffix(base, "/v1/messages") {
-			reqURL = base
-		} else if strings.HasSuffix(base, "/v1") {
-			reqURL = base + "/messages"
-		} else {
-			reqURL = base + "/v1/messages"
+	}
+
+	return err
+}
+
+func parseProviderStatusError(msg string) (int, string, bool) {
+	matches := providerStatusErrPattern.FindStringSubmatch(msg)
+	if len(matches) != 3 {
+		return 0, "", false
+	}
+	var statusCode int
+	if _, err := fmt.Sscanf(matches[1], "%d", &statusCode); err != nil {
+		return 0, "", false
+	}
+	return statusCode, matches[2], true
+}
+
+func extractProviderMessage(msg string) (string, bool) {
+	for _, prefix := range []string{"OpenAI API error: ", "Claude API error: ", "Gemini API error: "} {
+		if strings.HasPrefix(msg, prefix) {
+			providerMsg := strings.TrimSpace(strings.TrimPrefix(msg, prefix))
+			if providerMsg != "" {
+				return providerMsg, true
+			}
 		}
-		reqBody, _ = json.Marshal(map[string]interface{}{
-			"model":      p.Model,
-			"messages":   []map[string]interface{}{{"role": "user", "content": []map[string]string{{"type": "text", "text": "Hi"}}}},
-			"max_tokens": 5,
-		})
-		hdrs["x-api-key"] = p.APIKey
-		hdrs["anthropic-version"] = "2023-06-01"
-	case "claude":
-		reqURL = llm.NormalizeClaudeURL(p.APIURL)
-		reqBody, _ = json.Marshal(map[string]interface{}{
-			"model":      p.Model,
-			"messages":   []map[string]string{{"role": "user", "content": "Hi"}},
-			"max_tokens": 5,
-		})
-		hdrs["x-api-key"] = p.APIKey
-		hdrs["anthropic-version"] = "2023-06-01"
-	case "gemini":
-		base := llm.NormalizeGeminiBase(p.APIURL)
-		if strings.Contains(base, ":generateContent") || strings.Contains(base, ":streamGenerateContent") {
-			reqURL = base + "?key=" + p.APIKey
-		} else {
-			reqURL = base + "/" + p.Model + ":generateContent?key=" + p.APIKey
-		}
-		reqBody, _ = json.Marshal(map[string]interface{}{
-			"contents": []map[string]interface{}{
-				{"parts": []map[string]string{{"text": "Hi"}}},
-			},
-		})
+	}
+	return "", false
+}
+
+// formatHTTPError converts an HTTP error status into a structured ProbeError.
+func formatHTTPError(statusCode int, apiURL, raw string) *ProbeError {
+	raw = truncate(raw, 300)
+	switch statusCode {
+	case 401, 403:
+		return &ProbeError{Kind: ProbeErrorAuth, StatusCode: statusCode, APIURL: apiURL, Detail: raw}
+	case 404:
+		return &ProbeError{Kind: ProbeErrorEndpointNotFound, StatusCode: statusCode, APIURL: apiURL, Detail: raw}
+	case 429:
+		return &ProbeError{Kind: ProbeErrorRateLimited, StatusCode: statusCode, APIURL: apiURL, Detail: raw}
 	default:
-		return fmt.Errorf("unsupported api_type: %s", p.APIType)
+		return &ProbeError{Kind: ProbeErrorRequestFailed, StatusCode: statusCode, APIURL: apiURL, Detail: raw}
 	}
+}
 
-	req, err := http.NewRequest("POST", reqURL, bytes.NewReader(reqBody))
-	if err != nil {
-		return err
+func truncate(s string, n int) string {
+	if len([]rune(s)) <= n {
+		return s
 	}
-	for k, v := range hdrs {
-		req.Header.Set(k, v)
-	}
-	// Apply custom headers from ExtraConfig
-	llm.ApplyCustomHeaders(req, extra.CustomHeaders)
+	return string([]rune(s)[:n])
+}
 
-	resp, err := client.Do(req)
-	if err != nil {
-		return err
+func cloneStringMap(src map[string]string) map[string]string {
+	if len(src) == 0 {
+		return nil
 	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode >= 400 {
-		body, _ := io.ReadAll(resp.Body)
-		if len(body) > 500 {
-			body = body[:500]
-		}
-		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
+	dst := make(map[string]string, len(src))
+	for k, v := range src {
+		dst[k] = v
 	}
-	return nil
+	return dst
 }

--- a/aiagent/llmconfig/probe_test.go
+++ b/aiagent/llmconfig/probe_test.go
@@ -1,0 +1,67 @@
+package llmconfig
+
+import (
+	"testing"
+
+	"github.com/ccfos/nightingale/v6/models"
+)
+
+func TestParseProviderStatusError(t *testing.T) {
+	statusCode, raw, ok := parseProviderStatusError("OpenAI API error (status 404): not found")
+	if !ok {
+		t.Fatal("expected status error to be parsed")
+	}
+	if statusCode != 404 {
+		t.Fatalf("unexpected status code: %d", statusCode)
+	}
+	if raw != "not found" {
+		t.Fatalf("unexpected raw body: %q", raw)
+	}
+}
+
+func TestClassifyProbeErrorHTTPStatus(t *testing.T) {
+	err := classifyProbeError(&models.AILLMConfig{APIURL: "https://api.openai.com", Model: "gpt-4o"},
+		assertErr("OpenAI API error (status 404): endpoint missing"))
+
+	probeErr, ok := err.(*ProbeError)
+	if !ok {
+		t.Fatalf("expected ProbeError, got %T", err)
+	}
+	if probeErr.Kind != ProbeErrorEndpointNotFound {
+		t.Fatalf("unexpected kind: %q", probeErr.Kind)
+	}
+	if probeErr.APIURL != "https://api.openai.com" || probeErr.Detail != "endpoint missing" || probeErr.StatusCode != 404 {
+		t.Fatalf("unexpected probe error: %#v", probeErr)
+	}
+}
+
+func TestClassifyProbeErrorProviderMessage(t *testing.T) {
+	err := classifyProbeError(&models.AILLMConfig{Model: "bad-model"}, assertErr("Claude API error: model not found"))
+
+	probeErr, ok := err.(*ProbeError)
+	if !ok {
+		t.Fatalf("expected ProbeError, got %T", err)
+	}
+	if probeErr.Kind != ProbeErrorModel {
+		t.Fatalf("unexpected kind: %q", probeErr.Kind)
+	}
+	if probeErr.Model != "bad-model" || probeErr.Detail != "model not found" {
+		t.Fatalf("unexpected probe error: %#v", probeErr)
+	}
+}
+
+func TestFormatHTTPErrorAuth(t *testing.T) {
+	err := formatHTTPError(401, "https://api.openai.com", "unauthorized")
+	if err.Kind != ProbeErrorAuth {
+		t.Fatalf("unexpected kind: %q", err.Kind)
+	}
+	if err.StatusCode != 401 || err.Detail != "unauthorized" {
+		t.Fatalf("unexpected probe error: %#v", err)
+	}
+}
+
+type assertErr string
+
+func (e assertErr) Error() string {
+	return string(e)
+}

--- a/alert/router/router_event.go
+++ b/alert/router/router_event.go
@@ -12,8 +12,8 @@ import (
 	"github.com/ccfos/nightingale/v6/alert/process"
 	"github.com/ccfos/nightingale/v6/alert/queue"
 	"github.com/ccfos/nightingale/v6/models"
-	"github.com/ccfos/nightingale/v6/pkg/poster"
 	"github.com/ccfos/nightingale/v6/pkg/ginx"
+	"github.com/ccfos/nightingale/v6/pkg/poster"
 
 	"github.com/gin-gonic/gin"
 	"github.com/toolkits/pkg/logger"
@@ -76,8 +76,8 @@ func (rt *Router) pushEventToQueue(c *gin.Context) {
 	dispatch.LogEvent(event, "http_push_queue")
 	if !queue.EventQueue.PushFront(event) {
 		msg := fmt.Sprintf("event:%s push_queue err: queue is full", event.Hash)
-		ginx.Bomb(200, msg)
-		logger.Warningf(msg)
+		ginx.Bomb(200, "%s", msg)
+		logger.Warning(msg)
 	}
 	ginx.NewRender(c).Message(nil)
 }

--- a/center/router/router_ai_assistant.go
+++ b/center/router/router_ai_assistant.go
@@ -1084,7 +1084,7 @@ func (rt *Router) serviceUser() gin.HandlerFunc {
 		}
 		user, err := models.UserGetByUsername(rt.Ctx, username)
 		if err != nil {
-			ginx.Bomb(http.StatusInternalServerError, err.Error())
+			bombErr(http.StatusInternalServerError, err)
 		}
 		if user == nil {
 			ginx.Bomb(http.StatusNotFound, "user not found: %s", username)

--- a/center/router/router_ai_llm_config.go
+++ b/center/router/router_ai_llm_config.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	"errors"
 	"net/http"
 	"strings"
 	"time"
@@ -8,6 +9,7 @@ import (
 	"github.com/ccfos/nightingale/v6/aiagent/llmconfig"
 	"github.com/ccfos/nightingale/v6/models"
 	"github.com/ccfos/nightingale/v6/pkg/ginx"
+	"github.com/ccfos/nightingale/v6/pkg/i18nx"
 
 	"github.com/gin-gonic/gin"
 )
@@ -153,7 +155,35 @@ func (rt *Router) aiLLMConfigTest(c *gin.Context) {
 		"duration_ms": durationMs,
 	}
 	if testErr != nil {
-		result["error"] = testErr.Error()
+		var errMsg string
+		var probeErr *llmconfig.ProbeError
+		if errors.As(testErr, &probeErr) {
+			errMsg = translateProbeError(c.GetHeader("X-Language"), probeErr)
+		} else {
+			errMsg = testErr.Error()
+		}
+		result["error"] = errMsg
 	}
 	ginx.NewRender(c).Data(result, nil)
+}
+
+func translateProbeError(lang string, err *llmconfig.ProbeError) string {
+	switch err.Kind {
+	case llmconfig.ProbeErrorAuth:
+		return i18nx.Translatef(lang, "llm test: authentication failed (HTTP %d), please verify your API Key is correct. server response: %s", err.StatusCode, err.Detail)
+	case llmconfig.ProbeErrorEndpointNotFound:
+		return i18nx.Translatef(lang, "llm test: endpoint not found (HTTP 404), please check your API URL (current: %s). for OpenAI-compatible APIs the URL should end with /v1, e.g. https://api.openai.com/v1. server response: %s", err.APIURL, err.Detail)
+	case llmconfig.ProbeErrorRateLimited:
+		return i18nx.Translatef(lang, "llm test: rate limit exceeded (HTTP 429), your API Key quota is exhausted or requests are too frequent. server response: %s", err.Detail)
+	case llmconfig.ProbeErrorRequestFailed:
+		return i18nx.Translatef(lang, "llm test: request failed (HTTP %d). server response: %s", err.StatusCode, err.Detail)
+	case llmconfig.ProbeErrorUnexpectedResponse:
+		return i18nx.Translatef(lang, "llm test: unexpected response format, the API URL may point to a wrong endpoint. raw: %s", err.Detail)
+	case llmconfig.ProbeErrorModel:
+		return i18nx.Translatef(lang, "llm test: LLM returned an error for model(%s): %s, please verify the model name is correct", err.Model, err.Detail)
+	case llmconfig.ProbeErrorNoContent:
+		return i18nx.Translatef(lang, "llm test: LLM returned no content, please verify the model name(%s) is correct", err.Model)
+	default:
+		return err.Error()
+	}
 }

--- a/center/router/router_ai_llm_config_test.go
+++ b/center/router/router_ai_llm_config_test.go
@@ -1,0 +1,35 @@
+package router
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ccfos/nightingale/v6/aiagent/llmconfig"
+)
+
+func TestTranslateProbeErrorAuth(t *testing.T) {
+	msg := translateProbeError("en", &llmconfig.ProbeError{
+		Kind:       llmconfig.ProbeErrorAuth,
+		StatusCode: 401,
+		Detail:     "invalid key",
+	})
+
+	if !strings.Contains(msg, "authentication failed (HTTP 401)") {
+		t.Fatalf("unexpected translated message: %q", msg)
+	}
+	if !strings.Contains(msg, "invalid key") {
+		t.Fatalf("unexpected translated message: %q", msg)
+	}
+}
+
+func TestTranslateProbeErrorModel(t *testing.T) {
+	msg := translateProbeError("en", &llmconfig.ProbeError{
+		Kind:   llmconfig.ProbeErrorModel,
+		Model:  "bad-model",
+		Detail: "model not found",
+	})
+
+	if !strings.Contains(msg, "model(bad-model): model not found") {
+		t.Fatalf("unexpected translated message: %q", msg)
+	}
+}

--- a/center/router/router_alert_rule.go
+++ b/center/router/router_alert_rule.go
@@ -378,12 +378,12 @@ func (rt *Router) alertRuleAdd(lst []models.AlertRule, username string, bgid int
 		}
 
 		if err := lst[i].FE2DB(); err != nil {
-			reterr[lst[i].Name] = i18n.Sprintf(lang, err.Error())
+			reterr[lst[i].Name] = translateText(lang, err.Error())
 			continue
 		}
 
 		if err := lst[i].Add(rt.Ctx); err != nil {
-			reterr[lst[i].Name] = i18n.Sprintf(lang, err.Error())
+			reterr[lst[i].Name] = translateText(lang, err.Error())
 		} else {
 			reterr[lst[i].Name] = ""
 		}
@@ -820,7 +820,7 @@ func (rt *Router) batchAlertRuleClone(c *gin.Context) {
 		for _, bgid := range f.Bgids {
 			// 为了让 bgid 和 arid 对应，将上面的 err 放到这里处理
 			if err != nil {
-				reterr[fmt.Sprintf("%d-%d", arid, bgid)] = i18n.Sprintf(lang, err.Error())
+				reterr[fmt.Sprintf("%d-%d", arid, bgid)] = translateText(lang, err.Error())
 				continue
 			}
 
@@ -832,7 +832,7 @@ func (rt *Router) batchAlertRuleClone(c *gin.Context) {
 			newAr := ar.Clone(me.Username, bgid)
 			err = newAr.Add(rt.Ctx)
 			if err != nil {
-				reterr[fmt.Sprintf("%d-%d", arid, bgid)] = i18n.Sprintf(lang, err.Error())
+				reterr[fmt.Sprintf("%d-%d", arid, bgid)] = translateText(lang, err.Error())
 				continue
 			}
 		}

--- a/center/router/router_alert_subscribe.go
+++ b/center/router/router_alert_subscribe.go
@@ -8,11 +8,10 @@ import (
 
 	"github.com/ccfos/nightingale/v6/alert/common"
 	"github.com/ccfos/nightingale/v6/models"
-	"github.com/ccfos/nightingale/v6/pkg/strx"
 	"github.com/ccfos/nightingale/v6/pkg/ginx"
+	"github.com/ccfos/nightingale/v6/pkg/strx"
 
 	"github.com/gin-gonic/gin"
-	"github.com/toolkits/pkg/i18n"
 )
 
 // Return all, front-end search and paging
@@ -130,11 +129,9 @@ func (rt *Router) alertSubscribeTryRun(c *gin.Context) {
 	curEvent := *hisEvent.ToCur()
 	curEvent.SetTagsMap()
 
-	lang := c.GetHeader("X-Language")
-
 	// 先判断匹配条件
 	if !f.SubscribeConfig.MatchCluster(curEvent.DatasourceId) {
-		ginx.Bomb(http.StatusBadRequest, i18n.Sprintf(lang, "event datasource not match"))
+		bombI18n(c, http.StatusBadRequest, "event datasource not match")
 	}
 
 	if len(f.SubscribeConfig.RuleIds) != 0 {
@@ -146,19 +143,19 @@ func (rt *Router) alertSubscribeTryRun(c *gin.Context) {
 			}
 		}
 		if !match {
-			ginx.Bomb(http.StatusBadRequest, i18n.Sprintf(lang, "event rule id not match"))
+			bombI18n(c, http.StatusBadRequest, "event rule id not match")
 		}
 	}
 
 	// 匹配 tag
 	f.SubscribeConfig.Parse()
 	if !common.MatchTags(curEvent.TagsMap, f.SubscribeConfig.ITags) {
-		ginx.Bomb(http.StatusBadRequest, i18n.Sprintf(lang, "event tags not match"))
+		bombI18n(c, http.StatusBadRequest, "event tags not match")
 	}
 
 	// 匹配group name
 	if !common.MatchGroupsName(curEvent.GroupName, f.SubscribeConfig.IBusiGroups) {
-		ginx.Bomb(http.StatusBadRequest, i18n.Sprintf(lang, "event group name not match"))
+		bombI18n(c, http.StatusBadRequest, "event group name not match")
 	}
 
 	// 检查严重级别（Severity）匹配
@@ -171,42 +168,42 @@ func (rt *Router) alertSubscribeTryRun(c *gin.Context) {
 			}
 		}
 		if !match {
-			ginx.Bomb(http.StatusBadRequest, i18n.Sprintf(lang, "event severity not match"))
+			bombI18n(c, http.StatusBadRequest, "event severity not match")
 		}
 	}
 
 	// 新版本通知规则
 	if f.SubscribeConfig.NotifyVersion == 1 {
 		if len(f.SubscribeConfig.NotifyRuleIds) == 0 {
-			ginx.Bomb(http.StatusBadRequest, i18n.Sprintf(lang, "no notify rules selected"))
+			bombI18n(c, http.StatusBadRequest, "no notify rules selected")
 		}
 
 		for _, id := range f.SubscribeConfig.NotifyRuleIds {
 			notifyRule, err := models.GetNotifyRule(rt.Ctx, id)
 			if err != nil {
-				ginx.Bomb(http.StatusNotFound, i18n.Sprintf(lang, "subscribe notify rule not found: %v", err))
+				bombI18n(c, http.StatusNotFound, "subscribe notify rule not found: %v", err)
 			}
 
 			for _, notifyConfig := range notifyRule.NotifyConfigs {
 				_, err = SendNotifyChannelMessage(rt.Ctx, rt.UserCache, rt.UserGroupCache, notifyConfig, []*models.AlertCurEvent{&curEvent})
 				if err != nil {
-					ginx.Bomb(http.StatusBadRequest, i18n.Sprintf(lang, "notify rule send error: %v", err))
+					bombI18n(c, http.StatusBadRequest, "notify rule send error: %v", err)
 				}
 			}
 		}
 
-		ginx.NewRender(c).Data(i18n.Sprintf(lang, "event match subscribe and notification test ok"), nil)
+		ginx.NewRender(c).Data(translate(c, "event match subscribe and notification test ok"), nil)
 		return
 	}
 
 	// 旧版通知方式
 	f.SubscribeConfig.ModifyEvent(&curEvent)
 	if len(curEvent.NotifyChannelsJSON) == 0 {
-		ginx.Bomb(http.StatusBadRequest, i18n.Sprintf(lang, "no notify channels selected"))
+		bombI18n(c, http.StatusBadRequest, "no notify channels selected")
 	}
 
 	if len(curEvent.NotifyGroupsJSON) == 0 {
-		ginx.Bomb(http.StatusOK, i18n.Sprintf(lang, "no notify groups selected"))
+		bombI18n(c, http.StatusOK, "no notify groups selected")
 	}
 
 	ancs := make([]string, 0, len(curEvent.NotifyChannelsJSON))
@@ -246,10 +243,10 @@ func (rt *Router) alertSubscribeTryRun(c *gin.Context) {
 		}
 	}
 	if len(ancs) > 0 {
-		ginx.Bomb(http.StatusBadRequest, i18n.Sprintf(lang, "all users missing notify channel configurations: %v", ancs))
+		bombI18n(c, http.StatusBadRequest, "all users missing notify channel configurations: %v", ancs)
 	}
 
-	ginx.NewRender(c).Data(i18n.Sprintf(lang, "event match subscribe and notify settings ok"), nil)
+	ginx.NewRender(c).Data(translate(c, "event match subscribe and notify settings ok"), nil)
 }
 
 func (rt *Router) alertSubscribePut(c *gin.Context) {

--- a/center/router/router_board.go
+++ b/center/router/router_board.go
@@ -6,11 +6,10 @@ import (
 	"time"
 
 	"github.com/ccfos/nightingale/v6/models"
-	"github.com/ccfos/nightingale/v6/pkg/strx"
 	"github.com/ccfos/nightingale/v6/pkg/ginx"
+	"github.com/ccfos/nightingale/v6/pkg/strx"
 
 	"github.com/gin-gonic/gin"
-	"github.com/toolkits/pkg/i18n"
 )
 
 type boardForm struct {
@@ -365,12 +364,12 @@ func (rt *Router) boardBatchClone(c *gin.Context) {
 			newBoard := bo.Clone(me.Username, bgid, "")
 			payload, err := models.BoardPayloadGet(rt.Ctx, bo.Id)
 			if err != nil {
-				reterr[fmt.Sprintf("%s-%d", newBoard.Name, bgid)] = i18n.Sprintf(lang, err.Error())
+				reterr[fmt.Sprintf("%s-%d", newBoard.Name, bgid)] = translateText(lang, err.Error())
 				continue
 			}
 
 			if err = newBoard.AtomicAdd(rt.Ctx, payload); err != nil {
-				reterr[fmt.Sprintf("%s-%d", newBoard.Name, bgid)] = i18n.Sprintf(lang, err.Error())
+				reterr[fmt.Sprintf("%s-%d", newBoard.Name, bgid)] = translateText(lang, err.Error())
 			}
 		}
 	}

--- a/center/router/router_builtin_metrics.go
+++ b/center/router/router_builtin_metrics.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ccfos/nightingale/v6/pkg/ginx"
 
 	"github.com/gin-gonic/gin"
-	"github.com/toolkits/pkg/i18n"
 )
 
 // single or import
@@ -33,7 +32,7 @@ func (rt *Router) builtinMetricsAdd(c *gin.Context) {
 		lst[i].Lang = lang
 		lst[i].UUID = time.Now().UnixMicro()
 		if err := lst[i].Add(rt.Ctx, username); err != nil {
-			reterr[lst[i].Name] = i18n.Sprintf(c.GetHeader("X-Language"), err.Error())
+			reterr[lst[i].Name] = translateText(c.GetHeader("X-Language"), err.Error())
 		}
 	}
 	ginx.NewRender(c).Data(reterr, nil)

--- a/center/router/router_builtin_payload.go
+++ b/center/router/router_builtin_payload.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ccfos/nightingale/v6/models"
 	"github.com/ccfos/nightingale/v6/pkg/ginx"
 	"github.com/gin-gonic/gin"
-	"github.com/toolkits/pkg/i18n"
 )
 
 type Board struct {
@@ -67,7 +66,7 @@ func (rt *Router) builtinPayloadsAdd(c *gin.Context) {
 					}
 
 					if err := bp.Add(rt.Ctx, username); err != nil {
-						reterr[bp.Name] = i18n.Sprintf(c.GetHeader("X-Language"), err.Error())
+						reterr[bp.Name] = translateText(c.GetHeader("X-Language"), err.Error())
 					}
 				}
 				continue
@@ -102,7 +101,7 @@ func (rt *Router) builtinPayloadsAdd(c *gin.Context) {
 			}
 
 			if err := bp.Add(rt.Ctx, username); err != nil {
-				reterr[bp.Name] = i18n.Sprintf(c.GetHeader("X-Language"), err.Error())
+				reterr[bp.Name] = translateText(c.GetHeader("X-Language"), err.Error())
 			}
 		} else if lst[i].Type == "dashboard" {
 			if strings.HasPrefix(strings.TrimSpace(lst[i].Content), "[") {
@@ -137,7 +136,7 @@ func (rt *Router) builtinPayloadsAdd(c *gin.Context) {
 					}
 
 					if err := bp.Add(rt.Ctx, username); err != nil {
-						reterr[bp.Name] = i18n.Sprintf(c.GetHeader("X-Language"), err.Error())
+						reterr[bp.Name] = translateText(c.GetHeader("X-Language"), err.Error())
 					}
 				}
 				continue
@@ -145,7 +144,7 @@ func (rt *Router) builtinPayloadsAdd(c *gin.Context) {
 
 			dashboard := Board{}
 			if err := json.Unmarshal([]byte(lst[i].Content), &dashboard); err != nil {
-				reterr[lst[i].Name] = i18n.Sprintf(c.GetHeader("X-Language"), err.Error())
+				reterr[lst[i].Name] = translateText(c.GetHeader("X-Language"), err.Error())
 				continue
 			}
 
@@ -173,7 +172,7 @@ func (rt *Router) builtinPayloadsAdd(c *gin.Context) {
 			}
 
 			if err := bp.Add(rt.Ctx, username); err != nil {
-				reterr[bp.Name] = i18n.Sprintf(c.GetHeader("X-Language"), err.Error())
+				reterr[bp.Name] = translateText(c.GetHeader("X-Language"), err.Error())
 			}
 		} else {
 			if lst[i].Type == "collect" {
@@ -185,7 +184,7 @@ func (rt *Router) builtinPayloadsAdd(c *gin.Context) {
 			}
 
 			if err := lst[i].Add(rt.Ctx, username); err != nil {
-				reterr[lst[i].Name] = i18n.Sprintf(c.GetHeader("X-Language"), err.Error())
+				reterr[lst[i].Name] = translateText(c.GetHeader("X-Language"), err.Error())
 			}
 		}
 
@@ -265,7 +264,7 @@ func (rt *Router) builtinPayloadsPut(c *gin.Context) {
 	if req.Type == "alert" {
 		alertRule := models.AlertRule{}
 		if err := json.Unmarshal([]byte(req.Content), &alertRule); err != nil {
-			ginx.Bomb(http.StatusBadRequest, err.Error())
+			bombErr(http.StatusBadRequest, err)
 		}
 
 		req.Name = alertRule.Name
@@ -273,7 +272,7 @@ func (rt *Router) builtinPayloadsPut(c *gin.Context) {
 	} else if req.Type == "dashboard" {
 		dashboard := Board{}
 		if err := json.Unmarshal([]byte(req.Content), &dashboard); err != nil {
-			ginx.Bomb(http.StatusBadRequest, err.Error())
+			bombErr(http.StatusBadRequest, err)
 		}
 
 		req.Name = dashboard.Name
@@ -282,7 +281,7 @@ func (rt *Router) builtinPayloadsPut(c *gin.Context) {
 	} else if req.Type == "collect" {
 		c := make(map[string]interface{})
 		if _, err := toml.Decode(req.Content, &c); err != nil {
-			ginx.Bomb(http.StatusBadRequest, err.Error())
+			bombErr(http.StatusBadRequest, err)
 		}
 	}
 

--- a/center/router/router_datasource.go
+++ b/center/router/router_datasource.go
@@ -347,7 +347,7 @@ func DatasourceCheck(c *gin.Context, ds models.Datasource) error {
 			logger.Errorf("Error creating request: %v", err)
 			if !strings.Contains(ds.HTTPJson.Url, "/loki") {
 				lang := c.GetHeader("X-Language")
-				return fmt.Errorf(i18n.Sprintf(lang, "/loki suffix is miss, please add /loki to the url: %s", ds.HTTPJson.Url+"/loki"))
+				return newMessageError(i18n.Sprintf(lang, "/loki suffix is miss, please add /loki to the url: %s", ds.HTTPJson.Url+"/loki"))
 			}
 			return fmt.Errorf("request url:%s failed: %v", fullURL, err)
 		}
@@ -372,7 +372,7 @@ func DatasourceCheck(c *gin.Context, ds models.Datasource) error {
 		logger.Errorf("Error making request: %v\n", resp.StatusCode)
 		if resp.StatusCode == 404 && ds.PluginType == models.LOKI && !strings.Contains(ds.HTTPJson.Url, "/loki") {
 			lang := c.GetHeader("X-Language")
-			return fmt.Errorf(i18n.Sprintf(lang, "/loki suffix is miss, please add /loki to the url: %s", ds.HTTPJson.Url+"/loki"))
+			return newMessageError(i18n.Sprintf(lang, "/loki suffix is miss, please add /loki to the url: %s", ds.HTTPJson.Url+"/loki"))
 		}
 		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("request url:%s failed code:%d body:%s", fullURL, resp.StatusCode, string(body))

--- a/center/router/router_event_pipeline.go
+++ b/center/router/router_event_pipeline.go
@@ -143,7 +143,7 @@ func (rt *Router) addEventPipeline(c *gin.Context) {
 
 	err := pipeline.Verify()
 	if err != nil {
-		ginx.Bomb(http.StatusBadRequest, err.Error())
+		bombErr(http.StatusBadRequest, err)
 	}
 
 	rt.checkEventPipelinePermission(c, &pipeline, "rw")
@@ -229,7 +229,7 @@ func (rt *Router) tryRunEventPipeline(c *gin.Context) {
 
 	m := map[string]interface{}{
 		"event":        resultEvent,
-		"result":       i18n.Sprintf(lang, result.Message),
+		"result":       translateText(lang, result.Message),
 		"status":       result.Status,
 		"node_results": result.NodeResults,
 	}
@@ -275,7 +275,7 @@ func (rt *Router) tryRunEventProcessor(c *gin.Context) {
 	}
 	ginx.NewRender(c).Data(map[string]interface{}{
 		"event":  resultEvent,
-		"result": i18n.Sprintf(lang, res),
+		"result": translateText(lang, res),
 	}, nil)
 }
 
@@ -425,7 +425,7 @@ func (rt *Router) triggerEventPipelineByAPI(c *gin.Context) {
 
 	executionID, err := rt.executePipelineTrigger(pipeline, &f, me.Username)
 	if err != nil {
-		ginx.Bomb(http.StatusBadRequest, err.Error())
+		bombErr(http.StatusBadRequest, err)
 	}
 
 	ginx.NewRender(c).Data(gin.H{

--- a/center/router/router_mute.go
+++ b/center/router/router_mute.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ccfos/nightingale/v6/pkg/strx"
 
 	"github.com/gin-gonic/gin"
-	"github.com/toolkits/pkg/i18n"
 	"github.com/toolkits/pkg/logger"
 )
 
@@ -125,9 +124,7 @@ func (rt *Router) alertMuteTryRun(c *gin.Context) {
 
 	match, err := mute.MatchMute(&curEvent, &f.AlertMute)
 	if err != nil {
-		// 对错误信息进行 i18n 翻译
-		translatedErr := i18n.Sprintf(c.GetHeader("X-Language"), err.Error())
-		ginx.Bomb(http.StatusBadRequest, translatedErr)
+		bombMsg(http.StatusBadRequest, translate(c, err.Error()))
 	}
 
 	if !match {

--- a/center/router/router_mw.go
+++ b/center/router/router_mw.go
@@ -36,7 +36,7 @@ func (rt *Router) handleProxyUser(c *gin.Context) *models.User {
 
 	user, err := models.UserGetByUsername(rt.Ctx, username)
 	if err != nil {
-		ginx.Bomb(http.StatusInternalServerError, err.Error())
+		bombErr(http.StatusInternalServerError, err)
 	}
 
 	if user == nil {
@@ -52,7 +52,7 @@ func (rt *Router) handleProxyUser(c *gin.Context) *models.User {
 		}
 		err = user.Add(rt.Ctx)
 		if err != nil {
-			ginx.Bomb(http.StatusInternalServerError, err.Error())
+			bombErr(http.StatusInternalServerError, err)
 		}
 	}
 	return user

--- a/center/router/router_notify_channel.go
+++ b/center/router/router_notify_channel.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+
 	// TODO(dingtalkapp): errors 仅在已注释的 dingtalkGroupsGetByNotifyChannel 中使用，钉钉应用上线时一并恢复。
 	// "errors"
 	"fmt"
@@ -376,7 +377,7 @@ func getFlashDutyChannels(integrationUrl string, jsonData []byte, timeout time.D
 	}
 
 	if res.Error.Message != "" {
-		return nil, fmt.Errorf(res.Error.Message)
+		return nil, newMessageError(res.Error.Message)
 	}
 
 	return res.Data.Items, nil
@@ -409,7 +410,7 @@ func (rt *Router) pagerDutyNotifyServicesGet(c *gin.Context) {
 
 	items, err := getPagerDutyServices(nc.RequestConfig.PagerDutyRequestConfig.ApiKey, time.Duration(nc.RequestConfig.PagerDutyRequestConfig.Timeout)*time.Millisecond)
 	if err != nil {
-		ginx.Bomb(http.StatusInternalServerError, fmt.Sprintf("failed to get pagerduty services: %v", err))
+		ginx.Bomb(http.StatusInternalServerError, "failed to get pagerduty services: %v", err)
 	}
 	// 服务: []集成，扁平化为服务-集成
 	var flattenedItems []map[string]string
@@ -441,7 +442,7 @@ func (rt *Router) pagerDutyIntegrationKeyGet(c *gin.Context) {
 	integrationUrl := fmt.Sprintf("https://api.pagerduty.com/services/%s/integrations/%s", serviceId, integrationId)
 	integrationKey, err := getPagerDutyIntegrationKey(integrationUrl, nc.RequestConfig.PagerDutyRequestConfig.ApiKey, time.Duration(nc.RequestConfig.PagerDutyRequestConfig.Timeout)*time.Millisecond)
 	if err != nil {
-		ginx.Bomb(http.StatusInternalServerError, fmt.Sprintf("failed to get pagerduty integration key: %v", err))
+		ginx.Bomb(http.StatusInternalServerError, "failed to get pagerduty integration key: %v", err)
 	}
 
 	ginx.NewRender(c).Data(map[string]string{

--- a/center/router/router_notify_rule.go
+++ b/center/router/router_notify_rule.go
@@ -156,7 +156,7 @@ func (rt *Router) notifyTest(c *gin.Context) {
 		event := he.ToCur()
 		event.SetTagsMap()
 		if err := dispatch.NotifyRuleMatchCheck(&f.NotifyConfig, event); err != nil {
-			ginx.Bomb(http.StatusBadRequest, err.Error())
+			bombErr(http.StatusBadRequest, err)
 		}
 
 		events = append(events, event)

--- a/center/router/router_role_operation.go
+++ b/center/router/router_role_operation.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ccfos/nightingale/v6/models"
 	"github.com/ccfos/nightingale/v6/pkg/ginx"
 	"github.com/gin-gonic/gin"
-	"github.com/toolkits/pkg/i18n"
 )
 
 func (rt *Router) operationOfRole(c *gin.Context) {
@@ -62,13 +61,13 @@ func (rt *Router) operations(c *gin.Context) {
 	for _, v := range rt.Operations.Ops {
 		newOp := cconf.Ops{
 			Name:  v.Name,
-			Cname: i18n.Sprintf(c.GetHeader("X-Language"), v.Cname),
+			Cname: translateText(c.GetHeader("X-Language"), v.Cname),
 			Ops:   []cconf.SingleOp{},
 		}
 		for i := range v.Ops {
 			op := cconf.SingleOp{
 				Name:  v.Ops[i].Name,
-				Cname: i18n.Sprintf(c.GetHeader("X-Language"), v.Ops[i].Cname),
+				Cname: translateText(c.GetHeader("X-Language"), v.Ops[i].Cname),
 			}
 			newOp.Ops = append(newOp.Ops, op)
 		}

--- a/center/router/router_target.go
+++ b/center/router/router_target.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/ccfos/nightingale/v6/models"
 	"github.com/ccfos/nightingale/v6/pkg/ctx"
+	"github.com/ccfos/nightingale/v6/pkg/ginx"
 	"github.com/ccfos/nightingale/v6/pkg/strx"
 	"github.com/ccfos/nightingale/v6/pushgw/idents"
 	"github.com/ccfos/nightingale/v6/storage"
-	"github.com/ccfos/nightingale/v6/pkg/ginx"
 
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/common/model"
@@ -264,7 +264,7 @@ func (rt *Router) targetBindTagsByFE(c *gin.Context) {
 	// Acquire idents by idents and hostIps
 	failedResults, f.Idents, err = models.TargetsGetIdentsByIdentsAndHostIps(rt.Ctx, f.Idents, f.HostIps)
 	if err != nil {
-		ginx.Bomb(http.StatusBadRequest, err.Error())
+		bombErr(http.StatusBadRequest, err)
 	}
 
 	rt.checkTargetPerm(c, f.Idents)
@@ -284,7 +284,7 @@ func (rt *Router) targetBindTagsByService(c *gin.Context) {
 	// Acquire idents by idents and hostIps
 	failedResults, f.Idents, err = models.TargetsGetIdentsByIdentsAndHostIps(rt.Ctx, f.Idents, f.HostIps)
 	if err != nil {
-		ginx.Bomb(http.StatusBadRequest, err.Error())
+		bombErr(http.StatusBadRequest, err)
 	}
 
 	ginx.NewRender(c).Data(rt.targetBindTags(f, failedResults))
@@ -367,7 +367,7 @@ func (rt *Router) targetUnbindTagsByFE(c *gin.Context) {
 	// Acquire idents by idents and hostIps
 	failedResults, f.Idents, err = models.TargetsGetIdentsByIdentsAndHostIps(rt.Ctx, f.Idents, f.HostIps)
 	if err != nil {
-		ginx.Bomb(http.StatusBadRequest, err.Error())
+		bombErr(http.StatusBadRequest, err)
 	}
 
 	rt.checkTargetPerm(c, f.Idents)
@@ -387,7 +387,7 @@ func (rt *Router) targetUnbindTagsByService(c *gin.Context) {
 	// Acquire idents by idents and hostIps
 	failedResults, f.Idents, err = models.TargetsGetIdentsByIdentsAndHostIps(rt.Ctx, f.Idents, f.HostIps)
 	if err != nil {
-		ginx.Bomb(http.StatusBadRequest, err.Error())
+		bombErr(http.StatusBadRequest, err)
 	}
 
 	ginx.NewRender(c).Data(rt.targetUnbindTags(f, failedResults))
@@ -431,7 +431,7 @@ func (rt *Router) targetUpdateNote(c *gin.Context) {
 	// Acquire idents by idents and hostIps
 	failedResults, f.Idents, err = models.TargetsGetIdentsByIdentsAndHostIps(rt.Ctx, f.Idents, f.HostIps)
 	if err != nil {
-		ginx.Bomb(http.StatusBadRequest, err.Error())
+		bombErr(http.StatusBadRequest, err)
 	}
 
 	rt.checkTargetPerm(c, f.Idents)
@@ -452,7 +452,7 @@ func (rt *Router) targetUpdateNoteByService(c *gin.Context) {
 	// Acquire idents by idents and hostIps
 	failedResults, f.Idents, err = models.TargetsGetIdentsByIdentsAndHostIps(rt.Ctx, f.Idents, f.HostIps)
 	if err != nil {
-		ginx.Bomb(http.StatusBadRequest, err.Error())
+		bombErr(http.StatusBadRequest, err)
 	}
 
 	ginx.NewRender(c).Data(failedResults, models.TargetUpdateNote(rt.Ctx, f.Idents, f.Note))
@@ -501,7 +501,7 @@ func (rt *Router) targetBindBgids(c *gin.Context) {
 	// Acquire idents by idents and hostIps
 	failedResults, f.Idents, err = models.TargetsGetIdentsByIdentsAndHostIps(rt.Ctx, f.Idents, f.HostIps)
 	if err != nil {
-		ginx.Bomb(http.StatusBadRequest, err.Error())
+		bombErr(http.StatusBadRequest, err)
 	}
 
 	user := c.MustGet("user").(*models.User)
@@ -548,14 +548,14 @@ func (rt *Router) targetBindBgids(c *gin.Context) {
 	case "del":
 		if !f.Force {
 			if err := rt.TargetBgidChangeCheck(f.Idents, "del", f.Bgids); err != nil {
-				ginx.Bomb(http.StatusBadRequest, err.Error())
+				bombErr(http.StatusBadRequest, err)
 			}
 		}
 		ginx.NewRender(c).Data(failedResults, models.TargetUnbindBgids(rt.Ctx, f.Idents, f.Bgids))
 	case "reset":
 		if !f.Force {
 			if err := rt.TargetBgidChangeCheck(f.Idents, "reset", f.Bgids); err != nil {
-				ginx.Bomb(http.StatusBadRequest, err.Error())
+				bombErr(http.StatusBadRequest, err)
 			}
 		}
 		ginx.NewRender(c).Data(failedResults, models.TargetOverrideBgids(rt.Ctx, f.Idents, f.Bgids, f.Tags))
@@ -577,7 +577,7 @@ func (rt *Router) targetUpdateBgidByService(c *gin.Context) {
 	// Acquire idents by idents and hostIps
 	failedResults, f.Idents, err = models.TargetsGetIdentsByIdentsAndHostIps(rt.Ctx, f.Idents, f.HostIps)
 	if err != nil {
-		ginx.Bomb(http.StatusBadRequest, err.Error())
+		bombErr(http.StatusBadRequest, err)
 	}
 
 	ginx.NewRender(c).Data(failedResults, models.TargetOverrideBgids(rt.Ctx, f.Idents, []int64{f.Bgid}, nil))
@@ -602,7 +602,7 @@ func (rt *Router) targetDel(c *gin.Context) {
 	// Acquire idents by idents and hostIps
 	failedResults, f.Idents, err = models.TargetsGetIdentsByIdentsAndHostIps(rt.Ctx, f.Idents, f.HostIps)
 	if err != nil {
-		ginx.Bomb(http.StatusBadRequest, err.Error())
+		bombErr(http.StatusBadRequest, err)
 	}
 
 	ginx.NewRender(c).Data(failedResults, models.TargetDel(rt.Ctx, f.Idents, f.Force, rt.TargetDeleteHook))
@@ -621,7 +621,7 @@ func (rt *Router) targetDelByService(c *gin.Context) {
 	// Acquire idents by idents and hostIps
 	failedResults, f.Idents, err = models.TargetsGetIdentsByIdentsAndHostIps(rt.Ctx, f.Idents, f.HostIps)
 	if err != nil {
-		ginx.Bomb(http.StatusBadRequest, err.Error())
+		bombErr(http.StatusBadRequest, err)
 	}
 
 	ginx.NewRender(c).Data(failedResults, models.TargetDel(rt.Ctx, f.Idents, true, rt.TargetDeleteHook))
@@ -673,7 +673,7 @@ func (rt *Router) targetsOfHostQuery(c *gin.Context) {
 	var lst []*models.Target
 	err := session.Find(&lst).Error
 	if err != nil {
-		ginx.Bomb(http.StatusInternalServerError, err.Error())
+		bombErr(http.StatusInternalServerError, err)
 	}
 
 	ginx.NewRender(c).Data(lst, nil)

--- a/center/router/router_task.go
+++ b/center/router/router_task.go
@@ -6,11 +6,10 @@ import (
 
 	"github.com/ccfos/nightingale/v6/alert/sender"
 	"github.com/ccfos/nightingale/v6/models"
-	"github.com/ccfos/nightingale/v6/pkg/strx"
 	"github.com/ccfos/nightingale/v6/pkg/ginx"
+	"github.com/ccfos/nightingale/v6/pkg/strx"
 
 	"github.com/gin-gonic/gin"
-	"github.com/toolkits/pkg/i18n"
 )
 
 func (rt *Router) taskGets(c *gin.Context) {
@@ -93,7 +92,7 @@ func (rt *Router) taskRecordAdd(c *gin.Context) {
 
 func (rt *Router) taskAdd(c *gin.Context) {
 	if !rt.Ibex.Enable {
-		ginx.Bomb(400, i18n.Sprintf(c.GetHeader("X-Language"), "This functionality has not been enabled. Please contact the system administrator to activate it."))
+		bombI18n(c, 400, "This functionality has not been enabled. Please contact the system administrator to activate it.")
 		return
 	}
 

--- a/center/router/router_task_tpl.go
+++ b/center/router/router_task_tpl.go
@@ -7,11 +7,10 @@ import (
 	"time"
 
 	"github.com/ccfos/nightingale/v6/models"
-	"github.com/ccfos/nightingale/v6/pkg/strx"
 	"github.com/ccfos/nightingale/v6/pkg/ginx"
+	"github.com/ccfos/nightingale/v6/pkg/strx"
 
 	"github.com/gin-gonic/gin"
-	"github.com/toolkits/pkg/i18n"
 	"github.com/toolkits/pkg/str"
 )
 
@@ -135,7 +134,7 @@ func (f *taskTplForm) Verify() {
 
 func (rt *Router) taskTplAdd(c *gin.Context) {
 	if !rt.Ibex.Enable {
-		ginx.Bomb(400, i18n.Sprintf(c.GetHeader("X-Language"), "This functionality has not been enabled. Please contact the system administrator to activate it."))
+		bombI18n(c, 400, "This functionality has not been enabled. Please contact the system administrator to activate it.")
 		return
 	}
 

--- a/center/router/vet_helpers.go
+++ b/center/router/vet_helpers.go
@@ -1,0 +1,43 @@
+package router
+
+import (
+	"errors"
+
+	"github.com/ccfos/nightingale/v6/pkg/ginx"
+	"github.com/ccfos/nightingale/v6/pkg/i18nx"
+	"github.com/gin-gonic/gin"
+)
+
+func bombMsg(code int, msg string) {
+	ginx.Bomb(code, "%s", msg)
+}
+
+func bombErr(code int, err error) {
+	if err != nil {
+		ginx.Bomb(code, "%s", err.Error())
+	}
+}
+
+func translateText(lang, key string) string {
+	return i18nx.Translate(lang, key)
+}
+
+func requestLang(c *gin.Context) string {
+	return c.GetHeader("X-Language")
+}
+
+func translate(c *gin.Context, key string) string {
+	return i18nx.Translate(requestLang(c), key)
+}
+
+func translatef(c *gin.Context, format string, args ...interface{}) string {
+	return i18nx.Translatef(requestLang(c), format, args...)
+}
+
+func bombI18n(c *gin.Context, code int, format string, args ...interface{}) {
+	bombMsg(code, translatef(c, format, args...))
+}
+
+func newMessageError(msg string) error {
+	return errors.New(msg)
+}

--- a/pkg/aop/rec.go
+++ b/pkg/aop/rec.go
@@ -18,9 +18,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ccfos/nightingale/v6/pkg/i18nx"
 	"github.com/gin-gonic/gin"
 	"github.com/toolkits/pkg/errorx"
-	"github.com/toolkits/pkg/i18n"
 )
 
 var (
@@ -47,10 +47,10 @@ func RecoveryWithWriter(out io.Writer) gin.HandlerFunc {
 				// custom error
 				if e, ok := err.(errorx.PageError); ok {
 					if e.Code != 200 {
-						c.String(e.Code, i18n.Sprintf(c.GetHeader("X-Language"), e.Message))
+						c.String(e.Code, i18nx.Translate(c.GetHeader("X-Language"), e.Message))
 					} else {
 						c.JSON(e.Code, gin.H{
-							"err":        i18n.Sprintf(c.GetHeader("X-Language"), e.Message),
+							"err":        i18nx.Translate(c.GetHeader("X-Language"), e.Message),
 							"request_id": c.GetString("trace_id"),
 						})
 					}

--- a/pkg/i18nx/i18n.go
+++ b/pkg/i18nx/i18n.go
@@ -2,12 +2,16 @@ package i18nx
 
 import (
 	"encoding/json"
+	"fmt"
 	"path"
+	"strings"
 
 	"github.com/toolkits/pkg/file"
 	"github.com/toolkits/pkg/i18n"
 	"github.com/toolkits/pkg/logger"
 )
+
+var dict map[string]map[string]string
 
 func Init(configDir string) {
 	filePath := path.Join(configDir, "i18n.json")
@@ -59,5 +63,53 @@ func Init(configDir string) {
 		}
 	}
 
+	dict = m
 	i18n.DictRegister(m)
+}
+
+func Translate(lang, key string) string {
+	if key == "" || len(dict) == 0 {
+		return key
+	}
+
+	if msg, ok := lookup(lang, key); ok {
+		return msg
+	}
+
+	normalized := normalizeLang(lang)
+	if normalized != lang {
+		if msg, ok := lookup(normalized, key); ok {
+			return msg
+		}
+	}
+
+	return key
+}
+
+func Translatef(lang, format string, args ...interface{}) string {
+	return fmt.Sprintf(Translate(lang, format), args...)
+}
+
+func lookup(lang, key string) (string, bool) {
+	if catalog, ok := dict[lang]; ok {
+		if msg, ok := catalog[key]; ok {
+			return msg, true
+		}
+	}
+	return "", false
+}
+
+func normalizeLang(lang string) string {
+	switch strings.ToLower(strings.ReplaceAll(lang, "-", "_")) {
+	case "zh", "cn", "zh_cn":
+		return "zh_CN"
+	case "zh_hk", "zh_tw":
+		return "zh_HK"
+	case "ja", "jp", "ja_jp":
+		return "ja_JP"
+	case "ru", "ru_ru":
+		return "ru_RU"
+	default:
+		return lang
+	}
 }

--- a/pkg/i18nx/var.go
+++ b/pkg/i18nx/var.go
@@ -206,6 +206,14 @@ var I18N = `{
     "saved view page is blank": "视图页面不能为空",
     "saved view name already exists in this page": "该页面下已存在同名的公开视图",
 
+    "llm test: authentication failed (HTTP %d), please verify your API Key is correct. server response: %s": "LLM 连接测试失败：认证失败（HTTP %d），请检查 API Key 是否正确。服务端返回：%s",
+    "llm test: endpoint not found (HTTP 404), please check your API URL (current: %s). for OpenAI-compatible APIs the URL should end with /v1, e.g. https://api.openai.com/v1. server response: %s": "LLM 连接测试失败：接口地址不存在（HTTP 404），请检查 API URL 是否正确（当前：%s）。OpenAI 兼容接口地址通常应以 /v1 结尾，例如 https://api.openai.com/v1。服务端返回：%s",
+    "llm test: rate limit exceeded (HTTP 429), your API Key quota is exhausted or requests are too frequent. server response: %s": "LLM 连接测试失败：请求频率超限（HTTP 429），API Key 配额已耗尽或请求过于频繁，请稍后重试。服务端返回：%s",
+    "llm test: request failed (HTTP %d). server response: %s": "LLM 连接测试失败：请求失败（HTTP %d）。服务端返回：%s",
+    "llm test: unexpected response format, the API URL may point to a wrong endpoint. raw: %s": "LLM 连接测试失败：接口返回了非预期的响应格式，API URL 可能指向了错误的端点。原始内容：%s",
+    "llm test: LLM returned an error for model(%s): %s, please verify the model name is correct": "LLM 连接测试失败：模型「%s」返回错误：%s，请检查模型名称是否正确",
+    "llm test: LLM returned no content, please verify the model name(%s) is correct": "LLM 连接测试失败：LLM 未返回有效内容，请检查模型名称「%s」是否正确",
+
     "---------zh_CN--------": "---------zh_CN--------"
   },
   "zh_HK": {
@@ -415,6 +423,14 @@ var I18N = `{
     "saved view page is blank": "視圖頁面不能為空",
     "saved view name already exists in this page": "該頁面下已存在同名的公開視圖",
 
+    "llm test: authentication failed (HTTP %d), please verify your API Key is correct. server response: %s": "LLM 連接測試失敗：認證失敗（HTTP %d），請檢查 API Key 是否正確。服務端返回：%s",
+    "llm test: endpoint not found (HTTP 404), please check your API URL (current: %s). for OpenAI-compatible APIs the URL should end with /v1, e.g. https://api.openai.com/v1. server response: %s": "LLM 連接測試失敗：介面地址不存在（HTTP 404），請檢查 API URL 是否正確（當前：%s）。OpenAI 相容介面地址通常應以 /v1 結尾，例如 https://api.openai.com/v1。服務端返回：%s",
+    "llm test: rate limit exceeded (HTTP 429), your API Key quota is exhausted or requests are too frequent. server response: %s": "LLM 連接測試失敗：請求頻率超限（HTTP 429），API Key 配額已耗盡或請求過於頻繁，請稍後重試。服務端返回：%s",
+    "llm test: request failed (HTTP %d). server response: %s": "LLM 連接測試失敗：請求失敗（HTTP %d）。服務端返回：%s",
+    "llm test: unexpected response format, the API URL may point to a wrong endpoint. raw: %s": "LLM 連接測試失敗：介面返回了非預期的響應格式，API URL 可能指向了錯誤的端點。原始內容：%s",
+    "llm test: LLM returned an error for model(%s): %s, please verify the model name is correct": "LLM 連接測試失敗：模型「%s」返回錯誤：%s，請檢查模型名稱是否正確",
+    "llm test: LLM returned no content, please verify the model name(%s) is correct": "LLM 連接測試失敗：LLM 未返回有效內容，請檢查模型名稱「%s」是否正確",
+
     "---------zh_HK--------": "---------zh_HK--------"
   },
   "ja_JP": {
@@ -621,6 +637,14 @@ var I18N = `{
     "saved view page is blank": "ビューページを空にすることはできません",
     "saved view name already exists in this page": "このページには同名の公開ビューが既に存在します",
 
+    "llm test: authentication failed (HTTP %d), please verify your API Key is correct. server response: %s": "LLM 接続テスト失敗：認証エラー（HTTP %d）、API Key が正しいか確認してください。サーバーの応答：%s",
+    "llm test: endpoint not found (HTTP 404), please check your API URL (current: %s). for OpenAI-compatible APIs the URL should end with /v1, e.g. https://api.openai.com/v1. server response: %s": "LLM 接続テスト失敗：エンドポイントが見つかりません（HTTP 404）、API URL を確認してください（現在：%s）。OpenAI 互換 API の URL は通常 /v1 で終わる必要があります（例：https://api.openai.com/v1）。サーバーの応答：%s",
+    "llm test: rate limit exceeded (HTTP 429), your API Key quota is exhausted or requests are too frequent. server response: %s": "LLM 接続テスト失敗：レート制限超過（HTTP 429）、API Key のクォータが枯渇したかリクエストが頻繁すぎます。しばらくしてから再試行してください。サーバーの応答：%s",
+    "llm test: request failed (HTTP %d). server response: %s": "LLM 接続テスト失敗：リクエスト失敗（HTTP %d）。サーバーの応答：%s",
+    "llm test: unexpected response format, the API URL may point to a wrong endpoint. raw: %s": "LLM 接続テスト失敗：予期しない応答形式です。API URL が誤ったエンドポイントを指している可能性があります。内容：%s",
+    "llm test: LLM returned an error for model(%s): %s, please verify the model name is correct": "LLM 接続テスト失敗：モデル「%s」がエラーを返しました：%s。モデル名が正しいか確認してください",
+    "llm test: LLM returned no content, please verify the model name(%s) is correct": "LLM 接続テスト失敗：LLM が有効なコンテンツを返しませんでした。モデル名「%s」が正しいか確認してください",
+
     "---------ja_JP--------": "---------ja_JP--------"
   },
   "ru_RU": {
@@ -826,6 +850,14 @@ var I18N = `{
     "saved view name is blank": "Название вида не может быть пустым",
     "saved view page is blank": "Страница вида не может быть пустой",
     "saved view name already exists in this page": "На этой странице уже существует публичный вид с таким названием",
+
+    "llm test: authentication failed (HTTP %d), please verify your API Key is correct. server response: %s": "Тест подключения LLM не пройден: ошибка аутентификации (HTTP %d), проверьте правильность API Key. Ответ сервера: %s",
+    "llm test: endpoint not found (HTTP 404), please check your API URL (current: %s). for OpenAI-compatible APIs the URL should end with /v1, e.g. https://api.openai.com/v1. server response: %s": "Тест подключения LLM не пройден: эндпоинт не найден (HTTP 404), проверьте API URL (текущий: %s). Для OpenAI-совместимых API URL должен заканчиваться на /v1, например https://api.openai.com/v1. Ответ сервера: %s",
+    "llm test: rate limit exceeded (HTTP 429), your API Key quota is exhausted or requests are too frequent. server response: %s": "Тест подключения LLM не пройден: превышен лимит запросов (HTTP 429), квота API Key исчерпана или запросы слишком частые. Повторите попытку позже. Ответ сервера: %s",
+    "llm test: request failed (HTTP %d). server response: %s": "Тест подключения LLM не пройден: запрос завершился ошибкой (HTTP %d). Ответ сервера: %s",
+    "llm test: unexpected response format, the API URL may point to a wrong endpoint. raw: %s": "Тест подключения LLM не пройден: неожиданный формат ответа, API URL может указывать на неверный эндпоинт. Содержимое: %s",
+    "llm test: LLM returned an error for model(%s): %s, please verify the model name is correct": "Тест подключения LLM не пройден: модель «%s» вернула ошибку: %s. Проверьте правильность названия модели",
+    "llm test: LLM returned no content, please verify the model name(%s) is correct": "Тест подключения LLM не пройден: LLM не вернула содержимого. Проверьте правильность названия модели «%s»",
 
     "---------ru_RU--------": "---------ru_RU--------"
   }

--- a/pkg/ldapx/ldapx.go
+++ b/pkg/ldapx/ldapx.go
@@ -141,18 +141,37 @@ func (s *SsoClient) Reload(cf Config) {
 
 func (s *SsoClient) Copy() *SsoClient {
 	s.RLock()
+	defer s.RUnlock()
 
 	newRoles := make([]string, len(s.DefaultRoles))
 	copy(newRoles, s.DefaultRoles)
 	newTeams := make([]int64, len(s.DefaultTeams))
 	copy(newTeams, s.DefaultTeams)
-	lc := *s
-	lc.DefaultRoles = newRoles
-	lc.DefaultTeams = newTeams
 
-	s.RUnlock()
-
-	return &lc
+	return &SsoClient{
+		Enable:          s.Enable,
+		Host:            s.Host,
+		Port:            s.Port,
+		BaseDn:          s.BaseDn,
+		BaseDns:         s.BaseDns,
+		BindUser:        s.BindUser,
+		BindPass:        s.BindPass,
+		SyncAdd:         s.SyncAdd,
+		SyncDel:         s.SyncDel,
+		SyncInterval:    s.SyncInterval,
+		UserFilter:      s.UserFilter,
+		AuthFilter:      s.AuthFilter,
+		Attributes:      s.Attributes,
+		CoverAttributes: s.CoverAttributes,
+		CoverTeams:      s.CoverTeams,
+		CoverRoles:      s.CoverRoles,
+		TLS:             s.TLS,
+		StartTLS:        s.StartTLS,
+		DefaultRoles:    newRoles,
+		DefaultTeams:    newTeams,
+		RoleTeamMapping: s.RoleTeamMapping,
+		Ticker:          s.Ticker,
+	}
 }
 
 func (s *SsoClient) LoginCheck(user, pass string) (*ldap.SearchResult, error) {

--- a/pkg/ldapx/user_sync.go
+++ b/pkg/ldapx/user_sync.go
@@ -82,7 +82,7 @@ func (s *SsoClient) UserGetAll() (map[string]*models.User, error) {
 	}
 	defer conn.Close()
 
-	srs, err := lc.ldapReq(conn, lc.UserFilter)
+	srs, err := lc.ldapReq(conn, "%s", lc.UserFilter)
 	if err != nil {
 		return nil, fmt.Errorf("ldap.error: ldap search fail: %v", err)
 	}


### PR DESCRIPTION
## Summary

- **Fix format string injection vulnerabilities**: All instances of `ginx.Bomb(code, err.Error())` and `logger.Warningf(msg)` where user/external data was passed as a format string are now safely wrapped (e.g. `ginx.Bomb(code, "%s", err.Error())`). Extracted `vet_helpers.go` with `bombErr`/`bombI18n`/`translateText` helpers to make the safe pattern ergonomic and consistent.
- **Unify i18n translation layer**: Introduced `i18nx.Translate`/`Translatef` with automatic language normalization (`zh`→`zh_CN`, `ja`→`ja_JP`, etc.), replacing direct `i18n.Sprintf` calls across router handlers and the AOP recovery middleware.
- **Rewrite LLM probe with structured errors**: Replaced raw HTTP probe logic with `llm.New` client usage and introduced `ProbeError` with classified error kinds (`auth`, `endpoint_not_found`, `rate_limited`, etc.) plus full i18n support (zh_CN, zh_HK, ja_JP, ru_RU).
- **Fix `ldapx` vet warnings**: Resolved `go vet` "copies lock value" warning in `SsoClient.Copy()` by switching from value copy to field-by-field construction; fixed format string injection in `ldapReq` call.
- **Fix UTF-8 safety**: `truncate()` now uses rune-based slicing to avoid splitting multi-byte characters.

## Test plan

- [x] `go vet ./...` passes on all modified packages (including ldapx)
- [x] `go build` succeeds for all affected packages
- [x] Unit tests pass: `TestParseProviderStatusError`, `TestClassifyProbeErrorHTTPStatus`, `TestClassifyProbeErrorProviderMessage`, `TestFormatHTTPErrorAuth`, `TestTranslateProbeErrorAuth`, `TestTranslateProbeErrorModel`
- [ ] Manual verification: trigger LLM config test with invalid key and verify i18n error messages render correctly in zh_CN
- [ ] Manual verification: LDAP sync still functions correctly after Copy() refactor


Made with [Cursor](https://cursor.com)