### PR TITLE
fix: LLM connection test fails for thinking models (e.g. deepseek-v4-flash)

### DIFF
--- a/aiagent/llm/llm.go
+++ b/aiagent/llm/llm.go
@@ -63,10 +63,11 @@ type GenerateRequest struct {
 
 // GenerateResponse is the unified response from LLM generation
 type GenerateResponse struct {
-	Content      string     `json:"content"`
-	ToolCalls    []ToolCall `json:"tool_calls,omitempty"`
-	FinishReason string     `json:"finish_reason"`
-	Usage        *Usage     `json:"usage,omitempty"`
+	Content          string     `json:"content"`
+	ReasoningContent string     `json:"reasoning_content,omitempty"`
+	ToolCalls        []ToolCall `json:"tool_calls,omitempty"`
+	FinishReason     string     `json:"finish_reason"`
+	Usage            *Usage     `json:"usage,omitempty"`
 }
 
 // Usage represents token usage statistics

--- a/aiagent/llm/openai.go
+++ b/aiagent/llm/openai.go
@@ -103,10 +103,11 @@ func (r openAIRequest) MarshalJSON() ([]byte, error) {
 }
 
 type openAIMessage struct {
-	Role       string           `json:"role"`
-	Content    string           `json:"content,omitempty"`
-	ToolCalls  []openAIToolCall `json:"tool_calls,omitempty"`
-	ToolCallID string           `json:"tool_call_id,omitempty"`
+	Role             string           `json:"role"`
+	Content          string           `json:"content,omitempty"`
+	ReasoningContent string           `json:"reasoning_content,omitempty"`
+	ToolCalls        []openAIToolCall `json:"tool_calls,omitempty"`
+	ToolCallID       string           `json:"tool_call_id,omitempty"`
 }
 
 type openAITool struct {
@@ -334,6 +335,7 @@ func (o *OpenAI) convertResponse(resp *openAIResponse) *GenerateResponse {
 	if len(resp.Choices) > 0 {
 		choice := resp.Choices[0]
 		result.Content = choice.Message.Content
+		result.ReasoningContent = choice.Message.ReasoningContent
 		result.FinishReason = choice.FinishReason
 
 		// Convert tool calls

--- a/aiagent/llmconfig/probe.go
+++ b/aiagent/llmconfig/probe.go
@@ -77,7 +77,7 @@ func Test(p *models.AILLMConfig) error {
 	if err != nil {
 		return classifyProbeError(p, err)
 	}
-	if resp == nil || strings.TrimSpace(resp.Content) == "" {
+	if resp == nil || (strings.TrimSpace(resp.Content) == "" && strings.TrimSpace(resp.ReasoningContent) == "") {
 		return &ProbeError{Kind: ProbeErrorNoContent, Model: p.Model}
 	}
 	return nil
@@ -97,7 +97,7 @@ func buildLLMConfig(p *models.AILLMConfig) *llm.Config {
 		Proxy:         p.ExtraConfig.Proxy,
 		Temperature:   p.ExtraConfig.Temperature,
 		MaxTokens:     p.ExtraConfig.MaxTokens,
-		ExtraBody:     p.ExtraConfig.CustomParams,
+		ExtraBody:     llm.NormalizeThinkingParams(p.APIType, p.APIURL, p.Model, p.ExtraConfig.CustomParams),
 	}
 }
 


### PR DESCRIPTION
## Summary

- 修复 LLM Provider 配置页面点击「测试连接」对思考型模型（如 `deepseek-v4-flash`）报错「LLM 未返回有效内容」的问题
- 根因：probe 发送 `max_tokens=5` 的测试请求，思考型模型将全部 token 分配给 `reasoning_content`，`content` 为空；同时 probe 未像实际使用路径一样调用 `NormalizeThinkingParams` 关闭思考模式
- 在 probe 的 `buildLLMConfig` 中补上 `NormalizeThinkingParams`，保持与 `router_ai_assistant.go` 的行为一致；同时在连通性检查中兼容 `reasoning_content` 非空的情况作为防御性兜底

## Changes

| 文件 | 改动 |
|------|------|
| `aiagent/llmconfig/probe.go` | `buildLLMConfig` 调用 `NormalizeThinkingParams`；`Test()` 检查 `reasoning_content` |
| `aiagent/llm/openai.go` | `openAIMessage` 增加 `ReasoningContent` 字段；`convertResponse` 填充该字段 |
| `aiagent/llm/llm.go` | `GenerateResponse` 增加 `ReasoningContent` 字段 |

## Test plan

- [x] 配置 `deepseek-v4-flash` 模型，点击测试连接 → 成功
- [ ] 配置非思考型模型（如 `deepseek-chat`），点击测试连接 → 成功
- [ ] AI 助手对话使用 `deepseek-v4-flash` 模型 → 正常回复


Made with [Cursor](https://cursor.com)