### PR TITLE
feat(router): add CheckRuleQueriesPerm hook for alert/recording rule …

### DIFF
--- a/center/router/router_alert_rule.go
+++ b/center/router/router_alert_rule.go
@@ -143,7 +143,7 @@ func (rt *Router) alertRuleAddByFE(c *gin.Context) {
 	}
 
 	bgid := ginx.UrlParamInt64(c, "id")
-	reterr := rt.alertRuleAdd(lst, username, bgid, c.GetHeader("X-Language"))
+	reterr := rt.alertRuleAdd(c, lst, username, bgid, c.GetHeader("X-Language"))
 
 	ginx.NewRender(c).Data(reterr, nil)
 }
@@ -296,9 +296,9 @@ func (rt *Router) alertRuleAddByImport(c *gin.Context) {
 
 	var reterr map[string]string
 	if force {
-		reterr = rt.alertRuleUpsert(lst, username, bgid, lang)
+		reterr = rt.alertRuleUpsert(c, lst, username, bgid, lang)
 	} else {
-		reterr = rt.alertRuleAdd(lst, username, bgid, lang)
+		reterr = rt.alertRuleAdd(c, lst, username, bgid, lang)
 	}
 
 	ginx.NewRender(c).Data(reterr, nil)
@@ -322,7 +322,7 @@ func (rt *Router) alertRuleAddByImportPromRule(c *gin.Context) {
 	lst := models.DealPromGroup(groups, f.DatasourceQueries, f.Disabled)
 	username := c.MustGet("username").(string)
 	bgid := ginx.UrlParamInt64(c, "id")
-	ginx.NewRender(c).Data(rt.alertRuleAdd(lst, username, bgid, c.GetHeader("X-Language")), nil)
+	ginx.NewRender(c).Data(rt.alertRuleAdd(c, lst, username, bgid, c.GetHeader("X-Language")), nil)
 }
 
 func (rt *Router) alertRuleAddByService(c *gin.Context) {
@@ -373,7 +373,7 @@ func (rt *Router) alertRuleAddForService(lst []models.AlertRule, username string
 	return reterr
 }
 
-func (rt *Router) alertRuleAdd(lst []models.AlertRule, username string, bgid int64, lang string) map[string]string {
+func (rt *Router) alertRuleAdd(c *gin.Context, lst []models.AlertRule, username string, bgid int64, lang string) map[string]string {
 	count := len(lst)
 	// alert rule name -> error string
 	reterr := make(map[string]string)
@@ -383,6 +383,11 @@ func (rt *Router) alertRuleAdd(lst []models.AlertRule, username string, bgid int
 		if username != "" {
 			lst[i].CreateBy = username
 			lst[i].UpdateBy = username
+		}
+
+		if err := RuleChangeHook(c, &lst[i]); err != nil {
+			reterr[lst[i].Name] = translateText(lang, err.Error())
+			continue
 		}
 
 		if err := lst[i].FE2DB(); err != nil {
@@ -401,7 +406,7 @@ func (rt *Router) alertRuleAdd(lst []models.AlertRule, username string, bgid int
 
 // alertRuleUpsert 与 alertRuleAdd 对位，命中同名则覆盖；用于 force=true 的导入路径。
 // 注意：FE2DB 由 Upsert 内部按分支调用，这里不要预调用，否则覆盖分支会双调 FE2DB 污染累加型字段（如 EnableDaysOfWeek）。
-func (rt *Router) alertRuleUpsert(lst []models.AlertRule, username string, bgid int64, lang string) map[string]string {
+func (rt *Router) alertRuleUpsert(c *gin.Context, lst []models.AlertRule, username string, bgid int64, lang string) map[string]string {
 	count := len(lst)
 	reterr := make(map[string]string)
 	for i := 0; i < count; i++ {
@@ -410,6 +415,11 @@ func (rt *Router) alertRuleUpsert(lst []models.AlertRule, username string, bgid 
 		if username != "" {
 			lst[i].CreateBy = username // 仅插入路径生效，覆盖路径会被 existing.CreateBy 还原
 			lst[i].UpdateBy = username
+		}
+
+		if err := RuleChangeHook(c, &lst[i]); err != nil {
+			reterr[lst[i].Name] = translateText(lang, err.Error())
+			continue
 		}
 
 		if err := lst[i].Upsert(rt.Ctx); err != nil {
@@ -451,6 +461,10 @@ func (rt *Router) alertRulePutByFE(c *gin.Context) {
 	}
 
 	rt.bgrwCheck(c, ar.GroupId)
+
+	if err := RuleChangeHook(c, &f); err != nil {
+		ginx.Bomb(http.StatusForbidden, "%s", err.Error())
+	}
 
 	f.UpdateBy = c.MustGet("username").(string)
 	ginx.NewRender(c).Message(ar.Update(rt.Ctx, f))

--- a/center/router/router_query.go
+++ b/center/router/router_query.go
@@ -40,6 +40,21 @@ var CheckDsPerm CheckDsPermFunc = func(c *gin.Context, dsId int64, cate string, 
 	return true
 }
 
+// RuleChangeHookFunc 在告警规则、记录规则的创建/保存（add/put/upsert）前调用，
+// 作为可拒绝的守卫（return non-nil error 会中断本次保存并把错误透传给前端）。
+// rule 为 *models.AlertRule 或 *models.RecordingRule。
+//
+// 命名上叫 Hook 而非 CheckXxx，是为了给实现方保留在同一个入口内并联
+// 多种校验维度（权限、配额、命名规范、rule 体积等）的空间，而不必给
+// 每种校验都开一个 upstream 变量。上游只保证"这个入口会在 rule 变更前
+// 被调用一次"，具体校什么由实现方决定。
+type RuleChangeHookFunc func(c *gin.Context, rule interface{}) error
+
+// RuleChangeHook 默认放行所有规则。增强实现由外层注入（如 n9e-plus）。
+var RuleChangeHook RuleChangeHookFunc = func(c *gin.Context, rule interface{}) error {
+	return nil
+}
+
 type QueryFrom struct {
 	Queries []Query `json:"queries"`
 	Exps    []Exp   `json:"exps"`

--- a/center/router/router_recording_rule.go
+++ b/center/router/router_recording_rule.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	"github.com/ccfos/nightingale/v6/models"
-	"github.com/ccfos/nightingale/v6/pkg/strx"
 	"github.com/ccfos/nightingale/v6/pkg/ginx"
+	"github.com/ccfos/nightingale/v6/pkg/strx"
 
 	"github.com/gin-gonic/gin"
 )
@@ -93,6 +93,12 @@ func (rt *Router) recordingRuleAddByFE(c *gin.Context) {
 		lst[i].GroupId = bgid
 		lst[i].CreateBy = username
 		lst[i].UpdateBy = username
+
+		if err := RuleChangeHook(c, &lst[i]); err != nil {
+			reterr[lst[i].Name] = err.Error()
+			continue
+		}
+
 		lst[i].FE2DB()
 
 		if err := lst[i].Add(rt.Ctx); err != nil {
@@ -119,6 +125,10 @@ func (rt *Router) recordingRulePutByFE(c *gin.Context) {
 
 	rt.bgrwCheck(c, ar.GroupId)
 	rt.bgroCheck(c, f.GroupId)
+
+	if err := RuleChangeHook(c, &f); err != nil {
+		ginx.Bomb(http.StatusForbidden, "%s", err.Error())
+	}
 
 	f.UpdateBy = c.MustGet("username").(string)
 	ginx.NewRender(c).Message(ar.Update(rt.Ctx, f))


### PR DESCRIPTION
…add/put

Introduce a CheckRuleQueriesPerm hook in center/router so downstream implementations (e.g. n9e-plus) can validate that the data source resources referenced by each query in an alert/recording rule (such as Doris database.table) are authorized for the current user when the rule is being created or updated.

The hook is invoked from these front-end facing entry points:
- alertRuleAddByFE / alertRuleAddByImport (force=true|false) / alertRuleAddByImportPromRule (all through alertRuleAdd / alertRuleUpsert helpers)
- alertRulePutByFE
- recordingRuleAddByFE / recordingRulePutByFE

Service-token endpoints (*ByService) and field-only patches (*PutFields) are intentionally left untouched to preserve programmatic integration behavior (they have no user context in c.MustGet("user") to authorize against).

The hook signature uses rule interface{} rather than a typed sum so upstream stays free of downstream cate-specific dispatch logic; the default implementation returns nil and is fully backward compatible.

**What type of PR is this?**

**What this PR does / why we need it**:
<!--
"Nice to have" "You need it" is not a good reason. :)
-->

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or "Fixes (paste link of issue)"
-->
Fixes #
 
**Special notes for your reviewer**: