### PR TITLE
fix: copy target update idents before async post

### DIFF
--- a/pushgw/idents/idents.go
+++ b/pushgw/idents/idents.go
@@ -114,7 +114,7 @@ func (s *Set) UpdateTargets(lst []string, now int64) error {
 
 	if !s.ctx.IsCenter {
 		t := TargetUpdate{
-			Lst: lst,
+			Lst: append([]string(nil), lst...),
 			Now: now,
 		}
 


### PR DESCRIPTION
## What

Copy target update idents before posting them asynchronously in edge/non-center mode.

## Why

After `f0e50624` (`refactor: optimize edge ident update`), target updates in non-center mode are posted asynchronously.

The current code stores the caller-owned `lst` slice directly in `TargetUpdate`:

```go
t := TargetUpdate{
    Lst: lst,
    Now: now,
}
go func() {
    err := poster.PostByUrls(s.ctx, "/v1/n9e/target-update", t)
}()
```

However, the caller reuses the same backing array after `UpdateTargets` returns:

```go
lst = lst[:0]
```

The async goroutine may still be JSON-marshalling `t.Lst` while the caller appends the next batch into the same backing array. This causes a data race and may result in corrupted target idents being sent to center.

## Fix

Copy the slice before handing it to the goroutine:

```go
Lst: append([]string(nil), lst...)
```

This keeps the async request payload independent from the reused caller slice.

## Verification

```bash
go test ./pushgw/idents
```

I also verified locally with a race reproducer that the old aliased slice pattern triggers `WARNING: DATA RACE` during `encoding/json.Marshal`, while the copied-slice version passes with `-race`.

## Affected mode

This affects edge/non-center pushgw mode where target idents are posted to center through `/v1/n9e/target-update`.
