### PR TITLE
fix: specify conflict_target for ON CONFLICT to support OpenGauss-based databases

### DIFF
--- a/models/embedded_product.go
+++ b/models/embedded_product.go
@@ -71,7 +71,10 @@ func AddEmbeddedProduct(ctx *ctx.Context, eps []EmbeddedProduct) error {
 	}
 
 	// 用主键做冲突判断，有冲突则更新（UPSERT）
+	// 磐维数据库(基于OpenGauss/PostgreSQL 9.2)不支持 ON CONFLICT DO UPDATE（无冲突目标）语法，
+	// 必须显式指定冲突列：ON CONFLICT (id) DO UPDATE SET ...
 	return DB(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "id"}},
 		UpdateAll: true, // 冲突时更新所有字段
 	}).Create(&eps).Error
 }

--- a/models/target_busi_group.go
+++ b/models/target_busi_group.go
@@ -83,7 +83,12 @@ func TargetBindBgids(ctx *ctx.Context, idents []string, bgids []int64, tags []st
 	case "sqlite":
 		cl = clause.Insert{Modifier: "or ignore"}
 	case "postgres":
-		cl = clause.OnConflict{DoNothing: true}
+		// 磐维数据库(基于OpenGauss/PostgreSQL 9.2)不支持 ON CONFLICT DO NOTHING（无冲突目标）语法，
+		// 必须显式指定冲突列：ON CONFLICT (target_ident, group_id) DO NOTHING
+		cl = clause.OnConflict{
+			Columns:   []clause.Column{{Name: "target_ident"}, {Name: "group_id"}},
+			DoNothing: true,
+		}
 	}
 
 	return DB(ctx).Transaction(func(tx *gorm.DB) error {
@@ -155,7 +160,12 @@ func TargetOverrideBgids(ctx *ctx.Context, idents []string, bgids []int64, tags 
 		case "sqlite":
 			cl = clause.Insert{Modifier: "or ignore"}
 		case "postgres":
-			cl = clause.OnConflict{DoNothing: true}
+			// 磐维数据库(基于OpenGauss/PostgreSQL 9.2)不支持 ON CONFLICT DO NOTHING（无冲突目标）语法，
+			// 必须显式指定冲突列：ON CONFLICT (target_ident, group_id) DO NOTHING
+			cl = clause.OnConflict{
+				Columns:   []clause.Column{{Name: "target_ident"}, {Name: "group_id"}},
+				DoNothing: true,
+			}
 		}
 		if err := tx.Clauses(cl).CreateInBatches(&lst, 10).Error; err != nil {
 			return err


### PR DESCRIPTION
## Summary
OpenGauss (and databases derived from it, such as China Mobile's PanWei DB, based on PostgreSQL 9.2) do not support the `ON CONFLICT DO NOTHING` / `ON CONFLICT DO UPDATE` syntax without an explicit conflict target.

This commit adds explicit conflict target columns to the affected `clause.OnConflict` clauses.

## Changes
- `models/target_busi_group.go`: `TargetBindBgids()` and `TargetOverrideBgids()`
  - Before: `clause.OnConflict{DoNothing: true}` → generates `ON CONFLICT DO NOTHING` (unsupported by OpenGauss)
  - After: `clause.OnConflict{Columns: [{target_ident}, {group_id}], DoNothing: true}` → generates `ON CONFLICT (target_ident, group_id) DO NOTHING` ✓

- `models/embedded_product.go`: `AddEmbeddedProduct()`
  - Before: `clause.OnConflict{UpdateAll: true}` → generates `ON CONFLICT DO UPDATE SET ...` (unsupported by OpenGauss)
  - After: `clause.OnConflict{Columns: [{id}], UpdateAll: true}` → generates `ON CONFLICT (id) DO UPDATE SET ...` ✓

## Compatibility
These explicit conflict targets are also valid for standard PostgreSQL and do not change behavior on that platform.