### PR TITLE
fix(security): redact datasource secrets for non-admin users (#3173)

### DIFF
--- a/center/router/router_datasource.go
+++ b/center/router/router_datasource.go
@@ -49,9 +49,6 @@ func (rt *Router) datasourceList(c *gin.Context) {
 	list, err := models.GetDatasourcesGetsBy(rt.Ctx, typ, category, name, "")
 	list = rt.DatasourceCache.DatasourceFilter(list, user)
 
-	// 路由对非管理员开放（前端 Profile / 仪表盘数据源选择器都依赖该接口），
-	// 但 Datasource 结构体序列化时会带出密码 / Bearer token / 加密 blob 等敏感字段，
-	// 因此非管理员一律脱敏后再返回。
 	if !user.IsAdmin() {
 		for _, ds := range list {
 			ds.RedactSecrets()

--- a/center/router/router_datasource.go
+++ b/center/router/router_datasource.go
@@ -47,7 +47,18 @@ func (rt *Router) datasourceList(c *gin.Context) {
 	user := c.MustGet("user").(*models.User)
 
 	list, err := models.GetDatasourcesGetsBy(rt.Ctx, typ, category, name, "")
-	Render(c, rt.DatasourceCache.DatasourceFilter(list, user), err)
+	list = rt.DatasourceCache.DatasourceFilter(list, user)
+
+	// 路由对非管理员开放（前端 Profile / 仪表盘数据源选择器都依赖该接口），
+	// 但 Datasource 结构体序列化时会带出密码 / Bearer token / 加密 blob 等敏感字段，
+	// 因此非管理员一律脱敏后再返回。
+	if !user.IsAdmin() {
+		for _, ds := range list {
+			ds.RedactSecrets()
+		}
+	}
+
+	Render(c, list, err)
 }
 
 func (rt *Router) datasourceGetsByService(c *gin.Context) {
@@ -94,23 +105,29 @@ func (rt *Router) datasourceBriefs(c *gin.Context) {
 	ginx.Dangerous(err)
 
 	for _, item := range list {
-		item.AuthJson.BasicAuthPassword = ""
-		if item.PluginType == models.PROMETHEUS {
+		// 先挑出 UI 必需且不敏感的 settings 字段，再统一调用 RedactSecrets
+		// 全量脱敏，避免遗漏 HTTPJson.Headers / AuthEncoded / SettingsEncoded
+		// 之类同样会泄露密钥的字段。
+		var safeSettings map[string]interface{}
+		switch item.PluginType {
+		case models.PROMETHEUS:
+			safeSettings = make(map[string]interface{})
 			for k, v := range item.SettingsJson {
 				if strings.HasPrefix(k, "prometheus.") {
-					item.SettingsJson[strings.TrimPrefix(k, "prometheus.")] = v
-					delete(item.SettingsJson, k)
+					safeSettings[strings.TrimPrefix(k, "prometheus.")] = v
 				}
 			}
-		} else if item.PluginType == "cloudwatch" {
-			for k := range item.SettingsJson {
-				if !strings.Contains(k, "region") {
-					delete(item.SettingsJson, k)
+		case "cloudwatch":
+			safeSettings = make(map[string]interface{})
+			for k, v := range item.SettingsJson {
+				if strings.Contains(k, "region") {
+					safeSettings[k] = v
 				}
 			}
-		} else {
-			item.SettingsJson = nil
 		}
+
+		item.RedactSecrets()
+		item.SettingsJson = safeSettings
 		dss = append(dss, item)
 	}
 

--- a/models/datasource.go
+++ b/models/datasource.go
@@ -554,7 +554,9 @@ func (ds *Datasource) Decrypt() error {
 	return nil
 }
 
-// ClearPlaintext 清理敏感字段
+// ClearPlaintext 清理 Settings / Auth 的明文字段。
+// 仅用于 Encrypt() 之后，加密产物（SettingsEncoded / AuthEncoded）和 HTTP headers
+// 必须保留以便 edge 节点解密和使用。给最终用户脱敏请用 RedactSecrets()。
 func (ds *Datasource) ClearPlaintext() {
 	ds.Settings = ""
 	ds.SettingsJson = nil
@@ -562,6 +564,21 @@ func (ds *Datasource) ClearPlaintext() {
 	ds.Auth = ""
 	ds.AuthJson.BasicAuthUser = ""
 	ds.AuthJson.BasicAuthPassword = ""
+}
+
+// RedactSecrets 抹掉所有可能携带密钥 / 口令 / 令牌的字段，用于把数据源对象
+// 返回给非管理员用户。HTTPJson.Url/Urls 等非敏感连接信息保留，方便前端展示。
+func (ds *Datasource) RedactSecrets() {
+	ds.Settings = ""
+	ds.SettingsJson = nil
+	ds.SettingsEncoded = ""
+
+	ds.HTTP = ""
+	ds.HTTPJson.Headers = nil
+
+	ds.Auth = ""
+	ds.AuthJson = Auth{}
+	ds.AuthEncoded = ""
 }
 
 func DatasourceGetMap(ctx *ctx.Context) (map[int64]*Datasource, error) {

--- a/models/datasource.go
+++ b/models/datasource.go
@@ -575,6 +575,12 @@ func (ds *Datasource) RedactSecrets() {
 
 	ds.HTTP = ""
 	ds.HTTPJson.Headers = nil
+	// mTLS 客户端私钥及其口令属于密钥材料，必须抹掉；
+	// CA / 客户端证书不算口令，但也没有展示需求，一并清空。
+	ds.HTTPJson.TLS.CACert = ""
+	ds.HTTPJson.TLS.ClientCert = ""
+	ds.HTTPJson.TLS.ClientKey = ""
+	ds.HTTPJson.TLS.ClientKeyPassword = ""
 
 	ds.Auth = ""
 	ds.AuthJson = Auth{}


### PR DESCRIPTION
Fix [#3173](https://github.com/ccfos/nightingale/issues/3173) — `POST /api/n9e/datasource/list` lets any authenticated non-admin user recover the cleartext passwords, Bearer tokens and encrypted blobs of every datasource configured by the admin.

