### PR TITLE
fix(ormx): support MySQL Unix socket DSN

### DIFF
--- a/pkg/ormx/mysql_dsn_test.go
+++ b/pkg/ormx/mysql_dsn_test.go
@@ -1,0 +1,74 @@
+package ormx
+
+import (
+	"testing"
+
+	mysqlDriver "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseMysqlDatabaseDSN(t *testing.T) {
+	tests := []struct {
+		name     string
+		dsn      string
+		dbName   string
+		net      string
+		addr     string
+		paramKey string
+		paramVal string
+	}{
+		{
+			name:   "TCP",
+			dsn:    "root:1234@tcp(127.0.0.1:3306)/test?charset=utf8mb4&parseTime=True&loc=Local&allowNativePasswords=true",
+			dbName: "test",
+			net:    "tcp",
+			addr:   "127.0.0.1:3306",
+		},
+		{
+			name:   "TCP non-default port",
+			dsn:    "root:1234@tcp(127.0.0.1:3307)/test?charset=utf8mb4&parseTime=True&loc=Local&allowNativePasswords=true",
+			dbName: "test",
+			net:    "tcp",
+			addr:   "127.0.0.1:3307",
+		},
+		{
+			name:   "Unix socket",
+			dsn:    "root:1234@unix(/var/run/mysqld/mysqld.sock)/test?charset=utf8mb4&parseTime=True&loc=Local&allowNativePasswords=true",
+			dbName: "test",
+			net:    "unix",
+			addr:   "/var/run/mysqld/mysqld.sock",
+		},
+		{
+			name:     "Unix socket with slash in query param",
+			dsn:      "root:1234@unix(/var/run/mysqld/mysqld.sock)/test?charset=utf8mb4&arg=/some/path.ext",
+			dbName:   "test",
+			net:      "unix",
+			addr:     "/var/run/mysqld/mysqld.sock",
+			paramKey: "arg",
+			paramVal: "/some/path.ext",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dbName, serverDSN, err := parseMysqlDatabaseDSN(tt.dsn)
+			require.NoError(t, err)
+			require.Equal(t, tt.dbName, dbName)
+
+			cfg, err := mysqlDriver.ParseDSN(serverDSN)
+			require.NoError(t, err)
+			require.Empty(t, cfg.DBName)
+			require.Equal(t, tt.net, cfg.Net)
+			require.Equal(t, tt.addr, cfg.Addr)
+			if tt.paramKey != "" {
+				require.Equal(t, tt.paramVal, cfg.Params[tt.paramKey])
+			}
+		})
+	}
+}
+
+func TestParseMysqlDatabaseDSNWithoutDBName(t *testing.T) {
+	_, _, err := parseMysqlDatabaseDSN("root:1234@tcp(127.0.0.1:3306)/?charset=utf8mb4")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to parse database name from DSN")
+}

--- a/pkg/ormx/ormx.go
+++ b/pkg/ormx/ormx.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/glebarez/sqlite"
+	mysqlDriver "github.com/go-sql-driver/mysql"
 	tklog "github.com/toolkits/pkg/logger"
 	"gorm.io/driver/mysql"
 	"gorm.io/driver/postgres"
@@ -128,26 +129,14 @@ func createPostgresDatabase(dsn string, gconfig *gorm.Config) error {
 }
 
 func createMysqlDatabase(dsn string, gconfig *gorm.Config) error {
-	dsnParts := strings.SplitN(dsn, "/", 2)
-	if len(dsnParts) != 2 {
-		return fmt.Errorf("failed to parse DSN: %s", dsn)
+	dbName, serverDSN, err := parseMysqlDatabaseDSN(dsn)
+	if err != nil {
+		return err
 	}
 
-	connectionInfo := dsnParts[0]
-	dbInfo := dsnParts[1]
-	dbName := dbInfo
-
-	queryIndex := strings.Index(dbInfo, "?")
-	if queryIndex != -1 {
-		dbName = dbInfo[:queryIndex]
-	} else {
-		return fmt.Errorf("failed to parse database name from DSN: %s", dsn)
-	}
-
-	connectionWithoutDB := connectionInfo + "/?" + dbInfo[queryIndex+1:]
 	createDBQuery := fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s CHARACTER SET utf8mb4", dbName)
 
-	tempDialector := mysql.Open(connectionWithoutDB)
+	tempDialector := mysql.Open(serverDSN)
 
 	tempDB, err := gorm.Open(tempDialector, gconfig)
 	if err != nil {
@@ -160,6 +149,21 @@ func createMysqlDatabase(dsn string, gconfig *gorm.Config) error {
 	}
 
 	return nil
+}
+
+func parseMysqlDatabaseDSN(dsn string) (string, string, error) {
+	cfg, err := mysqlDriver.ParseDSN(dsn)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to parse DSN: %s", dsn)
+	}
+
+	dbName := cfg.DBName
+	if dbName == "" {
+		return "", "", fmt.Errorf("failed to parse database name from DSN: %s", dsn)
+	}
+
+	cfg.DBName = ""
+	return dbName, cfg.FormatDSN(), nil
 }
 
 func checkDatabaseExist(c DBConfig) (bool, error) {
@@ -228,30 +232,17 @@ func checkPostgresDatabaseExist(c DBConfig) (bool, error) {
 }
 
 func checkMysqlDatabaseExist(c DBConfig) (bool, error) {
-	dsnParts := strings.SplitN(c.DSN, "/", 2)
-	if len(dsnParts) != 2 {
-		return false, fmt.Errorf("failed to parse DSN: %s", c.DSN)
+	dbName, serverDSN, err := parseMysqlDatabaseDSN(c.DSN)
+	if err != nil {
+		return false, err
 	}
-
-	connectionInfo := dsnParts[0]
-	dbInfo := dsnParts[1]
-	dbName := dbInfo
-
-	queryIndex := strings.Index(dbInfo, "?")
-	if queryIndex != -1 {
-		dbName = dbInfo[:queryIndex]
-	} else {
-		return false, fmt.Errorf("failed to parse database name from DSN: %s", c.DSN)
-	}
-
-	connectionWithoutDB := connectionInfo + "/?" + dbInfo[queryIndex+1:]
 
 	var dialector gorm.Dialector
 	switch strings.ToLower(c.DBType) {
 	case "mysql":
-		dialector = mysql.Open(connectionWithoutDB)
+		dialector = mysql.Open(serverDSN)
 	case "postgres":
-		dialector = postgres.Open(connectionWithoutDB)
+		dialector = postgres.Open(serverDSN)
 	default:
 		return false, fmt.Errorf("unsupported database type: %s", c.DBType)
 	}


### PR DESCRIPTION
**What type of PR is this?**

* Use `go-sql-driver/mysql` to parse MySQL DSNs, avoiding fragile manual string splitting that can break Unix socket paths.
* Reuse the parsed configuration to generate a server-level DSN without a database name, while preserving TCP ports and connection parameters.
* Add unit tests covering TCP connections, Unix socket connections, and DSNs without a database name.


**What this PR does / why we need it**:

This PR uses `go-sql-driver/mysql` to parse MySQL DSNs instead of manually splitting strings, ensuring correct handling of TCP and Unix socket connections.

**Which issue(s) this PR fixes**:

Fixes #3123
 
**Special notes for your reviewer**: