### PR TITLE
feat: add Loki datasource and enrich VictoriaLogs APIs

### DIFF
--- a/center/router/router.go
+++ b/center/router/router.go
@@ -270,6 +270,10 @@ func (rt *Router) Config(r *gin.Engine) {
 			pages.POST("/victorialogs-histogram", rt.QueryVictoriaLogsHistogram)
 			pages.POST("/victorialogs-field-names", rt.QueryVictoriaLogsFieldNames)
 			pages.POST("/victorialogs-field-values", rt.QueryVictoriaLogsFieldValues)
+			pages.POST("/loki-label-names", rt.QueryLokiLabelNames)
+			pages.POST("/loki-label-values", rt.QueryLokiLabelValues)
+			pages.POST("/loki-parsed-fields", rt.QueryLokiParsedFields)
+			pages.POST("/loki-histogram", rt.QueryLokiHistogram)
 
 			pages.POST("/log-query-batch", rt.QueryLogBatch)
 
@@ -303,6 +307,10 @@ func (rt *Router) Config(r *gin.Engine) {
 			pages.POST("/victorialogs-histogram", rt.auth(), rt.user(), rt.QueryVictoriaLogsHistogram)
 			pages.POST("/victorialogs-field-names", rt.auth(), rt.user(), rt.QueryVictoriaLogsFieldNames)
 			pages.POST("/victorialogs-field-values", rt.auth(), rt.user(), rt.QueryVictoriaLogsFieldValues)
+			pages.POST("/loki-label-names", rt.auth(), rt.user(), rt.QueryLokiLabelNames)
+			pages.POST("/loki-label-values", rt.auth(), rt.user(), rt.QueryLokiLabelValues)
+			pages.POST("/loki-parsed-fields", rt.auth(), rt.user(), rt.QueryLokiParsedFields)
+			pages.POST("/loki-histogram", rt.auth(), rt.user(), rt.QueryLokiHistogram)
 
 			pages.POST("/log-query-batch", rt.auth(), rt.user(), rt.QueryLogBatch)
 

--- a/center/router/router.go
+++ b/center/router/router.go
@@ -267,9 +267,9 @@ func (rt *Router) Config(r *gin.Engine) {
 			pages.POST("/iotdb-databases", rt.iotdbDatabases)
 			pages.POST("/iotdb-tables", rt.iotdbTables)
 			pages.POST("/iotdb-columns", rt.iotdbColumns)
-			pages.POST("/victorialogs-stream-fields", rt.QueryVictoriaLogsStreamFields)
-			pages.POST("/victorialogs-stream-field-values", rt.QueryVictoriaLogsStreamFieldValues)
 			pages.POST("/victorialogs-histogram", rt.QueryVictoriaLogsHistogram)
+			pages.POST("/victorialogs-field-names", rt.QueryVictoriaLogsFieldNames)
+			pages.POST("/victorialogs-field-values", rt.QueryVictoriaLogsFieldValues)
 
 			pages.POST("/log-query-batch", rt.QueryLogBatch)
 
@@ -293,9 +293,6 @@ func (rt *Router) Config(r *gin.Engine) {
 
 			pages.POST("/ds-query", rt.auth(), rt.user(), rt.QueryData)
 			pages.POST("/logs-query", rt.auth(), rt.user(), rt.QueryLogV2)
-			pages.POST("/victorialogs-stream-fields", rt.auth(), rt.user(), rt.QueryVictoriaLogsStreamFields)
-			pages.POST("/victorialogs-stream-field-values", rt.auth(), rt.user(), rt.QueryVictoriaLogsStreamFieldValues)
-			pages.POST("/victorialogs-histogram", rt.auth(), rt.user(), rt.QueryVictoriaLogsHistogram)
 
 			pages.POST("/tdengine-databases", rt.auth(), rt.tdengineDatabases)
 			pages.POST("/tdengine-tables", rt.auth(), rt.tdengineTables)
@@ -303,6 +300,9 @@ func (rt *Router) Config(r *gin.Engine) {
 			pages.POST("/iotdb-databases", rt.auth(), rt.iotdbDatabases)
 			pages.POST("/iotdb-tables", rt.auth(), rt.iotdbTables)
 			pages.POST("/iotdb-columns", rt.auth(), rt.iotdbColumns)
+			pages.POST("/victorialogs-histogram", rt.auth(), rt.user(), rt.QueryVictoriaLogsHistogram)
+			pages.POST("/victorialogs-field-names", rt.auth(), rt.user(), rt.QueryVictoriaLogsFieldNames)
+			pages.POST("/victorialogs-field-values", rt.auth(), rt.user(), rt.QueryVictoriaLogsFieldValues)
 
 			pages.POST("/log-query-batch", rt.auth(), rt.user(), rt.QueryLogBatch)
 

--- a/center/router/router.go
+++ b/center/router/router.go
@@ -267,6 +267,9 @@ func (rt *Router) Config(r *gin.Engine) {
 			pages.POST("/iotdb-databases", rt.iotdbDatabases)
 			pages.POST("/iotdb-tables", rt.iotdbTables)
 			pages.POST("/iotdb-columns", rt.iotdbColumns)
+			pages.POST("/victorialogs-stream-fields", rt.QueryVictoriaLogsStreamFields)
+			pages.POST("/victorialogs-stream-field-values", rt.QueryVictoriaLogsStreamFieldValues)
+			pages.POST("/victorialogs-histogram", rt.QueryVictoriaLogsHistogram)
 
 			pages.POST("/log-query-batch", rt.QueryLogBatch)
 
@@ -290,6 +293,9 @@ func (rt *Router) Config(r *gin.Engine) {
 
 			pages.POST("/ds-query", rt.auth(), rt.user(), rt.QueryData)
 			pages.POST("/logs-query", rt.auth(), rt.user(), rt.QueryLogV2)
+			pages.POST("/victorialogs-stream-fields", rt.auth(), rt.user(), rt.QueryVictoriaLogsStreamFields)
+			pages.POST("/victorialogs-stream-field-values", rt.auth(), rt.user(), rt.QueryVictoriaLogsStreamFieldValues)
+			pages.POST("/victorialogs-histogram", rt.auth(), rt.user(), rt.QueryVictoriaLogsHistogram)
 
 			pages.POST("/tdengine-databases", rt.auth(), rt.tdengineDatabases)
 			pages.POST("/tdengine-tables", rt.auth(), rt.tdengineTables)

--- a/center/router/router_loki.go
+++ b/center/router/router_loki.go
@@ -1,0 +1,205 @@
+package router
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/ccfos/nightingale/v6/datasource/loki"
+	"github.com/ccfos/nightingale/v6/dscache"
+	"github.com/ccfos/nightingale/v6/pkg/ginx"
+	"github.com/ccfos/nightingale/v6/pkg/logx"
+
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	lokiDefaultLabelNamesLimit  = 100
+	lokiDefaultLabelValuesLimit = 100
+	lokiDefaultParsedLimit      = 200
+	lokiMaxParsedLimit          = 500
+)
+
+type LokiLabelNamesReq struct {
+	Cate         string `json:"cate"`
+	DatasourceId int64  `json:"datasource_id"`
+	Query        string `json:"query"`
+	Start        int64  `json:"start"`
+	End          int64  `json:"end"`
+	Filter       string `json:"filter"`
+	Limit        int    `json:"limit"`
+}
+
+type LokiLabelValuesReq struct {
+	Cate         string `json:"cate"`
+	DatasourceId int64  `json:"datasource_id"`
+	Query        string `json:"query"`
+	Start        int64  `json:"start"`
+	End          int64  `json:"end"`
+	Label        string `json:"label"`
+	Filter       string `json:"filter"`
+	Limit        int    `json:"limit"`
+}
+
+type LokiParsedFieldsReq struct {
+	Cate         string `json:"cate"`
+	DatasourceId int64  `json:"datasource_id"`
+	Query        string `json:"query"`
+	Start        int64  `json:"start"`
+	End          int64  `json:"end"`
+	Limit        int    `json:"limit"`
+}
+
+type LokiHistogramReq struct {
+	Cate         string                `json:"cate"`
+	DatasourceId int64                 `json:"datasource_id"`
+	Query        []loki.HistogramQuery `json:"query"`
+}
+
+func (rt *Router) QueryLokiLabelNames(c *gin.Context) {
+	var f LokiLabelNamesReq
+	ginx.BindJSON(c, &f)
+
+	validateLokiTimeRange(f.Start, f.End)
+	f.Limit = validateLokiLimit(f.Limit, lokiDefaultLabelNamesLimit)
+	if !rt.Center.AnonymousAccess.PromQuerier && !CheckDsPerm(c, f.DatasourceId, f.Cate, f) {
+		ginx.Bomb(403, "no permission")
+	}
+
+	vl := getLoki(c, f.Cate, f.DatasourceId)
+	ctx := withCallContext(c.Request.Context(), f.DatasourceId, ginUser(c))
+	ret, err := vl.QueryLabelNames(ctx, f.Query, f.Start, f.End, f.Filter, f.Limit)
+	ginx.Dangerous(err)
+	sort.Strings(ret)
+
+	ginx.NewRender(c).Data(ret, nil)
+}
+
+func (rt *Router) QueryLokiLabelValues(c *gin.Context) {
+	var f LokiLabelValuesReq
+	ginx.BindJSON(c, &f)
+
+	validateLokiLabel(f.Label)
+	validateLokiTimeRange(f.Start, f.End)
+	f.Limit = validateLokiLimit(f.Limit, lokiDefaultLabelValuesLimit)
+	if !rt.Center.AnonymousAccess.PromQuerier && !CheckDsPerm(c, f.DatasourceId, f.Cate, f) {
+		ginx.Bomb(403, "no permission")
+	}
+
+	vl := getLoki(c, f.Cate, f.DatasourceId)
+	ctx := withCallContext(c.Request.Context(), f.DatasourceId, ginUser(c))
+	ret, err := vl.QueryLabelValues(ctx, f.Query, f.Start, f.End, f.Label, f.Filter, f.Limit)
+	ginx.Dangerous(err)
+	sort.Slice(ret, func(i, j int) bool {
+		return ret[i].Value < ret[j].Value
+	})
+
+	ginx.NewRender(c).Data(ret, nil)
+}
+
+func (rt *Router) QueryLokiParsedFields(c *gin.Context) {
+	var f LokiParsedFieldsReq
+	ginx.BindJSON(c, &f)
+
+	if strings.TrimSpace(f.Query) == "" {
+		ginx.Bomb(http.StatusBadRequest, "query is required")
+	}
+	validateLokiTimeRange(f.Start, f.End)
+	f.Limit = validateLokiParsedLimit(f.Limit)
+	if !rt.Center.AnonymousAccess.PromQuerier && !CheckDsPerm(c, f.DatasourceId, f.Cate, f) {
+		ginx.Bomb(403, "no permission")
+	}
+
+	vl := getLoki(c, f.Cate, f.DatasourceId)
+	ctx := withCallContext(c.Request.Context(), f.DatasourceId, ginUser(c))
+	ret, err := vl.QueryParsedFields(ctx, f.Query, f.Start, f.End, f.Limit)
+	ginx.Dangerous(err)
+	sort.Slice(ret, func(i, j int) bool {
+		return ret[i].Field < ret[j].Field
+	})
+
+	ginx.NewRender(c).Data(ret, nil)
+}
+
+func (rt *Router) QueryLokiHistogram(c *gin.Context) {
+	var f LokiHistogramReq
+	ginx.BindJSON(c, &f)
+
+	if len(f.Query) == 0 {
+		ginx.Bomb(http.StatusBadRequest, "query is required")
+	}
+
+	vl := getLoki(c, f.Cate, f.DatasourceId)
+	ret := make([]loki.HistogramValues, 0)
+	for _, q := range f.Query {
+		if strings.TrimSpace(q.Query) == "" {
+			ginx.Bomb(http.StatusBadRequest, "query is required")
+		}
+		validateLokiTimeRange(q.Start, q.End)
+		if !rt.Center.AnonymousAccess.PromQuerier && !CheckDsPerm(c, f.DatasourceId, f.Cate, q) {
+			ginx.Bomb(403, "no permission")
+		}
+
+		ctx := withCallContext(c.Request.Context(), f.DatasourceId, ginUser(c))
+		data, err := vl.QueryHistogram(ctx, q)
+		ginx.Dangerous(err)
+		ret = append(ret, data...)
+	}
+
+	ginx.NewRender(c).Data(ret, nil)
+}
+
+func validateLokiTimeRange(start, end int64) {
+	if start <= 0 || end <= start {
+		ginx.Bomb(http.StatusBadRequest, "invalid time range")
+	}
+}
+
+func validateLokiLimit(limit, defaultLimit int) int {
+	if limit <= 0 {
+		return defaultLimit
+	}
+	if limit > 1000 {
+		return 1000
+	}
+	return limit
+}
+
+func validateLokiParsedLimit(limit int) int {
+	if limit <= 0 {
+		return lokiDefaultParsedLimit
+	}
+	if limit > lokiMaxParsedLimit {
+		return lokiMaxParsedLimit
+	}
+	return limit
+}
+
+func validateLokiLabel(label string) {
+	if strings.TrimSpace(label) == "" {
+		ginx.Bomb(http.StatusBadRequest, "label is required")
+	}
+	if len(label) > 512 {
+		ginx.Bomb(http.StatusBadRequest, "label is too long")
+	}
+	for _, r := range label {
+		if r < 32 || r == 127 {
+			ginx.Bomb(http.StatusBadRequest, "invalid label")
+		}
+	}
+}
+
+func getLoki(c *gin.Context, cate string, datasourceId int64) *loki.Loki {
+	plug, exists := dscache.DsCache.Get(cate, datasourceId)
+	if !exists {
+		logx.Warningf(c.Request.Context(), "cluster:%d not exists", datasourceId)
+		ginx.Bomb(200, "cluster not exists")
+	}
+
+	vl, ok := plug.(*loki.Loki)
+	if !ok {
+		ginx.Bomb(200, "cluster not loki")
+	}
+
+	return vl
+}

--- a/center/router/router_victorialogs.go
+++ b/center/router/router_victorialogs.go
@@ -13,18 +13,26 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-type VictoriaLogsStreamFieldsReq struct {
+const (
+	victoriaLogsDefaultFieldNamesLimit  = 50
+	victoriaLogsDefaultFieldValuesLimit = 20
+)
+
+type VictoriaLogsFieldNamesReq struct {
 	Cate         string `json:"cate"`
 	DatasourceId int64  `json:"datasource_id"`
+	Scope        string `json:"scope"`
 	Query        string `json:"query"`
 	Start        int64  `json:"start"`
 	End          int64  `json:"end"`
 	Filter       string `json:"filter"`
+	Limit        int    `json:"limit"`
 }
 
-type VictoriaLogsStreamFieldValuesReq struct {
+type VictoriaLogsFieldValuesReq struct {
 	Cate         string `json:"cate"`
 	DatasourceId int64  `json:"datasource_id"`
+	Scope        string `json:"scope"`
 	Query        string `json:"query"`
 	Start        int64  `json:"start"`
 	End          int64  `json:"end"`
@@ -39,52 +47,93 @@ type VictoriaLogsHistogramReq struct {
 	Query        []victorialogs.HistogramQuery `json:"query"`
 }
 
-func (rt *Router) QueryVictoriaLogsStreamFields(c *gin.Context) {
-	var f VictoriaLogsStreamFieldsReq
+func (rt *Router) QueryVictoriaLogsFieldNames(c *gin.Context) {
+	var f VictoriaLogsFieldNamesReq
 	ginx.BindJSON(c, &f)
 
+	if strings.TrimSpace(f.Query) == "" {
+		ginx.Bomb(http.StatusBadRequest, "query is required")
+	}
 	validateVictoriaLogsTimeRange(f.Start, f.End)
+	f.Limit = validateVictoriaLogsLimit(f.Limit, victoriaLogsDefaultFieldNamesLimit)
+	f.Scope = normalizeVictoriaLogsFieldScope(f.Scope)
 
 	if !rt.Center.AnonymousAccess.PromQuerier && !CheckDsPerm(c, f.DatasourceId, f.Cate, f) {
 		ginx.Bomb(403, "no permission")
 	}
 
 	vl := getVictoriaLogs(c, f.Cate, f.DatasourceId)
-	fields, err := vl.StreamFieldNames(c.Request.Context(), f.Query, f.Start, f.End, f.Filter)
+	if f.Scope == "stream_field" {
+		fields, err := vl.StreamFieldNames(c.Request.Context(), f.Query, f.Start, f.End, f.Filter)
+		ginx.Dangerous(err)
+
+		ret := make([]string, 0, len(fields))
+		for _, field := range fields {
+			ret = append(ret, field.Value)
+		}
+		sort.Strings(ret)
+
+		ginx.NewRender(c).Data(ret, nil)
+		return
+	}
+
+	fields, err := vl.QueryFieldNames(c.Request.Context(), f.Query, f.Start, f.End, f.Limit, f.Filter)
 	ginx.Dangerous(err)
 
-	ret := make([]string, 0, len(fields))
+	ret := make([]victorialogs.FieldName, 0, len(fields))
 	for _, field := range fields {
-		ret = append(ret, field.Value)
+		if isVictoriaLogsBuilderSuggestionBlockedField(field.Field) {
+			continue
+		}
+		field.Builtin = false
+		ret = append(ret, field)
 	}
-	sort.Strings(ret)
+	sort.Slice(ret, func(i, j int) bool {
+		return ret[i].Field < ret[j].Field
+	})
 
 	ginx.NewRender(c).Data(ret, nil)
 }
 
-func (rt *Router) QueryVictoriaLogsStreamFieldValues(c *gin.Context) {
-	var f VictoriaLogsStreamFieldValuesReq
+func (rt *Router) QueryVictoriaLogsFieldValues(c *gin.Context) {
+	var f VictoriaLogsFieldValuesReq
 	ginx.BindJSON(c, &f)
 
-	if f.Field == "" {
-		ginx.Bomb(http.StatusBadRequest, "field is required")
+	if strings.TrimSpace(f.Query) == "" {
+		ginx.Bomb(http.StatusBadRequest, "query is required")
 	}
+	validateVictoriaLogsField(f.Field)
 	validateVictoriaLogsTimeRange(f.Start, f.End)
+	f.Limit = validateVictoriaLogsLimit(f.Limit, victoriaLogsDefaultFieldValuesLimit)
+	f.Scope = normalizeVictoriaLogsFieldScope(f.Scope)
 
 	if !rt.Center.AnonymousAccess.PromQuerier && !CheckDsPerm(c, f.DatasourceId, f.Cate, f) {
 		ginx.Bomb(403, "no permission")
 	}
 
 	vl := getVictoriaLogs(c, f.Cate, f.DatasourceId)
-	values, err := vl.StreamFieldValues(c.Request.Context(), f.Query, f.Start, f.End, f.Field, f.Limit, f.Filter)
-	ginx.Dangerous(err)
+	if f.Scope == "stream_field" {
+		values, err := vl.StreamFieldValues(c.Request.Context(), f.Query, f.Start, f.End, f.Field, f.Limit, f.Filter)
+		ginx.Dangerous(err)
 
-	ret := make([]string, 0, len(values))
-	for _, value := range values {
-		ret = append(ret, value.Value)
+		ret := make([]string, 0, len(values))
+		for _, value := range values {
+			ret = append(ret, value.Value)
+		}
+
+		ginx.NewRender(c).Data(ret, nil)
+		return
 	}
 
-	ginx.NewRender(c).Data(ret, nil)
+	if isVictoriaLogsBuilderSuggestionBlockedField(f.Field) {
+		ginx.NewRender(c).Data([]victorialogs.FieldValue{}, nil)
+		return
+	}
+
+	values, err := vl.QueryFieldValues(c.Request.Context(), f.Query, f.Start, f.End, f.Field, f.Limit, f.Filter)
+	ginx.Dangerous(err)
+
+	ginx.NewRender(c).Data(values, nil)
 }
 
 func (rt *Router) QueryVictoriaLogsHistogram(c *gin.Context) {
@@ -122,6 +171,53 @@ func validateVictoriaLogsTimeRange(start, end int64) {
 	if start <= 0 || end <= start {
 		ginx.Bomb(http.StatusBadRequest, "invalid time range")
 	}
+}
+
+func validateVictoriaLogsLimit(limit, defaultLimit int) int {
+	if limit <= 0 {
+		return defaultLimit
+	}
+	if limit > 100 {
+		return 100
+	}
+	return limit
+}
+
+func normalizeVictoriaLogsFieldScope(scope string) string {
+	switch scope {
+	case "", "field":
+		return "field"
+	case "stream_field":
+		return "stream_field"
+	default:
+		ginx.Bomb(http.StatusBadRequest, "invalid scope")
+		return "field"
+	}
+}
+
+func validateVictoriaLogsField(field string) {
+	if strings.TrimSpace(field) == "" {
+		ginx.Bomb(http.StatusBadRequest, "field is required")
+	}
+	if len(field) > 512 {
+		ginx.Bomb(http.StatusBadRequest, "field is too long")
+	}
+	for _, r := range field {
+		if r < 32 || r == 127 {
+			ginx.Bomb(http.StatusBadRequest, "invalid field")
+		}
+	}
+}
+
+func isVictoriaLogsBuilderSuggestionBlockedField(field string) bool {
+	switch field {
+	case "_time", "_msg", "_stream", "_stream_id":
+		return true
+	}
+	if strings.HasPrefix(field, "_stream.") {
+		return true
+	}
+	return false
 }
 
 func getVictoriaLogs(c *gin.Context, cate string, datasourceId int64) *victorialogs.VictoriaLogs {

--- a/center/router/router_victorialogs.go
+++ b/center/router/router_victorialogs.go
@@ -1,0 +1,140 @@
+package router
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/ccfos/nightingale/v6/datasource/victorialogs"
+	"github.com/ccfos/nightingale/v6/dscache"
+	"github.com/ccfos/nightingale/v6/pkg/ginx"
+	"github.com/ccfos/nightingale/v6/pkg/logx"
+
+	"github.com/gin-gonic/gin"
+)
+
+type VictoriaLogsStreamFieldsReq struct {
+	Cate         string `json:"cate"`
+	DatasourceId int64  `json:"datasource_id"`
+	Query        string `json:"query"`
+	Start        int64  `json:"start"`
+	End          int64  `json:"end"`
+	Filter       string `json:"filter"`
+}
+
+type VictoriaLogsStreamFieldValuesReq struct {
+	Cate         string `json:"cate"`
+	DatasourceId int64  `json:"datasource_id"`
+	Query        string `json:"query"`
+	Start        int64  `json:"start"`
+	End          int64  `json:"end"`
+	Field        string `json:"field"`
+	Limit        int    `json:"limit"`
+	Filter       string `json:"filter"`
+}
+
+type VictoriaLogsHistogramReq struct {
+	Cate         string                        `json:"cate"`
+	DatasourceId int64                         `json:"datasource_id"`
+	Query        []victorialogs.HistogramQuery `json:"query"`
+}
+
+func (rt *Router) QueryVictoriaLogsStreamFields(c *gin.Context) {
+	var f VictoriaLogsStreamFieldsReq
+	ginx.BindJSON(c, &f)
+
+	validateVictoriaLogsTimeRange(f.Start, f.End)
+
+	if !rt.Center.AnonymousAccess.PromQuerier && !CheckDsPerm(c, f.DatasourceId, f.Cate, f) {
+		ginx.Bomb(403, "no permission")
+	}
+
+	vl := getVictoriaLogs(c, f.Cate, f.DatasourceId)
+	fields, err := vl.StreamFieldNames(c.Request.Context(), f.Query, f.Start, f.End, f.Filter)
+	ginx.Dangerous(err)
+
+	ret := make([]string, 0, len(fields))
+	for _, field := range fields {
+		ret = append(ret, field.Value)
+	}
+	sort.Strings(ret)
+
+	ginx.NewRender(c).Data(ret, nil)
+}
+
+func (rt *Router) QueryVictoriaLogsStreamFieldValues(c *gin.Context) {
+	var f VictoriaLogsStreamFieldValuesReq
+	ginx.BindJSON(c, &f)
+
+	if f.Field == "" {
+		ginx.Bomb(http.StatusBadRequest, "field is required")
+	}
+	validateVictoriaLogsTimeRange(f.Start, f.End)
+
+	if !rt.Center.AnonymousAccess.PromQuerier && !CheckDsPerm(c, f.DatasourceId, f.Cate, f) {
+		ginx.Bomb(403, "no permission")
+	}
+
+	vl := getVictoriaLogs(c, f.Cate, f.DatasourceId)
+	values, err := vl.StreamFieldValues(c.Request.Context(), f.Query, f.Start, f.End, f.Field, f.Limit, f.Filter)
+	ginx.Dangerous(err)
+
+	ret := make([]string, 0, len(values))
+	for _, value := range values {
+		ret = append(ret, value.Value)
+	}
+
+	ginx.NewRender(c).Data(ret, nil)
+}
+
+func (rt *Router) QueryVictoriaLogsHistogram(c *gin.Context) {
+	var f VictoriaLogsHistogramReq
+	ginx.BindJSON(c, &f)
+
+	if len(f.Query) == 0 {
+		ginx.Bomb(http.StatusBadRequest, "query is required")
+	}
+
+	for _, q := range f.Query {
+		if strings.TrimSpace(q.Query) == "" {
+			ginx.Bomb(http.StatusBadRequest, "query is required")
+		}
+		validateVictoriaLogsTimeRange(q.Start, q.End)
+	}
+
+	vl := getVictoriaLogs(c, f.Cate, f.DatasourceId)
+	ret := make([]victorialogs.HistogramValues, 0)
+
+	for _, q := range f.Query {
+		if !rt.Center.AnonymousAccess.PromQuerier && !CheckDsPerm(c, f.DatasourceId, f.Cate, q) {
+			ginx.Bomb(403, "no permission")
+		}
+
+		data, err := vl.QueryHistogram(c.Request.Context(), q)
+		ginx.Dangerous(err)
+		ret = append(ret, data...)
+	}
+
+	ginx.NewRender(c).Data(ret, nil)
+}
+
+func validateVictoriaLogsTimeRange(start, end int64) {
+	if start <= 0 || end <= start {
+		ginx.Bomb(http.StatusBadRequest, "invalid time range")
+	}
+}
+
+func getVictoriaLogs(c *gin.Context, cate string, datasourceId int64) *victorialogs.VictoriaLogs {
+	plug, exists := dscache.DsCache.Get(cate, datasourceId)
+	if !exists {
+		logx.Warningf(c.Request.Context(), "cluster:%d not exists", datasourceId)
+		ginx.Bomb(200, "cluster not exists")
+	}
+
+	vl, ok := plug.(*victorialogs.VictoriaLogs)
+	if !ok {
+		ginx.Bomb(200, "cluster not victorialogs")
+	}
+
+	return vl
+}

--- a/center/router/router_victorialogs.go
+++ b/center/router/router_victorialogs.go
@@ -85,7 +85,6 @@ func (rt *Router) QueryVictoriaLogsFieldNames(c *gin.Context) {
 		if isVictoriaLogsBuilderSuggestionBlockedField(field.Field) {
 			continue
 		}
-		field.Builtin = false
 		ret = append(ret, field)
 	}
 	sort.Slice(ret, func(i, j int) bool {

--- a/datasource/datasource.go
+++ b/datasource/datasource.go
@@ -81,6 +81,13 @@ func init() {
 		PluginType:     "iotdb",
 		PluginTypeName: "IoTDB",
 	}
+
+	DatasourceTypes[9] = DatasourceType{
+		Id:             9,
+		Category:       "logging",
+		PluginType:     "loki",
+		PluginTypeName: "Loki",
+	}
 }
 
 type NewDatasourceFn func(settings map[string]interface{}) (Datasource, error)

--- a/datasource/loki/loki.go
+++ b/datasource/loki/loki.go
@@ -1,0 +1,576 @@
+package loki
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ccfos/nightingale/v6/datasource"
+	lokikit "github.com/ccfos/nightingale/v6/dskit/loki"
+	dskittypes "github.com/ccfos/nightingale/v6/dskit/types"
+	"github.com/ccfos/nightingale/v6/models"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/prometheus/common/model"
+)
+
+const (
+	LokiType            = "loki"
+	LokiDefaultLogLimit = 500
+)
+
+type Loki struct {
+	lokikit.Loki `json:",inline" mapstructure:",squash"`
+}
+
+type Query struct {
+	Query     string `json:"query" mapstructure:"query"`
+	Start     int64  `json:"start" mapstructure:"start"`
+	End       int64  `json:"end" mapstructure:"end"`
+	Time      int64  `json:"time" mapstructure:"time"`
+	Step      string `json:"step" mapstructure:"step"`
+	Limit     int    `json:"limit" mapstructure:"limit"`
+	Direction string `json:"direction" mapstructure:"direction"`
+	Ref       string `json:"ref" mapstructure:"ref"`
+}
+
+type HistogramQuery struct {
+	Query       string `json:"query" mapstructure:"query"`
+	Start       int64  `json:"start" mapstructure:"start"`
+	End         int64  `json:"end" mapstructure:"end"`
+	Step        string `json:"step" mapstructure:"step"`
+	GroupBy     string `json:"group_by" mapstructure:"group_by"`
+	FieldsLimit int    `json:"fields_limit" mapstructure:"fields_limit"`
+}
+
+type HistogramValues struct {
+	Ref    string                 `json:"ref"`
+	Metric map[string]interface{} `json:"metric"`
+	Values [][]interface{}        `json:"values"`
+}
+
+type LabelValue = lokikit.LabelValue
+type FieldMeta = lokikit.FieldMeta
+
+func (q *Query) IsInstantQuery() bool {
+	return q.Time > 0 || (q.Start >= 0 && q.Start == q.End)
+}
+
+func init() {
+	datasource.RegisterDatasource(LokiType, new(Loki))
+}
+
+func (vl *Loki) Init(settings map[string]interface{}) (datasource.Datasource, error) {
+	newest := new(Loki)
+	err := mapstructure.Decode(settings, newest)
+	return newest, err
+}
+
+func (vl *Loki) InitClient() error {
+	if err := vl.InitHTTPClient(); err != nil {
+		return fmt.Errorf("failed to init loki http client: %w", err)
+	}
+	return nil
+}
+
+func (vl *Loki) Validate(ctx context.Context) error {
+	if strings.TrimSpace(vl.LokiAddr) == "" {
+		return fmt.Errorf("loki.addr is required")
+	}
+	if _, err := url.Parse(vl.LokiAddr); err != nil {
+		return fmt.Errorf("invalid loki.addr: %w", err)
+	}
+	if (vl.LokiBasic.LokiUser != "" && vl.LokiBasic.LokiPass == "") ||
+		(vl.LokiBasic.LokiUser == "" && vl.LokiBasic.LokiPass != "") {
+		return fmt.Errorf("both username and password must be provided")
+	}
+	if vl.Timeout == 0 {
+		vl.Timeout = 10000
+	}
+	if vl.MaxQueryRows == 0 {
+		vl.MaxQueryRows = LokiDefaultLogLimit
+	}
+	return nil
+}
+
+func (vl *Loki) Equal(other datasource.Datasource) bool {
+	o, ok := other.(*Loki)
+	if !ok {
+		return false
+	}
+	return vl.LokiAddr == o.LokiAddr &&
+		vl.LokiBasic.LokiUser == o.LokiBasic.LokiUser &&
+		vl.LokiBasic.LokiPass == o.LokiBasic.LokiPass &&
+		vl.LokiTls.SkipTlsVerify == o.LokiTls.SkipTlsVerify &&
+		vl.Timeout == o.Timeout &&
+		vl.MaxQueryRows == o.MaxQueryRows &&
+		vl.ClusterName == o.ClusterName &&
+		reflect.DeepEqual(vl.Headers, o.Headers)
+}
+
+func (vl *Loki) QueryLog(ctx context.Context, queryParam interface{}) ([]interface{}, int64, error) {
+	param := new(Query)
+	if err := mapstructure.Decode(queryParam, param); err != nil {
+		return nil, 0, fmt.Errorf("decode query param failed: %w", err)
+	}
+	param.Limit = vl.normalizeLogLimit(param.Limit)
+	if param.Direction == "" {
+		param.Direction = "backward"
+	}
+
+	result, err := vl.QueryRange(ctx, param.Query, param.Start, param.End, param.Step, param.Limit, param.Direction)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	logs := lokikit.NormalizeLogs(result)
+	sortLokiLogs(logs, param.Direction)
+	ret := make([]interface{}, 0, len(logs))
+	for _, log := range logs {
+		ret = append(ret, log)
+	}
+
+	total, err := vl.countLogs(ctx, param.Query, param.Start, param.End)
+	if err != nil {
+		return nil, 0, fmt.Errorf("count matching logs failed: %w", err)
+	}
+
+	return ret, total, nil
+}
+
+func (vl *Loki) QueryData(ctx context.Context, queryParam interface{}) ([]models.DataResp, error) {
+	param := new(Query)
+	if err := mapstructure.Decode(queryParam, param); err != nil {
+		return nil, fmt.Errorf("decode query param failed: %w", err)
+	}
+
+	var result *lokikit.QueryResponse
+	var err error
+	if param.IsInstantQuery() {
+		queryTime := param.Time
+		if queryTime == 0 {
+			queryTime = param.End
+		}
+		if queryTime == 0 {
+			queryTime = time.Now().Unix()
+		}
+		result, err = vl.QueryInstant(ctx, param.Query, queryTime)
+	} else {
+		result, err = vl.QueryRange(ctx, param.Query, param.Start, param.End, param.Step, 0, "")
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return convertLokiToDataResp(result, param.Ref), nil
+}
+
+func (vl *Loki) QueryLabelNames(ctx context.Context, query string, start, end int64, filter string, limit int) ([]string, error) {
+	return vl.LabelNames(ctx, query, start, end, filter, limit)
+}
+
+func (vl *Loki) QueryLabelValues(ctx context.Context, query string, start, end int64, label, filter string, limit int) ([]LabelValue, error) {
+	return vl.LabelValues(ctx, query, start, end, label, filter, limit)
+}
+
+func (vl *Loki) QueryParsedFields(ctx context.Context, query string, start, end int64, limit int) ([]FieldMeta, error) {
+	return vl.ParsedFields(ctx, query, start, end, limit)
+}
+
+func (vl *Loki) QueryHistogram(ctx context.Context, queryParam interface{}) ([]HistogramValues, error) {
+	param := new(HistogramQuery)
+	if err := mapstructure.Decode(queryParam, param); err != nil {
+		return nil, fmt.Errorf("decode query param failed: %w", err)
+	}
+	if param.Step == "" {
+		param.Step = defaultHistogramStep(param.Start, param.End)
+	}
+
+	logql := buildHistogramQuery(param.Query, param.Step, param.GroupBy)
+	result, err := vl.QueryRange(ctx, logql, param.Start, param.End, param.Step, 0, "")
+	if err != nil {
+		return nil, err
+	}
+
+	return limitHistogramValues(convertLokiHistogram(result, param.GroupBy), param.GroupBy, param.FieldsLimit), nil
+}
+
+func defaultHistogramStep(start, end int64) string {
+	return dskittypes.DefaultHistogramStep(normalizeUnixTimestamp(float64(start)), normalizeUnixTimestamp(float64(end)))
+}
+
+func buildHistogramQuery(query, step, groupBy string) string {
+	rangeQuery := fmt.Sprintf("count_over_time(%s [%s])", strings.TrimSpace(query), step)
+	if strings.TrimSpace(groupBy) == "" {
+		return fmt.Sprintf("sum(%s)", rangeQuery)
+	}
+	return fmt.Sprintf("sum by (%s) (%s)", groupBy, rangeQuery)
+}
+
+func (vl *Loki) countLogs(ctx context.Context, query string, start, end int64) (int64, error) {
+	logql, ok := buildLogCountQuery(query, start, end)
+	if !ok {
+		return 0, fmt.Errorf("invalid time range")
+	}
+
+	result, err := vl.QueryInstant(ctx, logql, end)
+	if err != nil {
+		return 0, err
+	}
+
+	var total float64
+	for _, item := range result.Data.Result {
+		if len(item.Value) != 2 {
+			continue
+		}
+		sample, ok := parseSampleValue(item.Value[1])
+		if !ok {
+			continue
+		}
+		total += sample
+	}
+	return int64(total), nil
+}
+
+func buildLogCountQuery(query string, start, end int64) (string, bool) {
+	rangeSeconds := normalizeUnixTimestamp(float64(end)) - normalizeUnixTimestamp(float64(start))
+	if strings.TrimSpace(query) == "" || rangeSeconds <= 0 {
+		return "", false
+	}
+	return fmt.Sprintf("sum(count_over_time(%s [%ds]))", strings.TrimSpace(query), rangeSeconds), true
+}
+
+func sortLokiLogs(logs []lokikit.NormalizedLog, direction string) {
+	desc := strings.EqualFold(direction, "backward") || direction == ""
+	sort.SliceStable(logs, func(i, j int) bool {
+		left := normalizedLogTimestampMillis(logs[i])
+		right := normalizedLogTimestampMillis(logs[j])
+		if desc {
+			return left > right
+		}
+		return left < right
+	})
+}
+
+func normalizedLogTimestampMillis(log lokikit.NormalizedLog) int64 {
+	switch value := log["timestamp"].(type) {
+	case int64:
+		return value
+	case int:
+		return int64(value)
+	case float64:
+		return int64(value)
+	case string:
+		ts, _ := strconv.ParseInt(value, 10, 64)
+		return ts
+	default:
+		return 0
+	}
+}
+
+func convertLokiToDataResp(resp *lokikit.QueryResponse, ref string) []models.DataResp {
+	if resp == nil {
+		return nil
+	}
+
+	ret := make([]models.DataResp, 0, len(resp.Data.Result))
+	for _, item := range resp.Data.Result {
+		dataResp := models.DataResp{
+			Ref: ref,
+		}
+		metric := item.Metric
+		if len(metric) == 0 {
+			metric = item.Stream
+		}
+		dataResp.Metric = make(model.Metric, len(metric))
+		for k, v := range metric {
+			dataResp.Metric[model.LabelName(k)] = model.LabelValue(v)
+		}
+
+		if len(item.Value) == 2 {
+			timestamp, ok := parseSampleTimestamp(item.Value[0])
+			if !ok {
+				continue
+			}
+			value, ok := parseSampleValue(item.Value[1])
+			if !ok {
+				continue
+			}
+			dataResp.Values = [][]float64{{timestamp, value}}
+		}
+
+		for _, value := range item.Values {
+			if len(value) != 2 {
+				continue
+			}
+			timestamp, ok := parseSampleTimestamp(value[0])
+			if !ok {
+				continue
+			}
+			sample, ok := parseSampleValue(value[1])
+			if !ok {
+				continue
+			}
+			dataResp.Values = append(dataResp.Values, []float64{timestamp, sample})
+		}
+
+		ret = append(ret, dataResp)
+	}
+	return ret
+}
+
+func convertLokiHistogram(resp *lokikit.QueryResponse, groupBy string) []HistogramValues {
+	if resp == nil {
+		return nil
+	}
+
+	ret := make([]HistogramValues, 0, len(resp.Data.Result))
+	for _, item := range resp.Data.Result {
+		metric := make(map[string]interface{}, len(item.Metric))
+		for k, v := range item.Metric {
+			metric[k] = v
+		}
+
+		values := make([][]interface{}, 0, len(item.Values))
+		for _, value := range item.Values {
+			if len(value) != 2 {
+				continue
+			}
+			timestamp, ok := parseSampleTimestamp(value[0])
+			if !ok {
+				continue
+			}
+			sample, ok := parseSampleValue(value[1])
+			if !ok {
+				values = append(values, []interface{}{int64(timestamp), nil})
+				continue
+			}
+			values = append(values, []interface{}{int64(timestamp), sample})
+		}
+
+		ret = append(ret, HistogramValues{
+			Ref:    histogramRef(item.Metric, groupBy),
+			Metric: metric,
+			Values: values,
+		})
+	}
+	return ret
+}
+
+func limitHistogramValues(values []HistogramValues, groupBy string, limit int) []HistogramValues {
+	if strings.TrimSpace(groupBy) == "" || limit <= 0 || len(values) <= limit {
+		return values
+	}
+
+	sort.SliceStable(values, func(i, j int) bool {
+		left := histogramValuesTotal(values[i])
+		right := histogramValuesTotal(values[j])
+		if left == right {
+			return values[i].Ref < values[j].Ref
+		}
+		return left > right
+	})
+
+	return values[:limit]
+}
+
+func histogramValuesTotal(value HistogramValues) float64 {
+	var total float64
+	for _, point := range value.Values {
+		if len(point) == 2 {
+			sample, _ := parseSampleValue(point[1])
+			total += sample
+		}
+	}
+	return total
+}
+
+func parseSampleTimestamp(value interface{}) (float64, bool) {
+	switch v := value.(type) {
+	case float64:
+		return float64(normalizeUnixTimestamp(v)), true
+	case int64:
+		return float64(normalizeUnixTimestamp(float64(v))), true
+	case int:
+		return float64(normalizeUnixTimestamp(float64(v))), true
+	case string:
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			return float64(normalizeUnixTimestamp(f)), true
+		}
+		if t, err := time.Parse(time.RFC3339Nano, v); err == nil {
+			return float64(t.Unix()), true
+		}
+		if t, err := time.Parse(time.RFC3339, v); err == nil {
+			return float64(t.Unix()), true
+		}
+	}
+	return 0, false
+}
+
+func parseSampleValue(value interface{}) (float64, bool) {
+	switch v := value.(type) {
+	case nil:
+		return 0, false
+	case float64:
+		return v, true
+	case int64:
+		return float64(v), true
+	case int:
+		return float64(v), true
+	case string:
+		f, err := strconv.ParseFloat(v, 64)
+		return f, err == nil
+	default:
+		return 0, false
+	}
+}
+
+func normalizeUnixTimestamp(value float64) int64 {
+	if value > 1e17 {
+		return int64(value / 1e9)
+	}
+	if value > 1e14 {
+		return int64(value / 1e6)
+	}
+	if value > 1e11 {
+		return int64(value / 1000)
+	}
+	return int64(value)
+}
+
+func histogramRef(metric map[string]string, groupBy string) string {
+	if len(metric) == 0 {
+		return ""
+	}
+	if groupBy != "" {
+		if value, ok := metric[groupBy]; ok {
+			return value
+		}
+	}
+
+	keys := make([]string, 0, len(metric))
+	for key := range metric {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		if key == "__name__" {
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%s=%s", key, metric[key]))
+	}
+	return strings.Join(parts, ",")
+}
+
+func (vl *Loki) normalizeLogLimit(limit int) int {
+	if limit <= 0 {
+		if vl.MaxQueryRows > 0 {
+			limit = vl.MaxQueryRows
+		} else {
+			limit = LokiDefaultLogLimit
+		}
+	}
+	return limit
+}
+
+func (vl *Loki) MakeLogQuery(ctx context.Context, query interface{}, eventTags []string, start, end int64) (interface{}, error) {
+	q := &Query{
+		Start: start,
+		End:   end,
+		Limit: LokiDefaultLogLimit,
+	}
+	if queryStr, ok := query.(string); ok {
+		q.Query = queryStr
+	} else if queryMap, ok := query.(map[string]interface{}); ok {
+		if qStr, exists := queryMap["query"]; exists {
+			q.Query = fmt.Sprintf("%v", qStr)
+		}
+		if limit, exists := queryMap["limit"]; exists {
+			if limitInt, ok := limit.(int); ok {
+				q.Limit = limitInt
+			} else if limitFloat, ok := limit.(float64); ok {
+				q.Limit = int(limitFloat)
+			}
+		}
+	}
+	return q, nil
+}
+
+func (vl *Loki) MakeTSQuery(ctx context.Context, query interface{}, eventTags []string, start, end int64) (interface{}, error) {
+	q := &Query{
+		Start: start,
+		End:   end,
+	}
+	if queryStr, ok := query.(string); ok {
+		q.Query = queryStr
+	} else if queryMap, ok := query.(map[string]interface{}); ok {
+		if qStr, exists := queryMap["query"]; exists {
+			q.Query = fmt.Sprintf("%v", qStr)
+		}
+		if step, exists := queryMap["step"]; exists {
+			q.Step = fmt.Sprintf("%v", step)
+		}
+	}
+	return q, nil
+}
+
+func (vl *Loki) QueryMapData(ctx context.Context, query interface{}) ([]map[string]string, error) {
+	param := new(Query)
+	if err := mapstructure.Decode(query, param); err != nil {
+		return nil, err
+	}
+	if param.End > 0 && param.Start > 0 {
+		param.Start = subtractUnixSeconds(param.Start, 30)
+	}
+	param.Limit = 1
+
+	logs, _, err := vl.QueryLog(ctx, param)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []map[string]string
+	for _, log := range logs {
+		logMap, ok := log.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		strMap := make(map[string]string)
+		for k, v := range logMap {
+			strMap[k] = fmt.Sprintf("%v", v)
+		}
+		result = append(result, strMap)
+		break
+	}
+	return result, nil
+}
+
+func subtractUnixSeconds(value, seconds int64) int64 {
+	if value <= 0 || seconds <= 0 {
+		return value
+	}
+
+	var delta int64
+	switch {
+	case value > 1e17:
+		delta = seconds * int64(time.Second)
+	case value > 1e14:
+		delta = seconds * int64(time.Millisecond)
+	case value > 1e11:
+		delta = seconds * 1000
+	default:
+		delta = seconds
+	}
+
+	if value <= delta {
+		return 0
+	}
+	return value - delta
+}

--- a/datasource/loki/loki.go
+++ b/datasource/loki/loki.go
@@ -46,7 +46,8 @@ type Query struct {
 	Time      int64  `json:"time" mapstructure:"time"`
 	Step      string `json:"step" mapstructure:"step"`
 	Limit     int    `json:"limit" mapstructure:"limit"`
-	Direction string `json:"direction" mapstructure:"direction"`
+	Reverse   bool   `json:"reverse" mapstructure:"reverse"`
+	Direction string `json:"direction" mapstructure:"direction"` // 兼容旧参数，存在时优先于 reverse
 	Ref       string `json:"ref" mapstructure:"ref"`
 	// SkipCount 为 true 时跳过独立的 count 查询，此时 QueryLog 返回的 total
 	// 等于 len(data)（即受 Limit 截断后的实际条数），并非真实总数。调用方需自行
@@ -134,11 +135,10 @@ func (vl *Loki) QueryLog(ctx context.Context, queryParam interface{}) ([]interfa
 		return nil, 0, fmt.Errorf("decode query param failed: %w", err)
 	}
 	param.Limit = vl.normalizeLogLimit(param.Limit)
-	if param.Direction == "" {
-		param.Direction = "backward"
-	}
+	desc := resolveLogTimeDesc(param)
+	direction := logTimeDescToLokiDirection(desc)
 
-	result, err := vl.QueryRange(ctx, param.Query, param.Start, param.End, param.Step, param.Limit, param.Direction)
+	result, err := vl.QueryRange(ctx, param.Query, param.Start, param.End, param.Step, param.Limit, direction)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -158,7 +158,7 @@ func (vl *Loki) QueryLog(ctx context.Context, queryParam interface{}) ([]interfa
 		}
 		logs = lokikit.NormalizeLogsWithLabelNames(result, labelNames)
 	}
-	sortLokiLogs(logs, param.Direction)
+	sortLokiLogs(logs, desc)
 	ret := make([]interface{}, 0, len(logs))
 	for _, log := range logs {
 		ret = append(ret, log)
@@ -277,8 +277,7 @@ func buildLogCountQuery(query string, start, end int64) (string, bool) {
 	return fmt.Sprintf("sum(count_over_time(%s [%ds]))", strings.TrimSpace(query), rangeSeconds), true
 }
 
-func sortLokiLogs(logs []lokikit.NormalizedLog, direction string) {
-	desc := strings.EqualFold(direction, "backward") || direction == ""
+func sortLokiLogs(logs []lokikit.NormalizedLog, desc bool) {
 	sort.SliceStable(logs, func(i, j int) bool {
 		left := normalizedLogTimestampMillis(logs[i])
 		right := normalizedLogTimestampMillis(logs[j])
@@ -287,6 +286,23 @@ func sortLokiLogs(logs []lokikit.NormalizedLog, direction string) {
 		}
 		return left < right
 	})
+}
+
+func logTimeDescToLokiDirection(desc bool) string {
+	if desc {
+		return "backward"
+	}
+	return "forward"
+}
+
+func resolveLogTimeDesc(param *Query) bool {
+	if param != nil {
+		if strings.TrimSpace(param.Direction) != "" {
+			return !strings.EqualFold(strings.TrimSpace(param.Direction), "forward")
+		}
+		return param.Reverse
+	}
+	return false
 }
 
 func normalizedLogTimestampMillis(log lokikit.NormalizedLog) int64 {

--- a/datasource/loki/loki.go
+++ b/datasource/loki/loki.go
@@ -233,7 +233,7 @@ func (vl *Loki) QueryHistogram(ctx context.Context, queryParam interface{}) ([]H
 }
 
 func defaultHistogramStep(start, end int64) string {
-	return dskittypes.DefaultHistogramStep(normalizeUnixTimestamp(float64(start)), normalizeUnixTimestamp(float64(end)))
+	return dskittypes.DefaultHistogramStepFromUnixRange(start, end)
 }
 
 func buildHistogramQuery(query, step, groupBy string) string {
@@ -270,10 +270,13 @@ func (vl *Loki) countLogs(ctx context.Context, query string, start, end int64) (
 }
 
 func buildLogCountQuery(query string, start, end int64) (string, bool) {
-	rangeSeconds := normalizeUnixTimestamp(float64(end)) - normalizeUnixTimestamp(float64(start))
-	if strings.TrimSpace(query) == "" || rangeSeconds <= 0 {
+	if strings.TrimSpace(query) == "" {
 		return "", false
 	}
+	if dskittypes.NormalizeUnixSeconds(end) <= dskittypes.NormalizeUnixSeconds(start) {
+		return "", false
+	}
+	rangeSeconds := dskittypes.UnixRangeDurationSeconds(start, end)
 	return fmt.Sprintf("sum(count_over_time(%s [%ds]))", strings.TrimSpace(query), rangeSeconds), true
 }
 
@@ -441,14 +444,14 @@ func histogramValuesTotal(value HistogramValues) float64 {
 func parseSampleTimestamp(value interface{}) (float64, bool) {
 	switch v := value.(type) {
 	case float64:
-		return float64(normalizeUnixTimestamp(v)), true
+		return float64(dskittypes.NormalizeUnixTimestamp(v)), true
 	case int64:
-		return float64(normalizeUnixTimestamp(float64(v))), true
+		return float64(dskittypes.NormalizeUnixSeconds(v)), true
 	case int:
-		return float64(normalizeUnixTimestamp(float64(v))), true
+		return float64(dskittypes.NormalizeUnixSeconds(int64(v))), true
 	case string:
 		if f, err := strconv.ParseFloat(v, 64); err == nil {
-			return float64(normalizeUnixTimestamp(f)), true
+			return float64(dskittypes.NormalizeUnixTimestamp(f)), true
 		}
 		if t, err := time.Parse(time.RFC3339Nano, v); err == nil {
 			return float64(t.Unix()), true
@@ -476,19 +479,6 @@ func parseSampleValue(value interface{}) (float64, bool) {
 	default:
 		return 0, false
 	}
-}
-
-func normalizeUnixTimestamp(value float64) int64 {
-	if value > 1e17 {
-		return int64(value / 1e9)
-	}
-	if value > 1e14 {
-		return int64(value / 1e6)
-	}
-	if value > 1e11 {
-		return int64(value / 1000)
-	}
-	return int64(value)
 }
 
 func histogramRef(metric map[string]string, groupBy string) string {
@@ -653,7 +643,7 @@ func timestampHourBucket(value int64) int64 {
 	if value <= 0 {
 		return 0
 	}
-	return normalizeUnixTimestamp(float64(value)) / 3600
+	return dskittypes.NormalizeUnixSeconds(value) / 3600
 }
 
 func decodeQueryParam(input interface{}, output interface{}) error {

--- a/datasource/loki/loki.go
+++ b/datasource/loki/loki.go
@@ -2,6 +2,8 @@ package loki
 
 import (
 	"context"
+	"crypto/sha1"
+	"encoding/hex"
 	"fmt"
 	"net/url"
 	"reflect"
@@ -16,12 +18,21 @@ import (
 	"github.com/ccfos/nightingale/v6/models"
 
 	"github.com/mitchellh/mapstructure"
+	gc "github.com/patrickmn/go-cache"
 	"github.com/prometheus/common/model"
+	"github.com/toolkits/pkg/logger"
+	"golang.org/x/sync/singleflight"
 )
 
 const (
 	LokiType            = "loki"
 	LokiDefaultLogLimit = 500
+	labelNamesCacheTTL  = 10 * time.Minute
+)
+
+var (
+	labelNamesCache = gc.New(labelNamesCacheTTL, time.Minute)
+	labelNamesGroup singleflight.Group
 )
 
 type Loki struct {
@@ -37,6 +48,10 @@ type Query struct {
 	Limit     int    `json:"limit" mapstructure:"limit"`
 	Direction string `json:"direction" mapstructure:"direction"`
 	Ref       string `json:"ref" mapstructure:"ref"`
+	// SkipCount 为 true 时跳过独立的 count 查询，此时 QueryLog 返回的 total
+	// 等于 len(data)（即受 Limit 截断后的实际条数），并非真实总数。调用方需自行
+	// 感知这一约定（例如翻页时改用 hasMore 语义，而不是依赖 total）。
+	SkipCount bool `json:"skip_count" mapstructure:"skip_count"`
 }
 
 type HistogramQuery struct {
@@ -115,7 +130,7 @@ func (vl *Loki) Equal(other datasource.Datasource) bool {
 
 func (vl *Loki) QueryLog(ctx context.Context, queryParam interface{}) ([]interface{}, int64, error) {
 	param := new(Query)
-	if err := mapstructure.Decode(queryParam, param); err != nil {
+	if err := decodeQueryParam(queryParam, param); err != nil {
 		return nil, 0, fmt.Errorf("decode query param failed: %w", err)
 	}
 	param.Limit = vl.normalizeLogLimit(param.Limit)
@@ -128,11 +143,28 @@ func (vl *Loki) QueryLog(ctx context.Context, queryParam interface{}) ([]interfa
 		return nil, 0, err
 	}
 
+	fieldInfo := lokikit.AnalyzeLogQLForLogFields(param.Query)
 	logs := lokikit.NormalizeLogs(result)
+	if fieldInfo.NeedsLabelNames {
+		labelNames, err := vl.cachedLabelNames(ctx, fieldInfo.Selector, param.Start, param.End)
+		if err != nil {
+			// 无法可靠区分原始 stream label 与 parser 阶段字段时，选择「全归 parsed_fields」
+			// （对应 splitStreamFields 中「非 nil 空集」分支），而非退回把所有 stream key 当 label。
+			// 这样至少能保证 labels 里出现的字段一定是真正 Loki 索引的 stream label；代价是
+			// Loki `/labels` 抖动期间用户会看到 labels 暂时为空。此处仅打 warning，不做进一步兜底。
+			logger.Warningf("loki cachedLabelNames failed, fallback to empty label set: addr=%s selector=%q start=%d end=%d err=%v",
+				vl.LokiAddr, fieldInfo.Selector, param.Start, param.End, err)
+			labelNames = []string{}
+		}
+		logs = lokikit.NormalizeLogsWithLabelNames(result, labelNames)
+	}
 	sortLokiLogs(logs, param.Direction)
 	ret := make([]interface{}, 0, len(logs))
 	for _, log := range logs {
 		ret = append(ret, log)
+	}
+	if param.SkipCount {
+		return ret, int64(len(ret)), nil
 	}
 
 	total, err := vl.countLogs(ctx, param.Query, param.Start, param.End)
@@ -145,7 +177,7 @@ func (vl *Loki) QueryLog(ctx context.Context, queryParam interface{}) ([]interfa
 
 func (vl *Loki) QueryData(ctx context.Context, queryParam interface{}) ([]models.DataResp, error) {
 	param := new(Query)
-	if err := mapstructure.Decode(queryParam, param); err != nil {
+	if err := decodeQueryParam(queryParam, param); err != nil {
 		return nil, fmt.Errorf("decode query param failed: %w", err)
 	}
 
@@ -184,7 +216,7 @@ func (vl *Loki) QueryParsedFields(ctx context.Context, query string, start, end 
 
 func (vl *Loki) QueryHistogram(ctx context.Context, queryParam interface{}) ([]HistogramValues, error) {
 	param := new(HistogramQuery)
-	if err := mapstructure.Decode(queryParam, param); err != nil {
+	if err := decodeQueryParam(queryParam, param); err != nil {
 		return nil, fmt.Errorf("decode query param failed: %w", err)
 	}
 	if param.Step == "" {
@@ -523,7 +555,7 @@ func (vl *Loki) MakeTSQuery(ctx context.Context, query interface{}, eventTags []
 
 func (vl *Loki) QueryMapData(ctx context.Context, query interface{}) ([]map[string]string, error) {
 	param := new(Query)
-	if err := mapstructure.Decode(query, param); err != nil {
+	if err := decodeQueryParam(query, param); err != nil {
 		return nil, err
 	}
 	if param.End > 0 && param.Start > 0 {
@@ -550,6 +582,73 @@ func (vl *Loki) QueryMapData(ctx context.Context, query interface{}) ([]map[stri
 		break
 	}
 	return result, nil
+}
+
+func (vl *Loki) cachedLabelNames(ctx context.Context, selector string, start, end int64) ([]string, error) {
+	key := vl.labelNamesCacheKey(selector, start, end)
+	if value, ok := labelNamesCache.Get(key); ok {
+		if labels, ok := value.([]string); ok {
+			return labels, nil
+		}
+	}
+
+	value, err, _ := labelNamesGroup.Do(key, func() (interface{}, error) {
+		if cached, ok := labelNamesCache.Get(key); ok {
+			if labels, ok := cached.([]string); ok {
+				return labels, nil
+			}
+		}
+		labels, err := vl.LabelNames(ctx, selector, start, end, "", 0)
+		if err != nil {
+			return nil, err
+		}
+		labelNamesCache.Set(key, labels, gc.DefaultExpiration)
+		return labels, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	labels, _ := value.([]string)
+	return labels, nil
+}
+
+func (vl *Loki) labelNamesCacheKey(selector string, start, end int64) string {
+	parts := []string{
+		vl.LokiAddr,
+		vl.ClusterName,
+		vl.LokiBasic.LokiUser,
+		selector,
+		strconv.FormatInt(timestampHourBucket(start), 10),
+		strconv.FormatInt(timestampHourBucket(end), 10),
+	}
+	headerKeys := make([]string, 0, len(vl.Headers))
+	for key := range vl.Headers {
+		headerKeys = append(headerKeys, key)
+	}
+	sort.Strings(headerKeys)
+	for _, key := range headerKeys {
+		parts = append(parts, key+"="+vl.Headers[key])
+	}
+	sum := sha1.Sum([]byte(strings.Join(parts, "\x00")))
+	return "loki-label-names:" + hex.EncodeToString(sum[:])
+}
+
+func timestampHourBucket(value int64) int64 {
+	if value <= 0 {
+		return 0
+	}
+	return normalizeUnixTimestamp(float64(value)) / 3600
+}
+
+func decodeQueryParam(input interface{}, output interface{}) error {
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		WeaklyTypedInput: true,
+		Result:           output,
+	})
+	if err != nil {
+		return err
+	}
+	return decoder.Decode(input)
 }
 
 func subtractUnixSeconds(value, seconds int64) int64 {

--- a/datasource/loki/loki_test.go
+++ b/datasource/loki/loki_test.go
@@ -56,8 +56,82 @@ func TestQueryLogReturnsTotalFromCountQuery(t *testing.T) {
 	if total != 42 {
 		t.Fatalf("unexpected total: %d", total)
 	}
+	log, ok := logs[0].(lokikit.NormalizedLog)
+	if !ok {
+		t.Fatalf("unexpected log type: %#v", logs[0])
+	}
+	labels, ok := log["labels"].(map[string]string)
+	if !ok || labels["app"] != "api" {
+		t.Fatalf("unexpected labels: %#v", log["labels"])
+	}
+	if _, exists := log["stream"]; exists {
+		t.Fatalf("stream should not be returned")
+	}
 	if !sawRangeQuery || !sawCountQuery {
-		t.Fatalf("expected both range and count queries, sawRange=%v sawCount=%v", sawRangeQuery, sawCountQuery)
+		t.Fatalf("expected range and count queries, sawRange=%v sawCount=%v", sawRangeQuery, sawCountQuery)
+	}
+}
+
+func TestQueryLogSplitsParsedFieldsWithCachedSelectorLabelNames(t *testing.T) {
+	labelNamesCache.Flush()
+	var labelsQueryCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/query_range":
+			if got := r.URL.Query().Get("query"); got != `{app="api"} | json` {
+				t.Fatalf("unexpected range query: %q", got)
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"streams","result":[{"stream":{"app":"api","trace_id":"abc"},"values":[["1710000060000000000","line"]]}]}}`))
+		case "/api/v1/labels":
+			labelsQueryCount++
+			if got := r.URL.Query().Get("query"); got != `{app="api"}` {
+				t.Fatalf("unexpected labels query: %q", got)
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":"success","data":["app"]}`))
+		case "/api/v1/query":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[{"metric":{},"value":[1710000060,"1"]}]}}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	vl := &Loki{
+		Loki: lokikit.Loki{
+			LokiAddr: server.URL,
+		},
+	}
+	query := Query{
+		Query: `{app="api"} | json`,
+		Start: 1710000000,
+		End:   1710000060,
+		Limit: 1,
+	}
+	logs, _, err := vl.QueryLog(context.Background(), query)
+	if err != nil {
+		t.Fatalf("QueryLog failed: %v", err)
+	}
+	if _, _, err := vl.QueryLog(context.Background(), query); err != nil {
+		t.Fatalf("second QueryLog failed: %v", err)
+	}
+	if labelsQueryCount != 1 {
+		t.Fatalf("label names should be cached, got labelsQueryCount=%d", labelsQueryCount)
+	}
+
+	log := logs[0].(lokikit.NormalizedLog)
+	labels := log["labels"].(map[string]string)
+	if got := labels["app"]; got != "api" {
+		t.Fatalf("unexpected app label: %q", got)
+	}
+	if _, exists := labels["trace_id"]; exists {
+		t.Fatalf("trace_id should not be treated as label")
+	}
+	parsedFields := log["parsed_fields"].(map[string]string)
+	if got := parsedFields["trace_id"]; got != "abc" {
+		t.Fatalf("unexpected parsed trace_id: %q", got)
 	}
 }
 
@@ -69,6 +143,27 @@ func TestBuildLogCountQueryNormalizesMillisecondRange(t *testing.T) {
 	want := `sum(count_over_time({app="api"} [3600s]))`
 	if got != want {
 		t.Fatalf("unexpected query: got %q want %q", got, want)
+	}
+}
+
+func TestDecodeQueryParamAcceptsStringNanosecondRange(t *testing.T) {
+	param := new(Query)
+	if err := decodeQueryParam(map[string]interface{}{
+		"query": `{app="api"}`,
+		"start": "1710000000000000000",
+		"end":   "1710000001000000000",
+		"limit": "30",
+	}, param); err != nil {
+		t.Fatalf("decodeQueryParam failed: %v", err)
+	}
+	if param.Start != 1710000000000000000 {
+		t.Fatalf("unexpected start: %d", param.Start)
+	}
+	if param.End != 1710000001000000000 {
+		t.Fatalf("unexpected end: %d", param.End)
+	}
+	if param.Limit != 30 {
+		t.Fatalf("unexpected limit: %d", param.Limit)
 	}
 }
 

--- a/datasource/loki/loki_test.go
+++ b/datasource/loki/loki_test.go
@@ -1,0 +1,174 @@
+package loki
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	lokikit "github.com/ccfos/nightingale/v6/dskit/loki"
+)
+
+func TestQueryLogReturnsTotalFromCountQuery(t *testing.T) {
+	var sawRangeQuery bool
+	var sawCountQuery bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/query_range":
+			sawRangeQuery = true
+			if got := r.URL.Query().Get("limit"); got != "1" {
+				t.Fatalf("unexpected range limit: %q", got)
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"streams","result":[{"stream":{"app":"api"},"values":[["1710000060000000000","line"]]}]}}`))
+		case "/api/v1/query":
+			sawCountQuery = true
+			query := r.URL.Query().Get("query")
+			if !strings.Contains(query, `sum(count_over_time({app="api"} [60s]))`) {
+				t.Fatalf("unexpected count query: %q", query)
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[{"metric":{},"value":[1710000060,"42"]}]}}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	vl := &Loki{
+		Loki: lokikit.Loki{
+			LokiAddr: server.URL,
+		},
+	}
+	logs, total, err := vl.QueryLog(context.Background(), Query{
+		Query: `{app="api"}`,
+		Start: 1710000000,
+		End:   1710000060,
+		Limit: 1,
+	})
+	if err != nil {
+		t.Fatalf("QueryLog failed: %v", err)
+	}
+	if len(logs) != 1 {
+		t.Fatalf("unexpected logs length: %d", len(logs))
+	}
+	if total != 42 {
+		t.Fatalf("unexpected total: %d", total)
+	}
+	if !sawRangeQuery || !sawCountQuery {
+		t.Fatalf("expected both range and count queries, sawRange=%v sawCount=%v", sawRangeQuery, sawCountQuery)
+	}
+}
+
+func TestBuildLogCountQueryNormalizesMillisecondRange(t *testing.T) {
+	got, ok := buildLogCountQuery(`{app="api"}`, 1710000000000, 1710003600000)
+	if !ok {
+		t.Fatalf("expected valid count query")
+	}
+	want := `sum(count_over_time({app="api"} [3600s]))`
+	if got != want {
+		t.Fatalf("unexpected query: got %q want %q", got, want)
+	}
+}
+
+func TestNormalizeLogLimitDoesNotApplyHardCap(t *testing.T) {
+	vl := &Loki{}
+	if got := vl.normalizeLogLimit(20000); got != 20000 {
+		t.Fatalf("expected explicit limit to pass through, got %d", got)
+	}
+	if got := vl.normalizeLogLimit(0); got != LokiDefaultLogLimit {
+		t.Fatalf("unexpected default limit: %d", got)
+	}
+
+	vl.MaxQueryRows = 800
+	if got := vl.normalizeLogLimit(0); got != 800 {
+		t.Fatalf("unexpected datasource default limit: %d", got)
+	}
+}
+
+func TestDefaultHistogramStepAcceptsMilliseconds(t *testing.T) {
+	start := int64(1710000000000)
+	end := int64(1710003600000)
+	if got := defaultHistogramStep(start, end); got != "1m" {
+		t.Fatalf("unexpected step for 1h millisecond range: %q", got)
+	}
+}
+
+func TestLimitHistogramValuesUsesTopTotals(t *testing.T) {
+	values := []HistogramValues{
+		{
+			Ref: "low",
+			Values: [][]interface{}{
+				{int64(1), float64(1)},
+				{int64(2), "2"},
+			},
+		},
+		{
+			Ref: "high",
+			Values: [][]interface{}{
+				{int64(1), float64(5)},
+				{int64(2), "6"},
+			},
+		},
+		{
+			Ref: "mid",
+			Values: [][]interface{}{
+				{int64(1), float64(4)},
+			},
+		},
+	}
+
+	got := limitHistogramValues(values, "app", 2)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 series, got %d", len(got))
+	}
+	if got[0].Ref != "high" || got[1].Ref != "mid" {
+		t.Fatalf("unexpected top series order: %#v", got)
+	}
+}
+
+func TestSortLokiLogsByDirection(t *testing.T) {
+	logs := []lokikit.NormalizedLog{
+		{"timestamp": int64(1000), "line": "old"},
+		{"timestamp": int64(3000), "line": "new"},
+		{"timestamp": int64(2000), "line": "mid"},
+	}
+
+	sortLokiLogs(logs, "backward")
+	if got := logs[0]["line"]; got != "new" {
+		t.Fatalf("backward should sort by timestamp desc, first line=%v", got)
+	}
+	if got := logs[2]["line"]; got != "old" {
+		t.Fatalf("backward should sort by timestamp desc, last line=%v", got)
+	}
+
+	sortLokiLogs(logs, "forward")
+	if got := logs[0]["line"]; got != "old" {
+		t.Fatalf("forward should sort by timestamp asc, first line=%v", got)
+	}
+	if got := logs[2]["line"]; got != "new" {
+		t.Fatalf("forward should sort by timestamp asc, last line=%v", got)
+	}
+}
+
+func TestSubtractUnixSecondsPreservesPrecision(t *testing.T) {
+	tests := []struct {
+		name string
+		in   int64
+		want int64
+	}{
+		{name: "seconds", in: 1710000030, want: 1710000000},
+		{name: "milliseconds", in: 1710000030000, want: 1710000000000},
+		{name: "microseconds", in: 1710000030000000, want: 1710000000000000},
+		{name: "nanoseconds", in: 1710000030000000000, want: 1710000000000000000},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := subtractUnixSeconds(tt.in, 30); got != tt.want {
+				t.Fatalf("unexpected value: got %d want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/datasource/loki/loki_test.go
+++ b/datasource/loki/loki_test.go
@@ -17,6 +17,9 @@ func TestQueryLogReturnsTotalFromCountQuery(t *testing.T) {
 		switch r.URL.Path {
 		case "/api/v1/query_range":
 			sawRangeQuery = true
+			if got := r.URL.Query().Get("direction"); got != "forward" {
+				t.Fatalf("unexpected default direction: %q", got)
+			}
 			if got := r.URL.Query().Get("limit"); got != "1" {
 				t.Fatalf("unexpected range limit: %q", got)
 			}
@@ -69,6 +72,64 @@ func TestQueryLogReturnsTotalFromCountQuery(t *testing.T) {
 	}
 	if !sawRangeQuery || !sawCountQuery {
 		t.Fatalf("expected range and count queries, sawRange=%v sawCount=%v", sawRangeQuery, sawCountQuery)
+	}
+}
+
+func TestQueryLogUsesReverseForDirection(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/query_range" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		requestCount++
+		wantDirection := "forward"
+		if requestCount == 2 {
+			wantDirection = "backward"
+		}
+		if got := r.URL.Query().Get("direction"); got != wantDirection {
+			t.Fatalf("unexpected Loki direction: got %q want %q", got, wantDirection)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"streams","result":[{"stream":{"app":"api"},"values":[["1710000060000000000","new"],["1710000000000000000","old"]]}]}}`))
+	}))
+	defer server.Close()
+
+	vl := &Loki{
+		Loki: lokikit.Loki{
+			LokiAddr: server.URL,
+		},
+	}
+	logs, total, err := vl.QueryLog(context.Background(), map[string]interface{}{
+		"query":      `{app="api"}`,
+		"start":      1710000000,
+		"end":        1710000060,
+		"limit":      2,
+		"reverse":    false,
+		"skip_count": true,
+	})
+	if err != nil {
+		t.Fatalf("QueryLog failed: %v", err)
+	}
+	if total != 2 {
+		t.Fatalf("unexpected total: %d", total)
+	}
+	if got := logs[0].(lokikit.NormalizedLog)["line"]; got != "old" {
+		t.Fatalf("reverse=false should sort logs asc, first line=%v", got)
+	}
+
+	logs, _, err = vl.QueryLog(context.Background(), map[string]interface{}{
+		"query":      `{app="api"}`,
+		"start":      1710000000,
+		"end":        1710000060,
+		"limit":      2,
+		"reverse":    true,
+		"skip_count": true,
+	})
+	if err != nil {
+		t.Fatalf("QueryLog with reverse=true failed: %v", err)
+	}
+	if got := logs[0].(lokikit.NormalizedLog)["line"]; got != "new" {
+		t.Fatalf("reverse=true should sort logs desc, first line=%v", got)
 	}
 }
 
@@ -223,27 +284,83 @@ func TestLimitHistogramValuesUsesTopTotals(t *testing.T) {
 	}
 }
 
-func TestSortLokiLogsByDirection(t *testing.T) {
+func TestSortLokiLogsByDesc(t *testing.T) {
 	logs := []lokikit.NormalizedLog{
 		{"timestamp": int64(1000), "line": "old"},
 		{"timestamp": int64(3000), "line": "new"},
 		{"timestamp": int64(2000), "line": "mid"},
 	}
 
-	sortLokiLogs(logs, "backward")
+	sortLokiLogs(logs, true)
 	if got := logs[0]["line"]; got != "new" {
-		t.Fatalf("backward should sort by timestamp desc, first line=%v", got)
+		t.Fatalf("desc should sort by timestamp desc, first line=%v", got)
 	}
 	if got := logs[2]["line"]; got != "old" {
-		t.Fatalf("backward should sort by timestamp desc, last line=%v", got)
+		t.Fatalf("desc should sort by timestamp desc, last line=%v", got)
 	}
 
-	sortLokiLogs(logs, "forward")
+	sortLokiLogs(logs, false)
 	if got := logs[0]["line"]; got != "old" {
-		t.Fatalf("forward should sort by timestamp asc, first line=%v", got)
+		t.Fatalf("asc should sort by timestamp asc, first line=%v", got)
 	}
 	if got := logs[2]["line"]; got != "new" {
-		t.Fatalf("forward should sort by timestamp asc, last line=%v", got)
+		t.Fatalf("asc should sort by timestamp asc, last line=%v", got)
+	}
+}
+
+func TestResolveLogTimeDesc(t *testing.T) {
+	tests := []struct {
+		name      string
+		direction string
+		reverse   bool
+		want      bool
+	}{
+		{
+			name:      "direction backward",
+			direction: "backward",
+			want:      true,
+		},
+		{
+			name:      "direction forward",
+			direction: "forward",
+			want:      false,
+		},
+		{
+			name:    "map reverse true",
+			reverse: true,
+			want:    true,
+		},
+		{
+			name: "map reverse false",
+			want: false,
+		},
+		{
+			name: "map reverse string false",
+			want: false,
+		},
+		{
+			name:    "struct reverse true",
+			reverse: true,
+			want:    true,
+		},
+		{
+			name:      "direction overrides reverse",
+			direction: "forward",
+			want:      false,
+		},
+		{
+			name: "default asc",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			param := &Query{Direction: tt.direction, Reverse: tt.reverse}
+			if got := resolveLogTimeDesc(param); got != tt.want {
+				t.Fatalf("resolveLogTimeDesc() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/datasource/victorialogs/victorialogs.go
+++ b/datasource/victorialogs/victorialogs.go
@@ -54,6 +54,17 @@ type HistogramValues struct {
 	Values [][]interface{}        `json:"values"`
 }
 
+type FieldName struct {
+	Field   string `json:"field"`
+	Type    string `json:"type"`
+	Builtin bool   `json:"builtin"`
+}
+
+type FieldValue struct {
+	Value string `json:"value"`
+	Count int64  `json:"count"`
+}
+
 // IsInstantQuery 判断是否为即时查询（告警场景）
 func (q *Query) IsInstantQuery() bool {
 	return q.Time > 0 || (q.Start >= 0 && q.Start == q.End)
@@ -143,11 +154,9 @@ func (vl *VictoriaLogs) QueryLog(ctx context.Context, queryParam interface{}) ([
 		result[i] = log
 	}
 
-	// 调用 HitsLogs 获取真实的 total
 	total, err := vl.HitsLogs(ctx, param.Query, param.Start, param.End)
 	if err != nil {
-		// 如果获取 total 失败，使用当前结果数量
-		total = int64(len(logs))
+		return nil, 0, fmt.Errorf("count matching logs failed: %w", err)
 	}
 
 	return result, total, nil
@@ -164,7 +173,7 @@ func (vl *VictoriaLogs) QueryHistogram(ctx context.Context, queryParam interface
 		groupByFields = append(groupByFields, param.GroupBy)
 	}
 	if param.Step == "" {
-		param.Step = defaultHistogramStep(param.Start, param.End)
+		param.Step = victorialogs.DefaultHistogramStep(param.Start, param.End)
 	}
 
 	result, err := vl.QueryHitsWithFieldsLimit(ctx, param.Query, param.Start, param.End, param.Step, param.FieldsLimit, groupByFields...)
@@ -173,6 +182,39 @@ func (vl *VictoriaLogs) QueryHistogram(ctx context.Context, queryParam interface
 	}
 
 	return convertHitsToHistogramValues(result.Hits, param.GroupBy), nil
+}
+
+func (vl *VictoriaLogs) QueryFieldNames(ctx context.Context, query string, start, end int64, limit int, filter string) ([]FieldName, error) {
+	values, err := vl.FieldNames(ctx, query, start, end, limit, filter)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := make([]FieldName, 0, len(values))
+	for _, value := range values {
+		if value.Value == "" {
+			continue
+		}
+		ret = append(ret, FieldName{
+			Field:   value.Value,
+			Type:    "string",
+			Builtin: false,
+		})
+	}
+	return ret, nil
+}
+
+func (vl *VictoriaLogs) QueryFieldValues(ctx context.Context, query string, start, end int64, field string, limit int, filter string) ([]FieldValue, error) {
+	values, err := vl.FieldValues(ctx, query, start, end, field, limit, filter)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := make([]FieldValue, 0, len(values))
+	for _, value := range values {
+		ret = append(ret, FieldValue{Value: value.Value, Count: value.Hits})
+	}
+	return ret, nil
 }
 
 // QueryData 指标数据查询
@@ -365,55 +407,6 @@ func normalizeUnixTimestamp(value float64) int64 {
 		return int64(value / 1000)
 	}
 	return int64(value)
-}
-
-func defaultHistogramStep(start, end int64) string {
-	return histogramWidthToStep(defaultHistogramWidthBySeconds(start, end))
-}
-
-func defaultHistogramWidthBySeconds(start, end int64) int64 {
-	diff := end - start
-	switch {
-	case diff <= 60:
-		return 1
-	case diff <= 300:
-		return 5
-	case diff <= 900:
-		return 30
-	case diff <= 1800:
-		return 30
-	case diff <= 3600:
-		return 60
-	case diff <= 3600*6:
-		return 5 * 60
-	case diff <= 3600*12:
-		return 10 * 60
-	case diff <= 3600*24:
-		return 30 * 60
-	case diff <= 3600*24*2:
-		return 60 * 60
-	case diff <= 3600*24*7:
-		return 3 * 60 * 60
-	case diff <= 3600*24*30:
-		return 12 * 60 * 60
-	case diff <= 3600*24*90:
-		return 24 * 60 * 60
-	default:
-		return 2 * 24 * 60 * 60
-	}
-}
-
-func histogramWidthToStep(width int64) string {
-	switch {
-	case width%86400 == 0:
-		return fmt.Sprintf("%dd", width/86400)
-	case width%3600 == 0:
-		return fmt.Sprintf("%dh", width/3600)
-	case width%60 == 0:
-		return fmt.Sprintf("%dm", width/60)
-	default:
-		return fmt.Sprintf("%ds", width)
-	}
 }
 
 func parseHistogramValue(value interface{}) (float64, bool) {

--- a/datasource/victorialogs/victorialogs.go
+++ b/datasource/victorialogs/victorialogs.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/ccfos/nightingale/v6/datasource"
+	dskittypes "github.com/ccfos/nightingale/v6/dskit/types"
 	"github.com/ccfos/nightingale/v6/dskit/victorialogs"
 	"github.com/ccfos/nightingale/v6/models"
 
@@ -171,7 +172,7 @@ func (vl *VictoriaLogs) QueryHistogram(ctx context.Context, queryParam interface
 		groupByFields = append(groupByFields, param.GroupBy)
 	}
 	if param.Step == "" {
-		param.Step = victorialogs.DefaultHistogramStep(param.Start, param.End)
+		param.Step = dskittypes.DefaultHistogramStep(param.Start, param.End)
 	}
 
 	result, err := vl.QueryHitsWithFieldsLimit(ctx, param.Query, param.Start, param.End, param.Step, param.FieldsLimit, groupByFields...)

--- a/datasource/victorialogs/victorialogs.go
+++ b/datasource/victorialogs/victorialogs.go
@@ -55,9 +55,7 @@ type HistogramValues struct {
 }
 
 type FieldName struct {
-	Field   string `json:"field"`
-	Type    string `json:"type"`
-	Builtin bool   `json:"builtin"`
+	Field string `json:"field"`
 }
 
 type FieldValue struct {
@@ -196,9 +194,7 @@ func (vl *VictoriaLogs) QueryFieldNames(ctx context.Context, query string, start
 			continue
 		}
 		ret = append(ret, FieldName{
-			Field:   value.Value,
-			Type:    "string",
-			Builtin: false,
+			Field: value.Value,
 		})
 	}
 	return ret, nil

--- a/datasource/victorialogs/victorialogs.go
+++ b/datasource/victorialogs/victorialogs.go
@@ -132,7 +132,9 @@ func (vl *VictoriaLogs) Equal(other datasource.Datasource) bool {
 		vl.VictorialogsTls.SkipTlsVerify == o.VictorialogsTls.SkipTlsVerify &&
 		vl.Timeout == o.Timeout &&
 		vl.MaxQueryRows == o.MaxQueryRows &&
-		reflect.DeepEqual(vl.Headers, o.Headers)
+		vl.EnableWrite == o.EnableWrite &&
+		reflect.DeepEqual(vl.Headers, o.Headers) &&
+		reflect.DeepEqual(vl.WriteAddrs, o.WriteAddrs)
 }
 
 // QueryLog 日志查询

--- a/datasource/victorialogs/victorialogs.go
+++ b/datasource/victorialogs/victorialogs.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"reflect"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -30,14 +31,15 @@ type VictoriaLogs struct {
 
 // Query 查询参数
 type Query struct {
-	Query  string `json:"query" mapstructure:"query"`   // LogsQL 查询语句
-	Start  int64  `json:"start" mapstructure:"start"`   // 开始时间（秒）
-	End    int64  `json:"end" mapstructure:"end"`       // 结束时间（秒）
-	Time   int64  `json:"time" mapstructure:"time"`     // 单点时间（秒）- 用于告警
-	Step   string `json:"step" mapstructure:"step"`     // 步长，如 "1m", "5m"
-	Limit  int    `json:"limit" mapstructure:"limit"`   // 限制返回数量
-	Offset int    `json:"offset" mapstructure:"offset"` // 偏移量
-	Ref    string `json:"ref" mapstructure:"ref"`       // 变量引用名（如 A、B）
+	Query   string `json:"query" mapstructure:"query"`   // LogsQL 查询语句
+	Start   int64  `json:"start" mapstructure:"start"`   // 开始时间（秒）
+	End     int64  `json:"end" mapstructure:"end"`       // 结束时间（秒）
+	Time    int64  `json:"time" mapstructure:"time"`     // 单点时间（秒）- 用于告警
+	Step    string `json:"step" mapstructure:"step"`     // 步长，如 "1m", "5m"
+	Limit   int    `json:"limit" mapstructure:"limit"`   // 限制返回数量
+	Offset  int    `json:"offset" mapstructure:"offset"` // 偏移量
+	Reverse bool   `json:"reverse" mapstructure:"reverse"`
+	Ref     string `json:"ref" mapstructure:"ref"` // 变量引用名（如 A、B）
 }
 
 type HistogramQuery struct {
@@ -143,8 +145,9 @@ func (vl *VictoriaLogs) QueryLog(ctx context.Context, queryParam interface{}) ([
 	if err := mapstructure.Decode(queryParam, param); err != nil {
 		return nil, 0, fmt.Errorf("decode query param failed: %w", err)
 	}
-
-	logs, err := vl.QueryWithOffset(ctx, param.Query, param.Start, param.End, param.Limit, param.Offset)
+	desc := resolveLogTimeDesc(param)
+	query := applyLogSortQuery(param.Query, desc)
+	logs, err := vl.QueryWithOffset(ctx, query, param.Start, param.End, param.Limit, param.Offset)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -161,6 +164,34 @@ func (vl *VictoriaLogs) QueryLog(ctx context.Context, queryParam interface{}) ([
 	}
 
 	return result, total, nil
+}
+
+func applyLogSortQuery(query string, desc bool) string {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return query
+	}
+	if hasSortPipe(query) {
+		return query
+	}
+
+	if desc {
+		return query + " | sort by (_time) desc"
+	}
+	return query + " | sort by (_time)"
+}
+
+var logSortPipePattern = regexp.MustCompile(`(?i)(^|\|)\s*(sort|order)(\s|$)`)
+
+func hasSortPipe(query string) bool {
+	return logSortPipePattern.MatchString(query)
+}
+
+func resolveLogTimeDesc(param *Query) bool {
+	if param != nil {
+		return param.Reverse
+	}
+	return false
 }
 
 func (vl *VictoriaLogs) QueryHistogram(ctx context.Context, queryParam interface{}) ([]HistogramValues, error) {

--- a/datasource/victorialogs/victorialogs.go
+++ b/datasource/victorialogs/victorialogs.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"net/url"
 	"reflect"
+	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/ccfos/nightingale/v6/datasource"
@@ -27,13 +29,29 @@ type VictoriaLogs struct {
 
 // Query 查询参数
 type Query struct {
-	Query string `json:"query" mapstructure:"query"` // LogsQL 查询语句
-	Start int64  `json:"start" mapstructure:"start"` // 开始时间（秒）
-	End   int64  `json:"end" mapstructure:"end"`     // 结束时间（秒）
-	Time  int64  `json:"time" mapstructure:"time"`   // 单点时间（秒）- 用于告警
-	Step  string `json:"step" mapstructure:"step"`   // 步长，如 "1m", "5m"
-	Limit int    `json:"limit" mapstructure:"limit"` // 限制返回数量
-	Ref   string `json:"ref" mapstructure:"ref"`     // 变量引用名（如 A、B）
+	Query  string `json:"query" mapstructure:"query"`   // LogsQL 查询语句
+	Start  int64  `json:"start" mapstructure:"start"`   // 开始时间（秒）
+	End    int64  `json:"end" mapstructure:"end"`       // 结束时间（秒）
+	Time   int64  `json:"time" mapstructure:"time"`     // 单点时间（秒）- 用于告警
+	Step   string `json:"step" mapstructure:"step"`     // 步长，如 "1m", "5m"
+	Limit  int    `json:"limit" mapstructure:"limit"`   // 限制返回数量
+	Offset int    `json:"offset" mapstructure:"offset"` // 偏移量
+	Ref    string `json:"ref" mapstructure:"ref"`       // 变量引用名（如 A、B）
+}
+
+type HistogramQuery struct {
+	Query       string `json:"query" mapstructure:"query"`
+	Start       int64  `json:"start" mapstructure:"start"`
+	End         int64  `json:"end" mapstructure:"end"`
+	Step        string `json:"step" mapstructure:"step"`
+	GroupBy     string `json:"group_by" mapstructure:"group_by"`
+	FieldsLimit int    `json:"fields_limit" mapstructure:"fields_limit"`
+}
+
+type HistogramValues struct {
+	Ref    string                 `json:"ref"`
+	Metric map[string]interface{} `json:"metric"`
+	Values [][]interface{}        `json:"values"`
 }
 
 // IsInstantQuery 判断是否为即时查询（告警场景）
@@ -114,7 +132,7 @@ func (vl *VictoriaLogs) QueryLog(ctx context.Context, queryParam interface{}) ([
 		return nil, 0, fmt.Errorf("decode query param failed: %w", err)
 	}
 
-	logs, err := vl.Query(ctx, param.Query, param.Start, param.End, param.Limit)
+	logs, err := vl.QueryWithOffset(ctx, param.Query, param.Start, param.End, param.Limit, param.Offset)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -133,6 +151,28 @@ func (vl *VictoriaLogs) QueryLog(ctx context.Context, queryParam interface{}) ([
 	}
 
 	return result, total, nil
+}
+
+func (vl *VictoriaLogs) QueryHistogram(ctx context.Context, queryParam interface{}) ([]HistogramValues, error) {
+	param := new(HistogramQuery)
+	if err := mapstructure.Decode(queryParam, param); err != nil {
+		return nil, fmt.Errorf("decode query param failed: %w", err)
+	}
+
+	var groupByFields []string
+	if param.GroupBy != "" {
+		groupByFields = append(groupByFields, param.GroupBy)
+	}
+	if param.Step == "" {
+		param.Step = defaultHistogramStep(param.Start, param.End)
+	}
+
+	result, err := vl.QueryHitsWithFieldsLimit(ctx, param.Query, param.Start, param.End, param.Step, param.FieldsLimit, groupByFields...)
+	if err != nil {
+		return nil, err
+	}
+
+	return convertHitsToHistogramValues(result.Hits, param.GroupBy), nil
 }
 
 // QueryData 指标数据查询
@@ -251,6 +291,172 @@ func convertPrometheusRangeToDataResp(resp *victorialogs.PrometheusResponse, ref
 	}
 
 	return dataResps
+}
+
+func convertHitsToHistogramValues(hits []victorialogs.HitResult, groupBy string) []HistogramValues {
+	ret := make([]HistogramValues, 0, len(hits))
+	for _, hit := range hits {
+		metric := make(map[string]interface{}, len(hit.Fields))
+		for k, v := range hit.Fields {
+			metric[k] = v
+		}
+
+		values := make([][]interface{}, 0, len(hit.Values))
+		for i, value := range hit.Values {
+			if i >= len(hit.Timestamps) {
+				break
+			}
+
+			timestamp, ok := parseHistogramTimestamp(hit.Timestamps[i])
+			if !ok {
+				continue
+			}
+
+			count, ok := parseHistogramValue(value)
+			if !ok {
+				values = append(values, []interface{}{timestamp, nil})
+				continue
+			}
+			values = append(values, []interface{}{timestamp, count})
+		}
+
+		ret = append(ret, HistogramValues{
+			Ref:    histogramRef(hit.Fields, groupBy),
+			Metric: metric,
+			Values: values,
+		})
+	}
+
+	return ret
+}
+
+func parseHistogramTimestamp(value interface{}) (int64, bool) {
+	switch v := value.(type) {
+	case float64:
+		return normalizeUnixTimestamp(v), true
+	case int64:
+		return normalizeUnixTimestamp(float64(v)), true
+	case int:
+		return normalizeUnixTimestamp(float64(v)), true
+	case string:
+		if ts, err := strconv.ParseFloat(v, 64); err == nil {
+			return normalizeUnixTimestamp(ts), true
+		}
+		if t, err := time.Parse(time.RFC3339Nano, v); err == nil {
+			return t.Unix(), true
+		}
+		if t, err := time.Parse(time.RFC3339, v); err == nil {
+			return t.Unix(), true
+		}
+		return 0, false
+	default:
+		return 0, false
+	}
+}
+
+func normalizeUnixTimestamp(value float64) int64 {
+	if value > 1e17 {
+		return int64(value / 1e9)
+	}
+	if value > 1e14 {
+		return int64(value / 1e6)
+	}
+	if value > 1e11 {
+		return int64(value / 1000)
+	}
+	return int64(value)
+}
+
+func defaultHistogramStep(start, end int64) string {
+	return histogramWidthToStep(defaultHistogramWidthBySeconds(start, end))
+}
+
+func defaultHistogramWidthBySeconds(start, end int64) int64 {
+	diff := end - start
+	switch {
+	case diff <= 60:
+		return 1
+	case diff <= 300:
+		return 5
+	case diff <= 900:
+		return 30
+	case diff <= 1800:
+		return 30
+	case diff <= 3600:
+		return 60
+	case diff <= 3600*6:
+		return 5 * 60
+	case diff <= 3600*12:
+		return 10 * 60
+	case diff <= 3600*24:
+		return 30 * 60
+	case diff <= 3600*24*2:
+		return 60 * 60
+	case diff <= 3600*24*7:
+		return 3 * 60 * 60
+	case diff <= 3600*24*30:
+		return 12 * 60 * 60
+	case diff <= 3600*24*90:
+		return 24 * 60 * 60
+	default:
+		return 2 * 24 * 60 * 60
+	}
+}
+
+func histogramWidthToStep(width int64) string {
+	switch {
+	case width%86400 == 0:
+		return fmt.Sprintf("%dd", width/86400)
+	case width%3600 == 0:
+		return fmt.Sprintf("%dh", width/3600)
+	case width%60 == 0:
+		return fmt.Sprintf("%dm", width/60)
+	default:
+		return fmt.Sprintf("%ds", width)
+	}
+}
+
+func parseHistogramValue(value interface{}) (float64, bool) {
+	switch v := value.(type) {
+	case nil:
+		return 0, false
+	case float64:
+		return v, true
+	case int64:
+		return float64(v), true
+	case int:
+		return float64(v), true
+	case string:
+		f, err := strconv.ParseFloat(v, 64)
+		return f, err == nil
+	default:
+		return 0, false
+	}
+}
+
+func histogramRef(fields map[string]string, groupBy string) string {
+	if len(fields) == 0 {
+		return ""
+	}
+
+	if groupBy != "" {
+		if value, ok := fields[groupBy]; ok {
+			return value
+		}
+	}
+
+	keys := make([]string, 0, len(fields))
+	for key := range fields {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%s", key, fields[key]))
+	}
+
+	return strings.Join(parts, ",")
 }
 
 // MakeLogQuery 构造日志查询参数

--- a/datasource/victorialogs/victorialogs.go
+++ b/datasource/victorialogs/victorialogs.go
@@ -32,9 +32,9 @@ type VictoriaLogs struct {
 // Query 查询参数
 type Query struct {
 	Query   string `json:"query" mapstructure:"query"`   // LogsQL 查询语句
-	Start   int64  `json:"start" mapstructure:"start"`   // 开始时间（秒）
-	End     int64  `json:"end" mapstructure:"end"`       // 结束时间（秒）
-	Time    int64  `json:"time" mapstructure:"time"`     // 单点时间（秒）- 用于告警
+	Start   int64  `json:"start" mapstructure:"start"`   // 开始时间（秒/毫秒等 unix 单位，dskit 归一化为毫秒）
+	End     int64  `json:"end" mapstructure:"end"`       // 结束时间（秒/毫秒等 unix 单位，dskit 归一化为毫秒）
+	Time    int64  `json:"time" mapstructure:"time"`     // 单点时间（秒/毫秒等 unix 单位，dskit 归一化为毫秒）
 	Step    string `json:"step" mapstructure:"step"`     // 步长，如 "1m", "5m"
 	Limit   int    `json:"limit" mapstructure:"limit"`   // 限制返回数量
 	Offset  int    `json:"offset" mapstructure:"offset"` // 偏移量
@@ -205,7 +205,7 @@ func (vl *VictoriaLogs) QueryHistogram(ctx context.Context, queryParam interface
 		groupByFields = append(groupByFields, param.GroupBy)
 	}
 	if param.Step == "" {
-		param.Step = dskittypes.DefaultHistogramStep(param.Start, param.End)
+		param.Step = dskittypes.DefaultHistogramStepFromUnixRange(param.Start, param.End)
 	}
 
 	result, err := vl.QueryHitsWithFieldsLimit(ctx, param.Query, param.Start, param.End, param.Step, param.FieldsLimit, groupByFields...)
@@ -268,7 +268,7 @@ func (vl *VictoriaLogs) queryDataInstant(ctx context.Context, param *Query) ([]m
 		queryTime = param.End // 如果没有 time，使用 end 作为查询时间点
 	}
 	if queryTime == 0 {
-		queryTime = time.Now().Unix()
+		queryTime = time.Now().UnixMilli()
 	}
 
 	result, err := vl.StatsQuery(ctx, param.Query, queryTime)
@@ -283,11 +283,10 @@ func (vl *VictoriaLogs) queryDataInstant(ctx context.Context, param *Query) ([]m
 func (vl *VictoriaLogs) queryDataRange(ctx context.Context, param *Query) ([]models.DataResp, error) {
 	step := param.Step
 	if step == "" {
-		// 根据时间范围计算合适的步长
-		duration := param.End - param.Start
-		if duration <= 3600 {
+		durationSec := dskittypes.UnixRangeDurationSeconds(param.Start, param.End)
+		if durationSec <= 3600 {
 			step = "1m" // 1 小时内，1 分钟步长
-		} else if duration <= 86400 {
+		} else if durationSec <= 86400 {
 			step = "5m" // 1 天内，5 分钟步长
 		} else {
 			step = "1h" // 超过 1 天，1 小时步长
@@ -405,14 +404,14 @@ func convertHitsToHistogramValues(hits []victorialogs.HitResult, groupBy string)
 func parseHistogramTimestamp(value interface{}) (int64, bool) {
 	switch v := value.(type) {
 	case float64:
-		return normalizeUnixTimestamp(v), true
+		return dskittypes.NormalizeUnixTimestamp(v), true
 	case int64:
-		return normalizeUnixTimestamp(float64(v)), true
+		return dskittypes.NormalizeUnixSeconds(v), true
 	case int:
-		return normalizeUnixTimestamp(float64(v)), true
+		return dskittypes.NormalizeUnixSeconds(int64(v)), true
 	case string:
 		if ts, err := strconv.ParseFloat(v, 64); err == nil {
-			return normalizeUnixTimestamp(ts), true
+			return dskittypes.NormalizeUnixTimestamp(ts), true
 		}
 		if t, err := time.Parse(time.RFC3339Nano, v); err == nil {
 			return t.Unix(), true
@@ -424,19 +423,6 @@ func parseHistogramTimestamp(value interface{}) (int64, bool) {
 	default:
 		return 0, false
 	}
-}
-
-func normalizeUnixTimestamp(value float64) int64 {
-	if value > 1e17 {
-		return int64(value / 1e9)
-	}
-	if value > 1e14 {
-		return int64(value / 1e6)
-	}
-	if value > 1e11 {
-		return int64(value / 1000)
-	}
-	return int64(value)
 }
 
 func parseHistogramValue(value interface{}) (float64, bool) {
@@ -542,7 +528,7 @@ func (vl *VictoriaLogs) QueryMapData(ctx context.Context, query interface{}) ([]
 
 	// 扩大查询范围，解决时间滞后问题
 	if param.End > 0 && param.Start > 0 {
-		param.Start = param.Start - 30
+		param.Start = dskittypes.NormalizeUnixMillisecondsInt(param.Start) - 30*1000
 	}
 
 	// 限制只取 1 条

--- a/datasource/victorialogs/victorialogs_test.go
+++ b/datasource/victorialogs/victorialogs_test.go
@@ -72,9 +72,21 @@ func TestDefaultHistogramStep(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if got := defaultHistogramStep(c.start, c.end); got != c.want {
+			if got := vlkit.DefaultHistogramStep(c.start, c.end); got != c.want {
 				t.Fatalf("unexpected step: got %q, want %q", got, c.want)
 			}
 		})
+	}
+}
+
+func TestVictoriaLogsFieldSuggestionTypes(t *testing.T) {
+	field := FieldName{Field: "status", Type: "string", Builtin: false}
+	if field.Field != "status" || field.Type != "string" || field.Builtin {
+		t.Fatalf("unexpected field name suggestion: %+v", field)
+	}
+
+	value := FieldValue{Value: "200", Count: 123}
+	if value.Value != "200" || value.Count != 123 {
+		t.Fatalf("unexpected field value suggestion: %+v", value)
 	}
 }

--- a/datasource/victorialogs/victorialogs_test.go
+++ b/datasource/victorialogs/victorialogs_test.go
@@ -1,11 +1,169 @@
 package victorialogs
 
 import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"testing"
 
 	vlkit "github.com/ccfos/nightingale/v6/dskit/victorialogs"
 )
+
+func TestApplyLogSortQuery(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+		desc  bool
+		want  string
+	}{
+		{
+			name:  "desc",
+			query: "*",
+			desc:  true,
+			want:  "* | sort by (_time) desc",
+		},
+		{
+			name:  "asc",
+			query: "error",
+			desc:  false,
+			want:  "error | sort by (_time)",
+		},
+		{
+			name:  "skip existing sort",
+			query: "error | sort by (service) desc",
+			desc:  true,
+			want:  "error | sort by (service) desc",
+		},
+		{
+			name:  "skip existing order alias",
+			query: "error | order by (service) desc",
+			desc:  true,
+			want:  "error | order by (service) desc",
+		},
+		{
+			name:  "do not treat sort prefix as sort pipe",
+			query: "error | sort_stats by (service)",
+			desc:  true,
+			want:  "error | sort_stats by (service) | sort by (_time) desc",
+		},
+		{
+			name:  "empty query unchanged",
+			query: "",
+			desc:  true,
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := applyLogSortQuery(tt.query, tt.desc); got != tt.want {
+				t.Fatalf("unexpected query: got %q want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveLogTimeDesc(t *testing.T) {
+	tests := []struct {
+		name    string
+		reverse bool
+		want    bool
+	}{
+		{name: "reverse true", reverse: true, want: true},
+		{name: "reverse false", want: false},
+		{name: "default asc", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			param := &Query{Reverse: tt.reverse}
+			if got := resolveLogTimeDesc(param); got != tt.want {
+				t.Fatalf("resolveLogTimeDesc() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestQueryLogAddsSort(t *testing.T) {
+	var queryQuery string
+	var hitsQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatal(err)
+		}
+		switch r.URL.Path {
+		case "/select/logsql/query":
+			queryQuery = r.Form.Get("query")
+			fmt.Fprintln(w, `{"_time":"2026-07-02T00:00:01Z","_msg":"a"}`)
+			fmt.Fprintln(w, `{"_time":"2026-07-02T00:00:02Z","_msg":"b"}`)
+		case "/select/logsql/hits":
+			hitsQuery = r.Form.Get("query")
+			fmt.Fprintln(w, `{"hits":[{"total":2,"fields":{},"timestamps":[],"values":[]}]}`)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	vl := &VictoriaLogs{
+		VictoriaLogs: vlkit.VictoriaLogs{
+			VictorialogsAddr: server.URL,
+			MaxQueryRows:     1000,
+		},
+	}
+	if err := vl.InitClient(); err != nil {
+		t.Fatalf("InitClient error: %v", err)
+	}
+
+	_, total, err := vl.QueryLog(context.Background(), Query{
+		Query: "*",
+		Start: 11,
+		End:   22,
+		Limit: 30,
+	})
+	if err != nil {
+		t.Fatalf("QueryLog error: %v", err)
+	}
+	if queryQuery != "* | sort by (_time)" {
+		t.Fatalf("unexpected query query: %q", queryQuery)
+	}
+	if hitsQuery != "*" {
+		t.Fatalf("hits should use original query without sort pipe: %q", hitsQuery)
+	}
+	if total != 2 {
+		t.Fatalf("unexpected total: %d", total)
+	}
+
+	_, _, err = vl.QueryLog(context.Background(), map[string]interface{}{
+		"query":   "*",
+		"start":   int64(11),
+		"end":     int64(22),
+		"limit":   30,
+		"reverse": false,
+	})
+	if err != nil {
+		t.Fatalf("QueryLog with reverse=false error: %v", err)
+	}
+	if queryQuery != "* | sort by (_time)" {
+		t.Fatalf("unexpected asc query: %q", queryQuery)
+	}
+
+	_, _, err = vl.QueryLog(context.Background(), map[string]interface{}{
+		"query":   "*",
+		"start":   int64(11),
+		"end":     int64(22),
+		"limit":   30,
+		"reverse": true,
+	})
+	if err != nil {
+		t.Fatalf("QueryLog with reverse=true error: %v", err)
+	}
+	if queryQuery != "* | sort by (_time) desc" {
+		t.Fatalf("unexpected desc query: %q", queryQuery)
+	}
+}
 
 func TestConvertHitsToHistogramValues(t *testing.T) {
 	hits := []vlkit.HitResult{

--- a/datasource/victorialogs/victorialogs_test.go
+++ b/datasource/victorialogs/victorialogs_test.go
@@ -165,6 +165,51 @@ func TestQueryLogAddsSort(t *testing.T) {
 	}
 }
 
+func TestQueryHistogramNormalizesMillisecondRange(t *testing.T) {
+	var gotStart, gotEnd, gotStep string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/select/logsql/hits" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatal(err)
+		}
+		gotStart = r.Form.Get("start")
+		gotEnd = r.Form.Get("end")
+		gotStep = r.Form.Get("step")
+		fmt.Fprintln(w, `{"hits":[{"fields":{},"timestamps":["2026-07-20T06:00:00Z","2026-07-20T06:05:00Z"],"values":["1","2"]}]}`)
+	}))
+	defer server.Close()
+
+	vl := &VictoriaLogs{
+		VictoriaLogs: vlkit.VictoriaLogs{
+			VictorialogsAddr: server.URL,
+			MaxQueryRows:     1000,
+		},
+	}
+	if err := vl.InitClient(); err != nil {
+		t.Fatalf("InitClient error: %v", err)
+	}
+
+	got, err := vl.QueryHistogram(context.Background(), HistogramQuery{
+		Query: "*",
+		Start: 1784526946385,
+		End:   1784537746385,
+	})
+	if err != nil {
+		t.Fatalf("QueryHistogram error: %v", err)
+	}
+	if gotStart != "1784526946385" || gotEnd != "1784537746385" {
+		t.Fatalf("unexpected normalized range: start=%q end=%q", gotStart, gotEnd)
+	}
+	if gotStep != "5m" {
+		t.Fatalf("unexpected step for ~3h range: %q", gotStep)
+	}
+	if len(got) != 1 || len(got[0].Values) != 2 {
+		t.Fatalf("unexpected histogram buckets: %#v", got)
+	}
+}
+
 func TestConvertHitsToHistogramValues(t *testing.T) {
 	hits := []vlkit.HitResult{
 		{

--- a/datasource/victorialogs/victorialogs_test.go
+++ b/datasource/victorialogs/victorialogs_test.go
@@ -47,38 +47,6 @@ func TestHistogramRefFallbackSortsFields(t *testing.T) {
 	}
 }
 
-func TestDefaultHistogramStep(t *testing.T) {
-	cases := []struct {
-		name  string
-		start int64
-		end   int64
-		want  string
-	}{
-		{name: "empty range", start: 10, end: 10, want: "1s"},
-		{name: "one minute", start: 0, end: 60, want: "1s"},
-		{name: "five minutes", start: 0, end: 300, want: "5s"},
-		{name: "fifteen minutes", start: 0, end: 900, want: "30s"},
-		{name: "thirty minutes", start: 0, end: 1800, want: "30s"},
-		{name: "one hour", start: 0, end: 3600, want: "1m"},
-		{name: "six hours", start: 0, end: 3600 * 6, want: "5m"},
-		{name: "twelve hours", start: 0, end: 3600 * 12, want: "10m"},
-		{name: "one day", start: 0, end: 86400, want: "30m"},
-		{name: "two days", start: 0, end: 86400 * 2, want: "1h"},
-		{name: "one week", start: 0, end: 86400 * 7, want: "3h"},
-		{name: "thirty days", start: 0, end: 86400 * 30, want: "12h"},
-		{name: "ninety days", start: 0, end: 86400 * 90, want: "1d"},
-		{name: "more than ninety days", start: 0, end: 86400*90 + 1, want: "2d"},
-	}
-
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			if got := vlkit.DefaultHistogramStep(c.start, c.end); got != c.want {
-				t.Fatalf("unexpected step: got %q, want %q", got, c.want)
-			}
-		})
-	}
-}
-
 func TestVictoriaLogsFieldSuggestionTypes(t *testing.T) {
 	field := FieldName{Field: "status"}
 	if field.Field != "status" {

--- a/datasource/victorialogs/victorialogs_test.go
+++ b/datasource/victorialogs/victorialogs_test.go
@@ -1,0 +1,80 @@
+package victorialogs
+
+import (
+	"reflect"
+	"testing"
+
+	vlkit "github.com/ccfos/nightingale/v6/dskit/victorialogs"
+)
+
+func TestConvertHitsToHistogramValues(t *testing.T) {
+	hits := []vlkit.HitResult{
+		{
+			Timestamps: []interface{}{"2026-07-02T00:00:00Z", float64(1782950700000), float64(1782951000000000000), "bad"},
+			Values:     []interface{}{"3", nil, 4, "5"},
+			Fields: map[string]string{
+				"service": "api",
+				"level":   "error",
+			},
+		},
+	}
+
+	got := convertHitsToHistogramValues(hits, "service")
+	if len(got) != 1 {
+		t.Fatalf("expected 1 series, got %d", len(got))
+	}
+	if got[0].Ref != "api" {
+		t.Fatalf("unexpected ref: %q", got[0].Ref)
+	}
+	if !reflect.DeepEqual(got[0].Metric, map[string]interface{}{"service": "api", "level": "error"}) {
+		t.Fatalf("unexpected metric: %#v", got[0].Metric)
+	}
+
+	wantValues := [][]interface{}{
+		{int64(1782950400), float64(3)},
+		{int64(1782950700), nil},
+		{int64(1782951000), float64(4)},
+	}
+	if !reflect.DeepEqual(got[0].Values, wantValues) {
+		t.Fatalf("unexpected values: %#v", got[0].Values)
+	}
+}
+
+func TestHistogramRefFallbackSortsFields(t *testing.T) {
+	got := histogramRef(map[string]string{"b": "2", "a": "1"}, "")
+	if got != "a=1,b=2" {
+		t.Fatalf("unexpected ref: %q", got)
+	}
+}
+
+func TestDefaultHistogramStep(t *testing.T) {
+	cases := []struct {
+		name  string
+		start int64
+		end   int64
+		want  string
+	}{
+		{name: "empty range", start: 10, end: 10, want: "1s"},
+		{name: "one minute", start: 0, end: 60, want: "1s"},
+		{name: "five minutes", start: 0, end: 300, want: "5s"},
+		{name: "fifteen minutes", start: 0, end: 900, want: "30s"},
+		{name: "thirty minutes", start: 0, end: 1800, want: "30s"},
+		{name: "one hour", start: 0, end: 3600, want: "1m"},
+		{name: "six hours", start: 0, end: 3600 * 6, want: "5m"},
+		{name: "twelve hours", start: 0, end: 3600 * 12, want: "10m"},
+		{name: "one day", start: 0, end: 86400, want: "30m"},
+		{name: "two days", start: 0, end: 86400 * 2, want: "1h"},
+		{name: "one week", start: 0, end: 86400 * 7, want: "3h"},
+		{name: "thirty days", start: 0, end: 86400 * 30, want: "12h"},
+		{name: "ninety days", start: 0, end: 86400 * 90, want: "1d"},
+		{name: "more than ninety days", start: 0, end: 86400*90 + 1, want: "2d"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := defaultHistogramStep(c.start, c.end); got != c.want {
+				t.Fatalf("unexpected step: got %q, want %q", got, c.want)
+			}
+		})
+	}
+}

--- a/datasource/victorialogs/victorialogs_test.go
+++ b/datasource/victorialogs/victorialogs_test.go
@@ -80,8 +80,8 @@ func TestDefaultHistogramStep(t *testing.T) {
 }
 
 func TestVictoriaLogsFieldSuggestionTypes(t *testing.T) {
-	field := FieldName{Field: "status", Type: "string", Builtin: false}
-	if field.Field != "status" || field.Type != "string" || field.Builtin {
+	field := FieldName{Field: "status"}
+	if field.Field != "status" {
 		t.Fatalf("unexpected field name suggestion: %+v", field)
 	}
 

--- a/dscache/sync.go
+++ b/dscache/sync.go
@@ -12,11 +12,13 @@ import (
 	_ "github.com/ccfos/nightingale/v6/datasource/doris"
 	"github.com/ccfos/nightingale/v6/datasource/es"
 	_ "github.com/ccfos/nightingale/v6/datasource/iotdb"
+	_ "github.com/ccfos/nightingale/v6/datasource/loki"
 	_ "github.com/ccfos/nightingale/v6/datasource/mysql"
 	_ "github.com/ccfos/nightingale/v6/datasource/opensearch"
 	_ "github.com/ccfos/nightingale/v6/datasource/postgresql"
 	_ "github.com/ccfos/nightingale/v6/datasource/victorialogs"
 	iotdbkit "github.com/ccfos/nightingale/v6/dskit/iotdb"
+	lokikit "github.com/ccfos/nightingale/v6/dskit/loki"
 	"github.com/ccfos/nightingale/v6/dskit/tdengine"
 	"github.com/ccfos/nightingale/v6/models"
 	"github.com/ccfos/nightingale/v6/pkg/ctx"
@@ -134,6 +136,8 @@ func getDatasourcesFromDBLoop(ctx *ctx.Context, fromAPI bool) {
 					tdN9eToDatasourceInfo(&ds, item)
 				} else if item.PluginType == "iotdb" {
 					iotdbN9eToDatasourceInfo(&ds, item)
+				} else if item.PluginType == "loki" {
+					lokiN9eToDatasourceInfo(&ds, item)
 				} else {
 					ds.Settings = make(map[string]interface{})
 					for k, v := range item.SettingsJson {
@@ -190,6 +194,28 @@ func iotdbN9eToDatasourceInfo(ds *datasource.DatasourceInfo, item models.Datasou
 	}
 }
 
+func lokiN9eToDatasourceInfo(ds *datasource.DatasourceInfo, item models.Datasource) {
+	ds.Settings = make(map[string]interface{})
+	for k, v := range item.SettingsJson {
+		ds.Settings[k] = v
+	}
+
+	ds.Settings["loki.cluster_name"] = item.ClusterName
+	ds.Settings["loki.addr"] = item.HTTPJson.Url
+	ds.Settings["loki.timeout"] = item.HTTPJson.Timeout
+	ds.Settings["loki.dial_timeout"] = item.HTTPJson.DialTimeout
+	ds.Settings["loki.max_idle_conns_per_host"] = item.HTTPJson.MaxIdleConnsPerHost
+	ds.Settings["loki.headers"] = item.HTTPJson.Headers
+	ds.Settings["loki.tls"] = lokikit.LokiTLS{
+		SkipTlsVerify: item.HTTPJson.TLS.SkipTlsVerify,
+	}
+	ds.Settings["loki.basic"] = lokikit.LokiBasicAuth{
+		LokiUser:      item.AuthJson.BasicAuthUser,
+		LokiPass:      item.AuthJson.BasicAuthPassword,
+		LokiIsEncrypt: false,
+	}
+}
+
 func esN9eToDatasourceInfo(ds *datasource.DatasourceInfo, item models.Datasource) {
 	ds.Settings = make(map[string]interface{})
 	ds.Settings["es.nodes"] = []string{item.HTTPJson.Url}
@@ -218,10 +244,6 @@ func PutDatasources(items []datasource.DatasourceInfo) {
 
 	for _, item := range items {
 		if item.Type == "prometheus" {
-			continue
-		}
-
-		if item.Type == "loki" {
 			continue
 		}
 

--- a/dscache/sync_test.go
+++ b/dscache/sync_test.go
@@ -1,0 +1,64 @@
+package dscache
+
+import (
+	"testing"
+
+	"github.com/ccfos/nightingale/v6/datasource"
+	lokikit "github.com/ccfos/nightingale/v6/dskit/loki"
+	"github.com/ccfos/nightingale/v6/models"
+)
+
+func TestLokiN9eToDatasourceInfoMergesSettingsJson(t *testing.T) {
+	ds := &datasource.DatasourceInfo{}
+	item := models.Datasource{
+		Name:        "prod-loki",
+		ClusterName: "edge-a",
+		SettingsJson: map[string]interface{}{
+			"custom":    "kept",
+			"loki.addr": "http://old.example",
+		},
+		HTTPJson: models.HTTP{
+			Url:                 "http://loki.example",
+			Timeout:             1234,
+			DialTimeout:         567,
+			MaxIdleConnsPerHost: 8,
+			Headers:             map[string]string{"X-Scope-OrgID": "team-a"},
+			TLS: models.TLS{
+				SkipTlsVerify: true,
+			},
+		},
+		AuthJson: models.Auth{
+			BasicAuthUser:     "user",
+			BasicAuthPassword: "pass",
+		},
+	}
+
+	lokiN9eToDatasourceInfo(ds, item)
+
+	if got := ds.Settings["custom"]; got != "kept" {
+		t.Fatalf("expected custom setting to be preserved, got %#v", got)
+	}
+	if got := ds.Settings["loki.addr"]; got != "http://loki.example" {
+		t.Fatalf("expected http url to override settings addr, got %#v", got)
+	}
+	if got := ds.Settings["loki.cluster_name"]; got != "edge-a" {
+		t.Fatalf("expected cluster name from datasource cluster_name, got %#v", got)
+	}
+	basic, ok := ds.Settings["loki.basic"].(lokikit.LokiBasicAuth)
+	if !ok {
+		t.Fatalf("expected loki.basic type, got %#v", ds.Settings["loki.basic"])
+	}
+	if basic.LokiUser != "user" || basic.LokiPass != "pass" {
+		t.Fatalf("unexpected basic auth: %#v", basic)
+	}
+}
+
+func TestLokiN9eToDatasourceInfoDoesNotInventMaxQueryRows(t *testing.T) {
+	ds := &datasource.DatasourceInfo{}
+
+	lokiN9eToDatasourceInfo(ds, models.Datasource{})
+
+	if _, exists := ds.Settings["loki.max_query_rows"]; exists {
+		t.Fatalf("loki.max_query_rows should not be invented by dscache conversion")
+	}
+}

--- a/dskit/loki/logql.go
+++ b/dskit/loki/logql.go
@@ -1,0 +1,320 @@
+package loki
+
+import "strings"
+
+type LogQLFieldInfo struct {
+	Selector        string
+	NeedsLabelNames bool
+}
+
+type LogQLLabelMatcher struct {
+	Key   string
+	Op    string
+	Value string
+}
+
+var parsedFieldStages = map[string]struct{}{
+	"json":         {},
+	"logfmt":       {},
+	"regexp":       {},
+	"pattern":      {},
+	"unpack":       {},
+	"label_format": {},
+}
+
+func AnalyzeLogQLForLogFields(query string) LogQLFieldInfo {
+	selector, selectorEnd := firstSelector(query)
+	return LogQLFieldInfo{
+		Selector:        selector,
+		NeedsLabelNames: hasParsedFieldStage(query[selectorEnd:]),
+	}
+}
+
+func ExtractLogQLLabelMatchers(query string) []LogQLLabelMatcher {
+	selector, _ := firstSelector(query)
+	return ExtractLogQLLabelMatchersFromSelector(selector)
+}
+
+func ExtractLogQLLabelMatchersFromSelector(selector string) []LogQLLabelMatcher {
+	if len(selector) < 2 || selector[0] != '{' || selector[len(selector)-1] != '}' {
+		return nil
+	}
+
+	parts := splitOutsideQuotes(selector[1:len(selector)-1], ',')
+	matchers := make([]LogQLLabelMatcher, 0, len(parts))
+	for _, part := range parts {
+		key, op, value, ok := parseLabelMatcher(part)
+		if !ok {
+			continue
+		}
+		matchers = append(matchers, LogQLLabelMatcher{
+			Key:   key,
+			Op:    op,
+			Value: value,
+		})
+	}
+	return matchers
+}
+
+func firstSelector(query string) (string, int) {
+	inQuote := rune(0)
+	escaped := false
+	for i, r := range query {
+		if inQuote != 0 {
+			if escaped {
+				escaped = false
+				continue
+			}
+			if r == '\\' {
+				escaped = true
+				continue
+			}
+			if r == inQuote {
+				inQuote = 0
+			}
+			continue
+		}
+		if r == '"' || r == '\'' || r == '`' {
+			inQuote = r
+			continue
+		}
+		if r == '{' {
+			if end := selectorEnd(query, i); end > i {
+				return query[i:end], end
+			}
+			return "", i
+		}
+	}
+	return "", 0
+}
+
+func selectorEnd(query string, start int) int {
+	inQuote := rune(0)
+	escaped := false
+	for i, r := range query[start+1:] {
+		index := start + 1 + i
+		if inQuote != 0 {
+			if escaped {
+				escaped = false
+				continue
+			}
+			if r == '\\' {
+				escaped = true
+				continue
+			}
+			if r == inQuote {
+				inQuote = 0
+			}
+			continue
+		}
+		if r == '"' || r == '\'' || r == '`' {
+			inQuote = r
+			continue
+		}
+		if r == '}' {
+			return index + 1
+		}
+	}
+	return -1
+}
+
+func hasParsedFieldStage(query string) bool {
+	inQuote := rune(0)
+	escaped := false
+	for i, r := range query {
+		if inQuote != 0 {
+			if escaped {
+				escaped = false
+				continue
+			}
+			if r == '\\' {
+				escaped = true
+				continue
+			}
+			if r == inQuote {
+				inQuote = 0
+			}
+			continue
+		}
+		if r == '"' || r == '\'' || r == '`' {
+			inQuote = r
+			continue
+		}
+		if r != '|' {
+			continue
+		}
+		next := skipSpaces(query, i+1)
+		if next >= len(query) || query[next] == '=' || query[next] == '~' {
+			continue
+		}
+		stage, _ := readIdentifier(query, next)
+		if _, ok := parsedFieldStages[strings.ToLower(stage)]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func skipSpaces(input string, start int) int {
+	for start < len(input) && (input[start] == ' ' || input[start] == '\t' || input[start] == '\n' || input[start] == '\r') {
+		start++
+	}
+	return start
+}
+
+func readIdentifier(input string, start int) (string, int) {
+	end := start
+	for end < len(input) {
+		c := input[end]
+		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' {
+			end++
+			continue
+		}
+		break
+	}
+	return input[start:end], end
+}
+
+func splitOutsideQuotes(input string, sep rune) []string {
+	parts := make([]string, 0)
+	inQuote := rune(0)
+	escaped := false
+	start := 0
+	for i, r := range input {
+		if inQuote != 0 {
+			if escaped {
+				escaped = false
+				continue
+			}
+			if r == '\\' && inQuote != '`' {
+				escaped = true
+				continue
+			}
+			if r == inQuote {
+				inQuote = 0
+			}
+			continue
+		}
+		if r == '"' || r == '\'' || r == '`' {
+			inQuote = r
+			continue
+		}
+		if r == sep {
+			parts = append(parts, input[start:i])
+			start = i + len(string(r))
+		}
+	}
+	parts = append(parts, input[start:])
+	return parts
+}
+
+func parseLabelMatcher(input string) (string, string, string, bool) {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return "", "", "", false
+	}
+
+	key, op, value, ok := splitLabelMatcher(input)
+	if !ok {
+		return "", "", "", false
+	}
+	key = strings.TrimSpace(key)
+	value = strings.TrimSpace(value)
+	if key == "" || value == "" {
+		return "", "", "", false
+	}
+	return key, op, unquoteLogQLString(value), true
+}
+
+func splitLabelMatcher(input string) (string, string, string, bool) {
+	inQuote := rune(0)
+	escaped := false
+	for i, r := range input {
+		if inQuote != 0 {
+			if escaped {
+				escaped = false
+				continue
+			}
+			if r == '\\' && inQuote != '`' {
+				escaped = true
+				continue
+			}
+			if r == inQuote {
+				inQuote = 0
+			}
+			continue
+		}
+		if r == '"' || r == '\'' || r == '`' {
+			inQuote = r
+			continue
+		}
+		if r != '=' && r != '!' {
+			continue
+		}
+
+		next := i + 1
+		if next >= len(input) {
+			return "", "", "", false
+		}
+		switch {
+		case r == '=' && input[next] == '~':
+			return input[:i], "=~", input[next+1:], true
+		case r == '!' && input[next] == '~':
+			return input[:i], "!~", input[next+1:], true
+		case r == '!' && input[next] == '=':
+			return input[:i], "!=", input[next+1:], true
+		case r == '=':
+			return input[:i], "=", input[next:], true
+		}
+	}
+	return "", "", "", false
+}
+
+func unquoteLogQLString(input string) string {
+	input = strings.TrimSpace(input)
+	if len(input) < 2 {
+		return input
+	}
+
+	quote := input[0]
+	if (quote != '"' && quote != '\'' && quote != '`') || input[len(input)-1] != quote {
+		return input
+	}
+	content := input[1 : len(input)-1]
+	if quote == '`' {
+		return content
+	}
+	return unescapeLogQLString(content)
+}
+
+func unescapeLogQLString(input string) string {
+	var b strings.Builder
+	b.Grow(len(input))
+	escaped := false
+	for _, r := range input {
+		if !escaped {
+			if r == '\\' {
+				escaped = true
+				continue
+			}
+			b.WriteRune(r)
+			continue
+		}
+
+		switch r {
+		case 'n':
+			b.WriteRune('\n')
+		case 'r':
+			b.WriteRune('\r')
+		case 't':
+			b.WriteRune('\t')
+		default:
+			b.WriteRune(r)
+		}
+		escaped = false
+	}
+	if escaped {
+		b.WriteRune('\\')
+	}
+	return b.String()
+}

--- a/dskit/loki/loki.go
+++ b/dskit/loki/loki.go
@@ -289,12 +289,18 @@ func (vl *Loki) ParsedFields(ctx context.Context, query string, start, end int64
 }
 
 func NormalizeLogs(resp *QueryResponse) []NormalizedLog {
+	return NormalizeLogsWithLabelNames(resp, nil)
+}
+
+func NormalizeLogsWithLabelNames(resp *QueryResponse, labelNames []string) []NormalizedLog {
 	if resp == nil {
 		return nil
 	}
 
+	labelNameSet := makeLabelNameSet(labelNames)
 	ret := make([]NormalizedLog, 0)
 	for _, item := range resp.Data.Result {
+		labels, parsedFields := splitStreamFields(item.Stream, labelNameSet)
 		for _, value := range item.Values {
 			if len(value) < 2 {
 				continue
@@ -308,10 +314,59 @@ func NormalizeLogs(resp *QueryResponse) []NormalizedLog {
 				"timestamp":     tsNs / int64(time.Millisecond),
 				"__timestamp__": strconv.FormatInt(tsNs, 10),
 				"line":          line,
-				"stream":        item.Stream,
+				"labels":        copyStringMap(labels),
+				"parsed_fields": copyStringMap(parsedFields),
 			}
 			ret = append(ret, log)
 		}
+	}
+	return ret
+}
+
+func makeLabelNameSet(labelNames []string) map[string]struct{} {
+	if labelNames == nil {
+		return nil
+	}
+	ret := make(map[string]struct{}, len(labelNames))
+	for _, name := range labelNames {
+		if name == "" {
+			continue
+		}
+		ret[name] = struct{}{}
+	}
+	return ret
+}
+
+func splitStreamFields(stream map[string]string, labelNameSet map[string]struct{}) (map[string]string, map[string]string) {
+	if len(stream) == 0 {
+		return map[string]string{}, map[string]string{}
+	}
+	if labelNameSet == nil {
+		return copyStringMap(stream), map[string]string{}
+	}
+
+	labels := make(map[string]string)
+	parsedFields := make(map[string]string)
+	for key, value := range stream {
+		if _, ok := labelNameSet[key]; ok {
+			labels[key] = value
+			continue
+		}
+		if key == "__error__" || key == "__error_details__" {
+			continue
+		}
+		parsedFields[key] = value
+	}
+	return labels, parsedFields
+}
+
+func copyStringMap(src map[string]string) map[string]string {
+	if len(src) == 0 {
+		return map[string]string{}
+	}
+	ret := make(map[string]string, len(src))
+	for key, value := range src {
+		ret[key] = value
 	}
 	return ret
 }

--- a/dskit/loki/loki.go
+++ b/dskit/loki/loki.go
@@ -1,0 +1,470 @@
+package loki
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type LokiBasicAuth struct {
+	LokiUser      string `json:"loki.user" mapstructure:"loki.user"`
+	LokiPass      string `json:"loki.password" mapstructure:"loki.password"`
+	LokiIsEncrypt bool   `json:"loki.is_encrypt" mapstructure:"loki.is_encrypt"`
+}
+
+type LokiTLS struct {
+	SkipTlsVerify bool `json:"loki.tls.skip_tls_verify" mapstructure:"loki.tls.skip_tls_verify"`
+}
+
+type Loki struct {
+	LokiAddr  string        `json:"loki.addr" mapstructure:"loki.addr"`
+	LokiBasic LokiBasicAuth `json:"loki.basic" mapstructure:"loki.basic"`
+	LokiTls   LokiTLS       `json:"loki.tls" mapstructure:"loki.tls"`
+
+	Headers             map[string]string `json:"loki.headers" mapstructure:"loki.headers"`
+	Timeout             int64             `json:"loki.timeout" mapstructure:"loki.timeout"`
+	DialTimeout         int64             `json:"loki.dial_timeout" mapstructure:"loki.dial_timeout"`
+	MaxIdleConnsPerHost int               `json:"loki.max_idle_conns_per_host" mapstructure:"loki.max_idle_conns_per_host"`
+	ClusterName         string            `json:"loki.cluster_name" mapstructure:"loki.cluster_name"`
+	MaxQueryRows        int               `json:"loki.max_query_rows" mapstructure:"loki.max_query_rows"`
+	HTTPClient          *http.Client      `json:"-" mapstructure:"-"`
+}
+
+type QueryResponse struct {
+	Status string    `json:"status"`
+	Data   QueryData `json:"data"`
+	Error  string    `json:"error,omitempty"`
+}
+
+type QueryData struct {
+	ResultType string      `json:"resultType"`
+	Result     []QueryItem `json:"result"`
+}
+
+type QueryItem struct {
+	Stream map[string]string `json:"stream,omitempty"`
+	Metric map[string]string `json:"metric,omitempty"`
+	Value  []interface{}     `json:"value,omitempty"`
+	Values [][]interface{}   `json:"values,omitempty"`
+}
+
+type responseEnvelope struct {
+	Status    string          `json:"status"`
+	Data      json.RawMessage `json:"data"`
+	ErrorType string          `json:"errorType,omitempty"`
+	Error     string          `json:"error,omitempty"`
+}
+
+type LabelValue struct {
+	Value string `json:"value"`
+}
+
+type FieldMeta struct {
+	Field        string   `json:"field"`
+	InferredType string   `json:"inferred_type,omitempty"`
+	Values       []string `json:"values,omitempty"`
+}
+
+type NormalizedLog map[string]interface{}
+
+const (
+	parsedFieldsDefaultLimit = 200
+	parsedFieldsMaxLimit     = 500
+	parsedFieldValuesMax     = 100
+	parsedFieldsTimeout      = 5 * time.Second
+)
+
+func (vl *Loki) InitHTTPClient() error {
+	maxIdleConnsPerHost := vl.MaxIdleConnsPerHost
+	if maxIdleConnsPerHost <= 0 {
+		maxIdleConnsPerHost = 10
+	}
+
+	dialTimeout := time.Duration(vl.DialTimeout) * time.Millisecond
+	if dialTimeout == 0 {
+		dialTimeout = 30 * time.Second
+	}
+
+	transport := &http.Transport{
+		MaxIdleConns:        100,
+		MaxIdleConnsPerHost: maxIdleConnsPerHost,
+		IdleConnTimeout:     90 * time.Second,
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: vl.LokiTls.SkipTlsVerify,
+		},
+	}
+	transport.DialContext = (&netDialer{timeout: dialTimeout}).DialContext
+
+	timeout := time.Duration(vl.Timeout) * time.Millisecond
+	if timeout == 0 {
+		timeout = 60 * time.Second
+	}
+
+	vl.HTTPClient = &http.Client{
+		Transport: transport,
+		Timeout:   timeout,
+	}
+	return nil
+}
+
+type netDialer struct {
+	timeout time.Duration
+}
+
+func (d *netDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	dialer := &net.Dialer{Timeout: d.timeout}
+	return dialer.DialContext(ctx, network, address)
+}
+
+func (vl *Loki) LabelNames(ctx context.Context, query string, start, end int64, filter string, limit int) ([]string, error) {
+	params := url.Values{}
+	if query != "" {
+		params.Set("query", query)
+	}
+	addTimeRangeParams(params, start, end)
+
+	body, err := vl.doRequest(ctx, http.MethodGet, "/api/v1/labels", params)
+	if err != nil {
+		return nil, err
+	}
+
+	var envelope responseEnvelope
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return nil, fmt.Errorf("decode labels response failed: %w, body=%s", err, string(body))
+	}
+	if envelope.Status != "success" {
+		return nil, fmt.Errorf("labels query failed: %s", envelope.Error)
+	}
+
+	var values []string
+	if err := json.Unmarshal(envelope.Data, &values); err != nil {
+		return nil, fmt.Errorf("decode labels data failed: %w", err)
+	}
+	return filterStrings(values, filter, limit), nil
+}
+
+func (vl *Loki) LabelValues(ctx context.Context, query string, start, end int64, label, filter string, limit int) ([]LabelValue, error) {
+	params := url.Values{}
+	if query != "" {
+		params.Set("query", query)
+	}
+	addTimeRangeParams(params, start, end)
+
+	body, err := vl.doRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/label/%s/values", url.PathEscape(label)), params)
+	if err != nil {
+		return nil, err
+	}
+
+	var envelope responseEnvelope
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return nil, fmt.Errorf("decode label values response failed: %w, body=%s", err, string(body))
+	}
+	if envelope.Status != "success" {
+		return nil, fmt.Errorf("label values query failed: %s", envelope.Error)
+	}
+
+	var values []string
+	if err := json.Unmarshal(envelope.Data, &values); err != nil {
+		return nil, fmt.Errorf("decode label values data failed: %w", err)
+	}
+
+	values = filterStrings(values, filter, limit)
+	ret := make([]LabelValue, 0, len(values))
+	for _, value := range values {
+		ret = append(ret, LabelValue{Value: value})
+	}
+	return ret, nil
+}
+
+func (vl *Loki) QueryRange(ctx context.Context, query string, start, end int64, step string, limit int, direction string) (*QueryResponse, error) {
+	params := url.Values{}
+	params.Set("query", query)
+	addTimeRangeParams(params, start, end)
+	if step != "" {
+		params.Set("step", step)
+	}
+	if limit > 0 {
+		params.Set("limit", strconv.Itoa(limit))
+	}
+	if direction != "" {
+		params.Set("direction", direction)
+	}
+
+	body, err := vl.doRequest(ctx, http.MethodGet, "/api/v1/query_range", params)
+	if err != nil {
+		return nil, err
+	}
+
+	var result QueryResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("decode query_range response failed: %w, body=%s", err, string(body))
+	}
+	if result.Status != "success" {
+		return nil, fmt.Errorf("query_range failed: %s", result.Error)
+	}
+	return &result, nil
+}
+
+func (vl *Loki) QueryInstant(ctx context.Context, query string, ts int64) (*QueryResponse, error) {
+	params := url.Values{}
+	params.Set("query", query)
+	if ts > 0 {
+		params.Set("time", formatLokiTimestamp(ts))
+	}
+
+	body, err := vl.doRequest(ctx, http.MethodGet, "/api/v1/query", params)
+	if err != nil {
+		return nil, err
+	}
+
+	var result QueryResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("decode query response failed: %w, body=%s", err, string(body))
+	}
+	if result.Status != "success" {
+		return nil, fmt.Errorf("query failed: %s", result.Error)
+	}
+	return &result, nil
+}
+
+func (vl *Loki) ParsedFields(ctx context.Context, query string, start, end int64, limit int) ([]FieldMeta, error) {
+	if limit <= 0 {
+		limit = parsedFieldsDefaultLimit
+	}
+	if limit > parsedFieldsMaxLimit {
+		limit = parsedFieldsMaxLimit
+	}
+
+	queryCtx, cancel := context.WithTimeout(ctx, parsedFieldsTimeout)
+	defer cancel()
+
+	result, err := vl.QueryRange(queryCtx, query, start, end, "", limit, "backward")
+	if err != nil {
+		return nil, err
+	}
+
+	fieldValues := make(map[string]map[string]struct{})
+	for _, item := range result.Data.Result {
+		for key, value := range item.Stream {
+			if key == "" {
+				continue
+			}
+			if _, exists := fieldValues[key]; !exists {
+				fieldValues[key] = make(map[string]struct{})
+			}
+			if value != "" && len(fieldValues[key]) < parsedFieldValuesMax {
+				fieldValues[key][value] = struct{}{}
+			}
+		}
+	}
+
+	keys := make([]string, 0, len(fieldValues))
+	for key := range fieldValues {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	ret := make([]FieldMeta, 0, len(keys))
+	for _, key := range keys {
+		values := make([]string, 0, len(fieldValues[key]))
+		for value := range fieldValues[key] {
+			values = append(values, value)
+		}
+		sort.Strings(values)
+		ret = append(ret, FieldMeta{
+			Field:  key,
+			Values: values,
+		})
+	}
+	return ret, nil
+}
+
+func NormalizeLogs(resp *QueryResponse) []NormalizedLog {
+	if resp == nil {
+		return nil
+	}
+
+	ret := make([]NormalizedLog, 0)
+	for _, item := range resp.Data.Result {
+		for _, value := range item.Values {
+			if len(value) < 2 {
+				continue
+			}
+			tsNs, ok := ParseTimestampNanos(value[0])
+			if !ok {
+				continue
+			}
+			line := fmt.Sprintf("%v", value[1])
+			log := NormalizedLog{
+				"timestamp":     tsNs / int64(time.Millisecond),
+				"__timestamp__": strconv.FormatInt(tsNs, 10),
+				"line":          line,
+				"stream":        item.Stream,
+			}
+			ret = append(ret, log)
+		}
+	}
+	return ret
+}
+
+func (vl *Loki) apiURL(path string) (string, error) {
+	u, err := url.Parse(vl.LokiAddr)
+	if err != nil {
+		return "", err
+	}
+	basePath := strings.TrimRight(u.Path, "/")
+	apiPath := "/" + strings.TrimLeft(path, "/")
+	u.Path = basePath + apiPath
+	return u.String(), nil
+}
+
+func (vl *Loki) doRequest(ctx context.Context, method, path string, params url.Values) ([]byte, error) {
+	if vl.HTTPClient == nil {
+		if err := vl.InitHTTPClient(); err != nil {
+			return nil, err
+		}
+	}
+
+	endpoint, err := vl.apiURL(path)
+	if err != nil {
+		return nil, fmt.Errorf("invalid loki addr: %w", err)
+	}
+
+	if method == http.MethodGet && len(params) > 0 {
+		endpoint = endpoint + "?" + params.Encode()
+	}
+
+	var body io.Reader
+	if method != http.MethodGet {
+		body = strings.NewReader(params.Encode())
+	}
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, body)
+	if err != nil {
+		return nil, fmt.Errorf("create request failed: %w", err)
+	}
+	if method != http.MethodGet {
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	}
+	if vl.LokiBasic.LokiUser != "" {
+		req.SetBasicAuth(vl.LokiBasic.LokiUser, vl.LokiBasic.LokiPass)
+	}
+	for k, v := range vl.Headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := vl.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response body failed: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("loki request failed: path=%s status=%d body=%s", path, resp.StatusCode, string(respBody))
+	}
+	return respBody, nil
+}
+
+func addTimeRangeParams(params url.Values, start, end int64) {
+	if start > 0 {
+		params.Set("start", formatLokiTimestamp(start))
+	}
+	if end > 0 {
+		params.Set("end", formatLokiTimestamp(end))
+	}
+}
+
+func formatLokiTimestamp(value int64) string {
+	switch {
+	case value <= 0:
+		return "0"
+	case value < 1e12:
+		return strconv.FormatInt(value*int64(time.Second), 10)
+	case value < 1e15:
+		return strconv.FormatInt(value*int64(time.Millisecond), 10)
+	case value < 1e18:
+		return strconv.FormatInt(value*int64(time.Microsecond), 10)
+	default:
+		return strconv.FormatInt(value, 10)
+	}
+}
+
+func ParseTimestampNanos(value interface{}) (int64, bool) {
+	switch v := value.(type) {
+	case float64:
+		return normalizeUnixTimestampNanosFloat(v), true
+	case int64:
+		return normalizeUnixTimestampNanosInt(v), true
+	case int:
+		return normalizeUnixTimestampNanosInt(int64(v)), true
+	case string:
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil {
+			return normalizeUnixTimestampNanosInt(n), true
+		}
+		if strings.Contains(v, ".") {
+			if f, err := strconv.ParseFloat(v, 64); err == nil {
+				return normalizeUnixTimestampNanosFloat(f), true
+			}
+		}
+		if t, err := time.Parse(time.RFC3339Nano, v); err == nil {
+			return t.UnixNano(), true
+		}
+		if t, err := time.Parse(time.RFC3339, v); err == nil {
+			return t.UnixNano(), true
+		}
+	}
+	return 0, false
+}
+
+func normalizeUnixTimestampNanosInt(value int64) int64 {
+	switch {
+	case value > 1e17:
+		return value
+	case value > 1e14:
+		return value * int64(time.Microsecond)
+	case value > 1e11:
+		return value * int64(time.Millisecond)
+	default:
+		return value * int64(time.Second)
+	}
+}
+
+func normalizeUnixTimestampNanosFloat(value float64) int64 {
+	switch {
+	case value > 1e17:
+		return int64(value)
+	case value > 1e14:
+		return int64(value * 1e3)
+	case value > 1e11:
+		return int64(value * 1e6)
+	default:
+		return int64(value * 1e9)
+	}
+}
+
+func filterStrings(values []string, filter string, limit int) []string {
+	sort.Strings(values)
+	ret := make([]string, 0, len(values))
+	for _, value := range values {
+		if filter != "" && !strings.Contains(value, filter) {
+			continue
+		}
+		ret = append(ret, value)
+		if limit > 0 && len(ret) >= limit {
+			break
+		}
+	}
+	return ret
+}

--- a/dskit/loki/loki_test.go
+++ b/dskit/loki/loki_test.go
@@ -81,20 +81,263 @@ func TestNormalizeLogsKeepsMillisecondTimestampAndRawNanoseconds(t *testing.T) {
 	if _, exists := logs[0]["timestamp_ns"]; exists {
 		t.Fatalf("timestamp_ns should not be returned")
 	}
-	stream, ok := logs[0]["stream"].(map[string]string)
+	if _, exists := logs[0]["stream"]; exists {
+		t.Fatalf("stream should not be returned")
+	}
+	labels, ok := logs[0]["labels"].(map[string]string)
 	if !ok {
-		t.Fatalf("stream should be returned as map[string]string, got %#v", logs[0]["stream"])
+		t.Fatalf("labels should be returned as map[string]string, got %#v", logs[0]["labels"])
 	}
-	if got := stream["job"]; got != "api" {
-		t.Fatalf("unexpected stream job: got %#v", got)
+	if got := labels["job"]; got != "api" {
+		t.Fatalf("unexpected labels job: got %#v", got)
 	}
-	if _, exists := logs[0]["labels"]; exists {
-		t.Fatalf("labels should not be returned; Loki stream should be returned as stream")
+	parsedFields, ok := logs[0]["parsed_fields"].(map[string]string)
+	if !ok {
+		t.Fatalf("parsed_fields should be returned as map[string]string, got %#v", logs[0]["parsed_fields"])
+	}
+	if len(parsedFields) != 0 {
+		t.Fatalf("parsed_fields should be empty without label names, got %#v", parsedFields)
 	}
 	if _, exists := logs[0]["job"]; exists {
 		t.Fatalf("stream should not be flattened into top-level fields")
 	}
 	if _, exists := logs[0]["stream.job"]; exists {
 		t.Fatalf("stream should not be flattened into stream.* fields")
+	}
+}
+
+func TestNormalizeLogsWithLabelNamesSplitsParsedFields(t *testing.T) {
+	resp := &QueryResponse{
+		Data: QueryData{
+			Result: []QueryItem{
+				{
+					Stream: map[string]string{
+						"job":               "api",
+						"level":             "error",
+						"trace_id":          "abc",
+						"__error__":         "JSONParserErr",
+						"__error_details__": "detail",
+					},
+					Values: [][]interface{}{
+						{"1710000000123456789", "hello"},
+					},
+				},
+			},
+		},
+	}
+
+	logs := NormalizeLogsWithLabelNames(resp, []string{"job", "level"})
+	if len(logs) != 1 {
+		t.Fatalf("expected 1 log, got %d", len(logs))
+	}
+
+	labels, ok := logs[0]["labels"].(map[string]string)
+	if !ok {
+		t.Fatalf("labels should be map[string]string, got %#v", logs[0]["labels"])
+	}
+	if got := labels["job"]; got != "api" {
+		t.Fatalf("unexpected labels job: got %#v", got)
+	}
+	if got := labels["level"]; got != "error" {
+		t.Fatalf("unexpected labels level: got %#v", got)
+	}
+	if _, exists := labels["trace_id"]; exists {
+		t.Fatalf("trace_id should not be in labels")
+	}
+
+	parsedFields, ok := logs[0]["parsed_fields"].(map[string]string)
+	if !ok {
+		t.Fatalf("parsed_fields should be map[string]string, got %#v", logs[0]["parsed_fields"])
+	}
+	if got := parsedFields["trace_id"]; got != "abc" {
+		t.Fatalf("unexpected parsed trace_id: got %#v", got)
+	}
+	if _, exists := parsedFields["__error__"]; exists {
+		t.Fatalf("__error__ should not be returned in parsed_fields")
+	}
+	if _, exists := parsedFields["__error_details__"]; exists {
+		t.Fatalf("__error_details__ should not be returned in parsed_fields")
+	}
+}
+
+func TestNormalizeLogsWithEmptyLabelNamesTreatsStreamAsParsedFields(t *testing.T) {
+	resp := &QueryResponse{
+		Data: QueryData{
+			Result: []QueryItem{
+				{
+					Stream: map[string]string{"job": "api", "trace_id": "abc"},
+					Values: [][]interface{}{
+						{"1710000000123456789", "hello"},
+					},
+				},
+			},
+		},
+	}
+
+	logs := NormalizeLogsWithLabelNames(resp, []string{})
+	labels := logs[0]["labels"].(map[string]string)
+	if len(labels) != 0 {
+		t.Fatalf("labels should be empty with an empty label names set, got %#v", labels)
+	}
+	parsedFields := logs[0]["parsed_fields"].(map[string]string)
+	if got := parsedFields["job"]; got != "api" {
+		t.Fatalf("job should fall back to parsed_fields when label names are unknown, got %#v", got)
+	}
+}
+
+func TestAnalyzeLogQLForLogFields(t *testing.T) {
+	tests := []struct {
+		name       string
+		query      string
+		selector   string
+		needsNames bool
+	}{
+		{
+			name:       "selector only",
+			query:      `{app="api"}`,
+			selector:   `{app="api"}`,
+			needsNames: false,
+		},
+		{
+			name:       "line filters do not need label names",
+			query:      `{app="api"} |= "error" |~ "timeout|failed"`,
+			selector:   `{app="api"}`,
+			needsNames: false,
+		},
+		{
+			name:       "json stage needs label names",
+			query:      `{app="api"} | json | level="error"`,
+			selector:   `{app="api"}`,
+			needsNames: true,
+		},
+		{
+			name:       "parser text inside string is ignored",
+			query:      `{app="api"} |= "| json"`,
+			selector:   `{app="api"}`,
+			needsNames: false,
+		},
+		{
+			name:       "regexp stage needs label names",
+			query:      `{app="api"} | regexp "(?P<level>\\w+)"`,
+			selector:   `{app="api"}`,
+			needsNames: true,
+		},
+		{
+			name:       "label format needs label names",
+			query:      `{app="api"} | label_format level="{{.severity}}"`,
+			selector:   `{app="api"}`,
+			needsNames: true,
+		},
+		{
+			name:       "selector keeps braces inside quoted matcher",
+			query:      `{app=~"api\\{1\\}"} | logfmt`,
+			selector:   `{app=~"api\\{1\\}"}`,
+			needsNames: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := AnalyzeLogQLForLogFields(tt.query)
+			if got.Selector != tt.selector {
+				t.Fatalf("unexpected selector: got %q want %q", got.Selector, tt.selector)
+			}
+			if got.NeedsLabelNames != tt.needsNames {
+				t.Fatalf("unexpected NeedsLabelNames: got %v want %v", got.NeedsLabelNames, tt.needsNames)
+			}
+		})
+	}
+}
+
+func TestExtractLogQLLabelMatchers(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+		want  []LogQLLabelMatcher
+	}{
+		{
+			name:  "multiple exact matchers",
+			query: `{app="api",namespace="prod"}`,
+			want: []LogQLLabelMatcher{
+				{Key: "app", Op: "=", Value: "api"},
+				{Key: "namespace", Op: "=", Value: "prod"},
+			},
+		},
+		{
+			name:  "comma inside value",
+			query: `{app="api,prod"}`,
+			want: []LogQLLabelMatcher{
+				{Key: "app", Op: "=", Value: "api,prod"},
+			},
+		},
+		{
+			name:  "brace inside value",
+			query: `{app="api}prod"}`,
+			want: []LogQLLabelMatcher{
+				{Key: "app", Op: "=", Value: "api}prod"},
+			},
+		},
+		{
+			name:  "regex matcher",
+			query: `{app=~"api|web"}`,
+			want: []LogQLLabelMatcher{
+				{Key: "app", Op: "=~", Value: "api|web"},
+			},
+		},
+		{
+			name:  "negative matchers",
+			query: `{app!="api",namespace!~"dev|test"}`,
+			want: []LogQLLabelMatcher{
+				{Key: "app", Op: "!=", Value: "api"},
+				{Key: "namespace", Op: "!~", Value: "dev|test"},
+			},
+		},
+		{
+			name:  "pipeline is ignored",
+			query: `{app="api"} |= "err" | json`,
+			want: []LogQLLabelMatcher{
+				{Key: "app", Op: "=", Value: "api"},
+			},
+		},
+		{
+			name:  "escaped quote and slash",
+			query: `{app="api\"prod",path="c:\\tmp"}`,
+			want: []LogQLLabelMatcher{
+				{Key: "app", Op: "=", Value: `api"prod`},
+				{Key: "path", Op: "=", Value: `c:\tmp`},
+			},
+		},
+		{
+			name:  "bad matcher is skipped",
+			query: `{app="api",bad,namespace="prod"}`,
+			want: []LogQLLabelMatcher{
+				{Key: "app", Op: "=", Value: "api"},
+				{Key: "namespace", Op: "=", Value: "prod"},
+			},
+		},
+		{
+			name:  "no selector",
+			query: `rate(foo[5m])`,
+			want:  nil,
+		},
+		{
+			name:  "incomplete selector",
+			query: `{app="api"`,
+			want:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractLogQLLabelMatchers(tt.query)
+			if len(got) != len(tt.want) {
+				t.Fatalf("unexpected matcher count: got %#v want %#v", got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Fatalf("unexpected matcher[%d]: got %#v want %#v", i, got[i], tt.want[i])
+				}
+			}
+		})
 	}
 }

--- a/dskit/loki/loki_test.go
+++ b/dskit/loki/loki_test.go
@@ -1,0 +1,100 @@
+package loki
+
+import "testing"
+
+func TestAPIURLPreservesConfiguredLokiPath(t *testing.T) {
+	tests := []struct {
+		name string
+		addr string
+		want string
+	}{
+		{
+			name: "with loki suffix",
+			addr: "http://example.com:3100/loki",
+			want: "http://example.com:3100/loki/api/v1/labels",
+		},
+		{
+			name: "bare host",
+			addr: "http://example.com:3100",
+			want: "http://example.com:3100/api/v1/labels",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vl := &Loki{LokiAddr: tt.addr}
+			got, err := vl.apiURL("/api/v1/labels")
+			if err != nil {
+				t.Fatalf("apiURL failed: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("unexpected url: got %q want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatLokiTimestamp(t *testing.T) {
+	tests := []struct {
+		name string
+		in   int64
+		want string
+	}{
+		{name: "seconds", in: 1710000000, want: "1710000000000000000"},
+		{name: "milliseconds", in: 1710000000000, want: "1710000000000000000"},
+		{name: "nanoseconds", in: 1710000000000000000, want: "1710000000000000000"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatLokiTimestamp(tt.in); got != tt.want {
+				t.Fatalf("unexpected timestamp: got %q want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeLogsKeepsMillisecondTimestampAndRawNanoseconds(t *testing.T) {
+	resp := &QueryResponse{
+		Data: QueryData{
+			Result: []QueryItem{
+				{
+					Stream: map[string]string{"job": "api"},
+					Values: [][]interface{}{
+						{"1710000000123456789", "hello"},
+					},
+				},
+			},
+		},
+	}
+
+	logs := NormalizeLogs(resp)
+	if len(logs) != 1 {
+		t.Fatalf("expected 1 log, got %d", len(logs))
+	}
+	if got := logs[0]["timestamp"]; got != int64(1710000000123) {
+		t.Fatalf("unexpected timestamp: got %#v", got)
+	}
+	if got := logs[0]["__timestamp__"]; got != "1710000000123456789" {
+		t.Fatalf("unexpected __timestamp__: got %#v", got)
+	}
+	if _, exists := logs[0]["timestamp_ns"]; exists {
+		t.Fatalf("timestamp_ns should not be returned")
+	}
+	stream, ok := logs[0]["stream"].(map[string]string)
+	if !ok {
+		t.Fatalf("stream should be returned as map[string]string, got %#v", logs[0]["stream"])
+	}
+	if got := stream["job"]; got != "api" {
+		t.Fatalf("unexpected stream job: got %#v", got)
+	}
+	if _, exists := logs[0]["labels"]; exists {
+		t.Fatalf("labels should not be returned; Loki stream should be returned as stream")
+	}
+	if _, exists := logs[0]["job"]; exists {
+		t.Fatalf("stream should not be flattened into top-level fields")
+	}
+	if _, exists := logs[0]["stream.job"]; exists {
+		t.Fatalf("stream should not be flattened into stream.* fields")
+	}
+}

--- a/dskit/types/histogram.go
+++ b/dskit/types/histogram.go
@@ -2,9 +2,65 @@ package types
 
 import "fmt"
 
-// DefaultHistogramStep returns a default histogram step for the given unix second time range.
-func DefaultHistogramStep(start, end int64) string {
-	return histogramWidthToStep(defaultHistogramWidthBySeconds(start, end))
+// NormalizeUnixTimestamp converts a unix timestamp in seconds, milliseconds,
+// microseconds, or nanoseconds to unix seconds.
+func NormalizeUnixTimestamp(value float64) int64 {
+	if value > 1e17 {
+		return int64(value / 1e9)
+	}
+	if value > 1e14 {
+		return int64(value / 1e6)
+	}
+	if value > 1e11 {
+		return int64(value / 1000)
+	}
+	return int64(value)
+}
+
+// NormalizeUnixSeconds is a convenience wrapper for int64 unix timestamps.
+func NormalizeUnixSeconds(value int64) int64 {
+	if value <= 0 {
+		return value
+	}
+	return NormalizeUnixTimestamp(float64(value))
+}
+
+// NormalizeUnixMillisecondsInt converts a unix timestamp in seconds, milliseconds,
+// microseconds, or nanoseconds to unix milliseconds.
+func NormalizeUnixMillisecondsInt(value int64) int64 {
+	if value <= 0 {
+		return value
+	}
+	v := float64(value)
+	if v > 1e17 {
+		return int64(v / 1e6)
+	}
+	if v > 1e14 {
+		return int64(v / 1e3)
+	}
+	if v > 1e11 {
+		return int64(v)
+	}
+	return int64(v * 1000)
+}
+
+// UnixRangeDurationSeconds returns the duration between two unix timestamps in
+// seconds. Input bounds may be expressed in seconds, milliseconds, microseconds,
+// or nanoseconds. Sub-second precision is truncated, which is sufficient for
+// histogram step and LogQL range sizing.
+func UnixRangeDurationSeconds(start, end int64) int64 {
+	diff := NormalizeUnixSeconds(end) - NormalizeUnixSeconds(start)
+	if diff <= 0 {
+		return 1
+	}
+	return diff
+}
+
+// DefaultHistogramStepFromUnixRange returns a default histogram step for a time range
+// whose bounds may be expressed in seconds, milliseconds, or other unix units.
+func DefaultHistogramStepFromUnixRange(start, end int64) string {
+	diffSec := UnixRangeDurationSeconds(start, end)
+	return histogramWidthToStep(defaultHistogramWidthBySeconds(0, diffSec))
 }
 
 func defaultHistogramWidthBySeconds(start, end int64) int64 {

--- a/dskit/types/histogram.go
+++ b/dskit/types/histogram.go
@@ -1,0 +1,53 @@
+package types
+
+import "fmt"
+
+// DefaultHistogramStep returns a default histogram step for the given unix second time range.
+func DefaultHistogramStep(start, end int64) string {
+	return histogramWidthToStep(defaultHistogramWidthBySeconds(start, end))
+}
+
+func defaultHistogramWidthBySeconds(start, end int64) int64 {
+	diff := end - start
+	switch {
+	case diff <= 60:
+		return 1
+	case diff <= 300:
+		return 5
+	case diff <= 900:
+		return 30
+	case diff <= 1800:
+		return 30
+	case diff <= 3600:
+		return 60
+	case diff <= 3600*6:
+		return 5 * 60
+	case diff <= 3600*12:
+		return 10 * 60
+	case diff <= 3600*24:
+		return 30 * 60
+	case diff <= 3600*24*2:
+		return 60 * 60
+	case diff <= 3600*24*7:
+		return 3 * 60 * 60
+	case diff <= 3600*24*30:
+		return 12 * 60 * 60
+	case diff <= 3600*24*90:
+		return 24 * 60 * 60
+	default:
+		return 2 * 24 * 60 * 60
+	}
+}
+
+func histogramWidthToStep(width int64) string {
+	switch {
+	case width%86400 == 0:
+		return fmt.Sprintf("%dd", width/86400)
+	case width%3600 == 0:
+		return fmt.Sprintf("%dh", width/3600)
+	case width%60 == 0:
+		return fmt.Sprintf("%dm", width/60)
+	default:
+		return fmt.Sprintf("%ds", width)
+	}
+}

--- a/dskit/types/histogram_test.go
+++ b/dskit/types/histogram_test.go
@@ -1,0 +1,35 @@
+package types
+
+import "testing"
+
+func TestDefaultHistogramStep(t *testing.T) {
+	cases := []struct {
+		name  string
+		start int64
+		end   int64
+		want  string
+	}{
+		{name: "empty range", start: 10, end: 10, want: "1s"},
+		{name: "one minute", start: 0, end: 60, want: "1s"},
+		{name: "five minutes", start: 0, end: 300, want: "5s"},
+		{name: "fifteen minutes", start: 0, end: 900, want: "30s"},
+		{name: "thirty minutes", start: 0, end: 1800, want: "30s"},
+		{name: "one hour", start: 0, end: 3600, want: "1m"},
+		{name: "six hours", start: 0, end: 3600 * 6, want: "5m"},
+		{name: "twelve hours", start: 0, end: 3600 * 12, want: "10m"},
+		{name: "one day", start: 0, end: 86400, want: "30m"},
+		{name: "two days", start: 0, end: 86400 * 2, want: "1h"},
+		{name: "one week", start: 0, end: 86400 * 7, want: "3h"},
+		{name: "thirty days", start: 0, end: 86400 * 30, want: "12h"},
+		{name: "ninety days", start: 0, end: 86400 * 90, want: "1d"},
+		{name: "more than ninety days", start: 0, end: 86400*90 + 1, want: "2d"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := DefaultHistogramStep(c.start, c.end); got != c.want {
+				t.Fatalf("unexpected step: got %q, want %q", got, c.want)
+			}
+		})
+	}
+}

--- a/dskit/types/histogram_test.go
+++ b/dskit/types/histogram_test.go
@@ -2,7 +2,82 @@ package types
 
 import "testing"
 
-func TestDefaultHistogramStep(t *testing.T) {
+func TestNormalizeUnixTimestamp(t *testing.T) {
+	cases := []struct {
+		name  string
+		value float64
+		want  int64
+	}{
+		{name: "seconds", value: 1710000030, want: 1710000030},
+		{name: "milliseconds", value: 1710000030000, want: 1710000030},
+		{name: "microseconds", value: 1710000030000000, want: 1710000030},
+		{name: "nanoseconds", value: 1710000030000000000, want: 1710000030},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := NormalizeUnixTimestamp(c.value); got != c.want {
+				t.Fatalf("unexpected value: got %d want %d", got, c.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeUnixSeconds(t *testing.T) {
+	if got := NormalizeUnixSeconds(0); got != 0 {
+		t.Fatalf("unexpected zero: %d", got)
+	}
+	if got := NormalizeUnixSeconds(1784526946385); got != 1784526946 {
+		t.Fatalf("unexpected ms normalization: got %d want %d", got, 1784526946)
+	}
+}
+
+func TestNormalizeUnixMillisecondsInt(t *testing.T) {
+	cases := []struct {
+		name  string
+		value int64
+		want  int64
+	}{
+		{name: "zero", value: 0, want: 0},
+		{name: "seconds", value: 1710000030, want: 1710000030000},
+		{name: "milliseconds", value: 1710000030000, want: 1710000030000},
+		{name: "microseconds", value: 1710000030000000, want: 1710000030000},
+		{name: "nanoseconds", value: 1710000030000000000, want: 1710000030000},
+		{name: "second input", value: 1784526946, want: 1784526946000},
+		{name: "millisecond input", value: 1784526946385, want: 1784526946385},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := NormalizeUnixMillisecondsInt(c.value); got != c.want {
+				t.Fatalf("unexpected value: got %d want %d", got, c.want)
+			}
+		})
+	}
+}
+
+func TestUnixRangeDurationSeconds(t *testing.T) {
+	cases := []struct {
+		name  string
+		start int64
+		end   int64
+		want  int64
+	}{
+		{name: "seconds", start: 1710000000, end: 1710003600, want: 3600},
+		{name: "milliseconds", start: 1710000000000, end: 1710003600000, want: 3600},
+		{name: "nanoseconds", start: 1710000000000000000, end: 1710003600000000000, want: 3600},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := UnixRangeDurationSeconds(c.start, c.end); got != c.want {
+				t.Fatalf("unexpected duration: got %d want %d", got, c.want)
+			}
+		})
+	}
+}
+
+func TestDefaultHistogramStepFromUnixRange(t *testing.T) {
 	cases := []struct {
 		name  string
 		start int64
@@ -23,11 +98,12 @@ func TestDefaultHistogramStep(t *testing.T) {
 		{name: "thirty days", start: 0, end: 86400 * 30, want: "12h"},
 		{name: "ninety days", start: 0, end: 86400 * 90, want: "1d"},
 		{name: "more than ninety days", start: 0, end: 86400*90 + 1, want: "2d"},
+		{name: "milliseconds", start: 1710000000000, end: 1710003600000, want: "1m"},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if got := DefaultHistogramStep(c.start, c.end); got != c.want {
+			if got := DefaultHistogramStepFromUnixRange(c.start, c.end); got != c.want {
 				t.Fatalf("unexpected step: got %q, want %q", got, c.want)
 			}
 		})

--- a/dskit/victorialogs/victorialogs.go
+++ b/dskit/victorialogs/victorialogs.go
@@ -57,9 +57,23 @@ type PrometheusItem struct {
 
 // HitsResult hits 查询响应
 type HitsResult struct {
-	Hits []struct {
-		Total int64 `json:"total"`
-	}
+	Hits []HitResult `json:"hits"`
+}
+
+type HitResult struct {
+	Total      int64             `json:"total"`
+	Timestamps []interface{}     `json:"timestamps"`
+	Values     []interface{}     `json:"values"`
+	Fields     map[string]string `json:"fields"`
+}
+
+type streamValuesResponse struct {
+	Values []StreamFieldValue `json:"values"`
+}
+
+type StreamFieldValue struct {
+	Value string `json:"value"`
+	Hits  int64  `json:"hits"`
 }
 
 // InitHTTPClient 初始化 HTTP 客户端
@@ -89,6 +103,10 @@ func (vl *VictoriaLogs) InitHTTPClient() error {
 // Query 执行日志查询
 // GET/POST /select/logsql/query?query=<query>&start=<start>&end=<end>&limit=<limit>
 func (vl *VictoriaLogs) Query(ctx context.Context, query string, start, end int64, limit int) ([]LogEntry, error) {
+	return vl.QueryWithOffset(ctx, query, start, end, limit, 0)
+}
+
+func (vl *VictoriaLogs) QueryWithOffset(ctx context.Context, query string, start, end int64, limit, offset int) ([]LogEntry, error) {
 	params := url.Values{}
 	params.Set("query", query)
 
@@ -102,6 +120,9 @@ func (vl *VictoriaLogs) Query(ctx context.Context, query string, start, end int6
 		params.Set("limit", strconv.Itoa(limit))
 	} else {
 		params.Set("limit", strconv.Itoa(vl.MaxQueryRows)) // 默认 1000 条
+	}
+	if offset > 0 {
+		params.Set("offset", strconv.Itoa(offset))
 	}
 
 	endpoint := fmt.Sprintf("%s/select/logsql/query", vl.VictorialogsAddr)
@@ -229,6 +250,23 @@ func (vl *VictoriaLogs) StatsQueryRange(ctx context.Context, query string, start
 // HitsLogs 返回查询命中的日志数量，用于计算 total
 // POST /select/logsql/hits?query=<query>&start=<start>&end=<end>
 func (vl *VictoriaLogs) HitsLogs(ctx context.Context, query string, start, end int64) (int64, error) {
+	result, err := vl.QueryHits(ctx, query, start, end, "")
+	if err != nil {
+		return 0, err
+	}
+
+	if len(result.Hits) == 0 {
+		return 0, nil
+	}
+
+	return result.Hits[0].Total, nil
+}
+
+func (vl *VictoriaLogs) QueryHits(ctx context.Context, query string, start, end int64, step string, groupByFields ...string) (*HitsResult, error) {
+	return vl.QueryHitsWithFieldsLimit(ctx, query, start, end, step, 5, groupByFields...)
+}
+
+func (vl *VictoriaLogs) QueryHitsWithFieldsLimit(ctx context.Context, query string, start, end int64, step string, fieldsLimit int, groupByFields ...string) (*HitsResult, error) {
 	params := url.Values{}
 	params.Set("query", query)
 
@@ -238,34 +276,105 @@ func (vl *VictoriaLogs) HitsLogs(ctx context.Context, query string, start, end i
 	if end > 0 {
 		params.Set("end", strconv.FormatInt(end, 10))
 	}
+	if step != "" {
+		params.Set("step", step)
+	}
+	if len(groupByFields) > 0 {
+		hasField := false
+		for _, field := range groupByFields {
+			if field != "" {
+				params.Add("field", field)
+				hasField = true
+			}
+		}
+		if hasField {
+			if fieldsLimit <= 0 {
+				fieldsLimit = 5
+			}
+			params.Set("fields_limit", strconv.Itoa(fieldsLimit))
+		}
+	}
 
 	endpoint := fmt.Sprintf("%s/select/logsql/hits", vl.VictorialogsAddr)
 
 	resp, err := vl.doRequest(ctx, "POST", endpoint, params)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return 0, fmt.Errorf("read response body failed: %w", err)
+		return nil, fmt.Errorf("read response body failed: %w", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return 0, fmt.Errorf("hits query failed: status=%d, body=%s", resp.StatusCode, string(body))
+		return nil, fmt.Errorf("hits query failed: status=%d, body=%s", resp.StatusCode, string(body))
 	}
 
 	var result HitsResult
 	if err := json.Unmarshal(body, &result); err != nil {
-		return 0, fmt.Errorf("decode response failed: %w, body=%s", err, string(body))
+		return nil, fmt.Errorf("decode response failed: %w, body=%s", err, string(body))
 	}
 
-	if len(result.Hits) == 0 {
-		return 0, nil
+	return &result, nil
+}
+
+func (vl *VictoriaLogs) StreamFieldNames(ctx context.Context, query string, start, end int64, filter string) ([]StreamFieldValue, error) {
+	return vl.streamFieldValues(ctx, "stream_field_names", query, start, end, "", 0, filter)
+}
+
+func (vl *VictoriaLogs) StreamFieldValues(ctx context.Context, query string, start, end int64, field string, limit int, filter string) ([]StreamFieldValue, error) {
+	return vl.streamFieldValues(ctx, "stream_field_values", query, start, end, field, limit, filter)
+}
+
+func (vl *VictoriaLogs) streamFieldValues(ctx context.Context, path, query string, start, end int64, field string, limit int, filter string) ([]StreamFieldValue, error) {
+	params := url.Values{}
+	if query == "" {
+		query = "*"
+	}
+	params.Set("query", query)
+	params.Set("ignore_pipes", "1")
+
+	if start > 0 {
+		params.Set("start", strconv.FormatInt(start, 10))
+	}
+	if end > 0 {
+		params.Set("end", strconv.FormatInt(end, 10))
+	}
+	if field != "" {
+		params.Set("field", field)
+	}
+	if limit > 0 {
+		params.Set("limit", strconv.Itoa(limit))
+	}
+	if filter != "" {
+		params.Set("filter", filter)
 	}
 
-	return result.Hits[0].Total, nil
+	endpoint := fmt.Sprintf("%s/select/logsql/%s", vl.VictorialogsAddr, path)
+
+	resp, err := vl.doRequest(ctx, "POST", endpoint, params)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response body failed: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s query failed: status=%d, body=%s", path, resp.StatusCode, string(body))
+	}
+
+	var result streamValuesResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("decode response failed: %w, body=%s", err, string(body))
+	}
+
+	return result.Values, nil
 }
 
 // doRequest 执行 HTTP 请求

--- a/dskit/victorialogs/victorialogs.go
+++ b/dskit/victorialogs/victorialogs.go
@@ -12,6 +12,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	dskittypes "github.com/ccfos/nightingale/v6/dskit/types"
 )
 
 type VictoriaLogs struct {
@@ -247,62 +249,12 @@ func (vl *VictoriaLogs) StatsQueryRange(ctx context.Context, query string, start
 	return &result, nil
 }
 
-// DefaultHistogramStep returns a default hits step for the given unix second time range.
-func DefaultHistogramStep(start, end int64) string {
-	return histogramWidthToStep(defaultHistogramWidthBySeconds(start, end))
-}
-
-func defaultHistogramWidthBySeconds(start, end int64) int64 {
-	diff := end - start
-	switch {
-	case diff <= 60:
-		return 1
-	case diff <= 300:
-		return 5
-	case diff <= 900:
-		return 30
-	case diff <= 1800:
-		return 30
-	case diff <= 3600:
-		return 60
-	case diff <= 3600*6:
-		return 5 * 60
-	case diff <= 3600*12:
-		return 10 * 60
-	case diff <= 3600*24:
-		return 30 * 60
-	case diff <= 3600*24*2:
-		return 60 * 60
-	case diff <= 3600*24*7:
-		return 3 * 60 * 60
-	case diff <= 3600*24*30:
-		return 12 * 60 * 60
-	case diff <= 3600*24*90:
-		return 24 * 60 * 60
-	default:
-		return 2 * 24 * 60 * 60
-	}
-}
-
-func histogramWidthToStep(width int64) string {
-	switch {
-	case width%86400 == 0:
-		return fmt.Sprintf("%dd", width/86400)
-	case width%3600 == 0:
-		return fmt.Sprintf("%dh", width/3600)
-	case width%60 == 0:
-		return fmt.Sprintf("%dm", width/60)
-	default:
-		return fmt.Sprintf("%ds", width)
-	}
-}
-
 // HitsLogs 返回查询命中的日志数量，用于计算 total
 // POST /select/logsql/hits?query=<query>&start=<start>&end=<end>&step=<step>
 func (vl *VictoriaLogs) HitsLogs(ctx context.Context, query string, start, end int64) (int64, error) {
 	step := ""
 	if start > 0 && end > start {
-		step = DefaultHistogramStep(start, end)
+		step = dskittypes.DefaultHistogramStep(start, end)
 	}
 
 	result, err := vl.QueryHits(ctx, query, start, end, step)

--- a/dskit/victorialogs/victorialogs.go
+++ b/dskit/victorialogs/victorialogs.go
@@ -113,13 +113,7 @@ func (vl *VictoriaLogs) Query(ctx context.Context, query string, start, end int6
 func (vl *VictoriaLogs) QueryWithOffset(ctx context.Context, query string, start, end int64, limit, offset int) ([]LogEntry, error) {
 	params := url.Values{}
 	params.Set("query", query)
-
-	if start > 0 {
-		params.Set("start", strconv.FormatInt(start, 10))
-	}
-	if end > 0 {
-		params.Set("end", strconv.FormatInt(end, 10))
-	}
+	addTimeRangeParams(params, start, end)
 	if limit > 0 {
 		params.Set("limit", strconv.Itoa(limit))
 	} else {
@@ -174,7 +168,7 @@ func (vl *VictoriaLogs) StatsQuery(ctx context.Context, query string, time int64
 	params.Set("query", query)
 
 	if time > 0 {
-		params.Set("time", strconv.FormatInt(time, 10))
+		params.Set("time", formatVictoriaLogsTimestamp(time))
 	}
 
 	endpoint := fmt.Sprintf("%s/select/logsql/stats_query", vl.VictorialogsAddr)
@@ -211,13 +205,7 @@ func (vl *VictoriaLogs) StatsQuery(ctx context.Context, query string, time int64
 func (vl *VictoriaLogs) StatsQueryRange(ctx context.Context, query string, start, end int64, step string) (*PrometheusResponse, error) {
 	params := url.Values{}
 	params.Set("query", query)
-
-	if start > 0 {
-		params.Set("start", strconv.FormatInt(start, 10))
-	}
-	if end > 0 {
-		params.Set("end", strconv.FormatInt(end, 10))
-	}
+	addTimeRangeParams(params, start, end)
 	if step != "" {
 		params.Set("step", step)
 	}
@@ -255,8 +243,10 @@ func (vl *VictoriaLogs) StatsQueryRange(ctx context.Context, query string, start
 // POST /select/logsql/hits?query=<query>&start=<start>&end=<end>&step=<step>
 func (vl *VictoriaLogs) HitsLogs(ctx context.Context, query string, start, end int64) (int64, error) {
 	step := ""
-	if start > 0 && end > start {
-		step = dskittypes.DefaultHistogramStep(start, end)
+	startMs := normalizeVictoriaLogsTimestamp(start)
+	endMs := normalizeVictoriaLogsTimestamp(end)
+	if startMs > 0 && endMs > startMs {
+		step = dskittypes.DefaultHistogramStepFromUnixRange(start, end)
 	}
 
 	result, err := vl.QueryHits(ctx, query, start, end, step)
@@ -278,13 +268,7 @@ func (vl *VictoriaLogs) QueryHits(ctx context.Context, query string, start, end 
 func (vl *VictoriaLogs) QueryHitsWithFieldsLimit(ctx context.Context, query string, start, end int64, step string, fieldsLimit int, groupByFields ...string) (*HitsResult, error) {
 	params := url.Values{}
 	params.Set("query", query)
-
-	if start > 0 {
-		params.Set("start", strconv.FormatInt(start, 10))
-	}
-	if end > 0 {
-		params.Set("end", strconv.FormatInt(end, 10))
-	}
+	addTimeRangeParams(params, start, end)
 	if step != "" {
 		params.Set("step", step)
 	}
@@ -352,13 +336,7 @@ func (vl *VictoriaLogs) streamFieldValues(ctx context.Context, path, query strin
 	}
 	params.Set("query", query)
 	params.Set("ignore_pipes", "1")
-
-	if start > 0 {
-		params.Set("start", strconv.FormatInt(start, 10))
-	}
-	if end > 0 {
-		params.Set("end", strconv.FormatInt(end, 10))
-	}
+	addTimeRangeParams(params, start, end)
 	if field != "" {
 		params.Set("field", field)
 	}
@@ -427,4 +405,27 @@ func (vl *VictoriaLogs) doRequest(ctx context.Context, method, endpoint string, 
 	}
 
 	return vl.HTTPClient.Do(req)
+}
+
+func addTimeRangeParams(params url.Values, start, end int64) {
+	if start > 0 {
+		params.Set("start", formatVictoriaLogsTimestamp(start))
+	}
+	if end > 0 {
+		params.Set("end", formatVictoriaLogsTimestamp(end))
+	}
+}
+
+func formatVictoriaLogsTimestamp(value int64) string {
+	if value <= 0 {
+		return "0"
+	}
+	return strconv.FormatInt(normalizeVictoriaLogsTimestamp(value), 10)
+}
+
+func normalizeVictoriaLogsTimestamp(value int64) int64 {
+	if value <= 0 {
+		return value
+	}
+	return dskittypes.NormalizeUnixMillisecondsInt(value)
 }

--- a/dskit/victorialogs/victorialogs.go
+++ b/dskit/victorialogs/victorialogs.go
@@ -247,10 +247,65 @@ func (vl *VictoriaLogs) StatsQueryRange(ctx context.Context, query string, start
 	return &result, nil
 }
 
+// DefaultHistogramStep returns a default hits step for the given unix second time range.
+func DefaultHistogramStep(start, end int64) string {
+	return histogramWidthToStep(defaultHistogramWidthBySeconds(start, end))
+}
+
+func defaultHistogramWidthBySeconds(start, end int64) int64 {
+	diff := end - start
+	switch {
+	case diff <= 60:
+		return 1
+	case diff <= 300:
+		return 5
+	case diff <= 900:
+		return 30
+	case diff <= 1800:
+		return 30
+	case diff <= 3600:
+		return 60
+	case diff <= 3600*6:
+		return 5 * 60
+	case diff <= 3600*12:
+		return 10 * 60
+	case diff <= 3600*24:
+		return 30 * 60
+	case diff <= 3600*24*2:
+		return 60 * 60
+	case diff <= 3600*24*7:
+		return 3 * 60 * 60
+	case diff <= 3600*24*30:
+		return 12 * 60 * 60
+	case diff <= 3600*24*90:
+		return 24 * 60 * 60
+	default:
+		return 2 * 24 * 60 * 60
+	}
+}
+
+func histogramWidthToStep(width int64) string {
+	switch {
+	case width%86400 == 0:
+		return fmt.Sprintf("%dd", width/86400)
+	case width%3600 == 0:
+		return fmt.Sprintf("%dh", width/3600)
+	case width%60 == 0:
+		return fmt.Sprintf("%dm", width/60)
+	default:
+		return fmt.Sprintf("%ds", width)
+	}
+}
+
 // HitsLogs 返回查询命中的日志数量，用于计算 total
-// POST /select/logsql/hits?query=<query>&start=<start>&end=<end>
+// POST /select/logsql/hits?query=<query>&start=<start>&end=<end>&step=<step>
 func (vl *VictoriaLogs) HitsLogs(ctx context.Context, query string, start, end int64) (int64, error) {
-	result, err := vl.QueryHits(ctx, query, start, end, "")
+	step := ""
+	if start > 0 && end > start {
+		step = DefaultHistogramStep(start, end)
+	}
+
+	result, err := vl.QueryHits(ctx, query, start, end, step)
 	if err != nil {
 		return 0, err
 	}
@@ -326,6 +381,14 @@ func (vl *VictoriaLogs) StreamFieldNames(ctx context.Context, query string, star
 
 func (vl *VictoriaLogs) StreamFieldValues(ctx context.Context, query string, start, end int64, field string, limit int, filter string) ([]StreamFieldValue, error) {
 	return vl.streamFieldValues(ctx, "stream_field_values", query, start, end, field, limit, filter)
+}
+
+func (vl *VictoriaLogs) FieldNames(ctx context.Context, query string, start, end int64, limit int, filter string) ([]StreamFieldValue, error) {
+	return vl.streamFieldValues(ctx, "field_names", query, start, end, "", limit, filter)
+}
+
+func (vl *VictoriaLogs) FieldValues(ctx context.Context, query string, start, end int64, field string, limit int, filter string) ([]StreamFieldValue, error) {
+	return vl.streamFieldValues(ctx, "field_values", query, start, end, field, limit, filter)
 }
 
 func (vl *VictoriaLogs) streamFieldValues(ctx context.Context, path, query string, start, end int64, field string, limit int, filter string) ([]StreamFieldValue, error) {

--- a/dskit/victorialogs/victorialogs.go
+++ b/dskit/victorialogs/victorialogs.go
@@ -30,6 +30,8 @@ type VictoriaLogs struct {
 	Timeout      int64             `json:"victorialogs.timeout" mapstructure:"victorialogs.timeout"` // millis
 	ClusterName  string            `json:"victorialogs.cluster_name" mapstructure:"victorialogs.cluster_name"`
 	MaxQueryRows int               `json:"victorialogs.max_query_rows" mapstructure:"victorialogs.max_query_rows"`
+	EnableWrite  bool              `json:"victorialogs.enable_write" mapstructure:"victorialogs.enable_write"`
+	WriteAddrs   []string          `json:"victorialogs.write_addrs" mapstructure:"victorialogs.write_addrs"`
 
 	HTTPClient *http.Client `json:"-" mapstructure:"-"`
 }

--- a/dskit/victorialogs/victorialogs_unit_test.go
+++ b/dskit/victorialogs/victorialogs_unit_test.go
@@ -1,0 +1,163 @@
+package victorialogs
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"testing"
+)
+
+func newTestVictoriaLogs(serverURL string) *VictoriaLogs {
+	vl := &VictoriaLogs{
+		VictorialogsAddr: serverURL,
+		Headers:          make(map[string]string),
+		MaxQueryRows:     1000,
+	}
+	if err := vl.InitHTTPClient(); err != nil {
+		panic(err)
+	}
+	return vl
+}
+
+func TestVictoriaLogs_QueryWithOffsetAddsOffset(t *testing.T) {
+	var got url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/select/logsql/query" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatal(err)
+		}
+		got = r.Form
+		fmt.Fprintln(w, `{"_msg":"ok"}`)
+	}))
+	defer server.Close()
+
+	logs, err := newTestVictoriaLogs(server.URL).QueryWithOffset(context.Background(), "*", 11, 22, 10, 30)
+	if err != nil {
+		t.Fatalf("QueryWithOffset error: %v", err)
+	}
+	if len(logs) != 1 {
+		t.Fatalf("expected 1 log entry, got %d", len(logs))
+	}
+
+	want := map[string]string{
+		"query":  "*",
+		"start":  "11",
+		"end":    "22",
+		"limit":  "10",
+		"offset": "30",
+	}
+	for key, value := range want {
+		if got.Get(key) != value {
+			t.Fatalf("unexpected %s: got %q, want %q", key, got.Get(key), value)
+		}
+	}
+}
+
+func TestVictoriaLogs_QueryHitsWithFieldsLimit(t *testing.T) {
+	var got url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/select/logsql/hits" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatal(err)
+		}
+		got = r.Form
+		fmt.Fprintln(w, `{"hits":[{"total":3,"timestamps":["2026-07-02T00:00:00Z"],"values":[3],"fields":{"service":"api"}}]}`)
+	}))
+	defer server.Close()
+
+	result, err := newTestVictoriaLogs(server.URL).QueryHitsWithFieldsLimit(context.Background(), "*", 11, 22, "5m", 20, "service")
+	if err != nil {
+		t.Fatalf("QueryHitsWithFieldsLimit error: %v", err)
+	}
+	if len(result.Hits) != 1 || result.Hits[0].Total != 3 {
+		t.Fatalf("unexpected hits result: %+v", result)
+	}
+
+	if got.Get("step") != "5m" {
+		t.Fatalf("unexpected step: %q", got.Get("step"))
+	}
+	if got.Get("fields_limit") != "20" {
+		t.Fatalf("unexpected fields_limit: %q", got.Get("fields_limit"))
+	}
+	if fields := got["field"]; !reflect.DeepEqual(fields, []string{"service"}) {
+		t.Fatalf("unexpected field params: %#v", fields)
+	}
+}
+
+func TestVictoriaLogs_StreamFieldNames(t *testing.T) {
+	var got url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/select/logsql/stream_field_names" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatal(err)
+		}
+		got = r.Form
+		fmt.Fprintln(w, `{"values":[{"value":"z","hits":1},{"value":"a","hits":2}]}`)
+	}))
+	defer server.Close()
+
+	fields, err := newTestVictoriaLogs(server.URL).StreamFieldNames(context.Background(), "", 11, 22, "svc")
+	if err != nil {
+		t.Fatalf("StreamFieldNames error: %v", err)
+	}
+	wantFields := []StreamFieldValue{
+		{Value: "z", Hits: 1},
+		{Value: "a", Hits: 2},
+	}
+	if !reflect.DeepEqual(fields, wantFields) {
+		t.Fatalf("unexpected fields: %#v", fields)
+	}
+	if got.Get("query") != "*" {
+		t.Fatalf("unexpected query: %q", got.Get("query"))
+	}
+	if got.Get("ignore_pipes") != "1" {
+		t.Fatalf("unexpected ignore_pipes: %q", got.Get("ignore_pipes"))
+	}
+	if got.Get("filter") != "svc" {
+		t.Fatalf("unexpected filter: %q", got.Get("filter"))
+	}
+}
+
+func TestVictoriaLogs_StreamFieldValues(t *testing.T) {
+	var got url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/select/logsql/stream_field_values" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatal(err)
+		}
+		got = r.Form
+		fmt.Fprintln(w, `{"values":[{"value":"api","hits":7}]}`)
+	}))
+	defer server.Close()
+
+	values, err := newTestVictoriaLogs(server.URL).StreamFieldValues(context.Background(), "_time:5m", 11, 22, "service", 10, "")
+	if err != nil {
+		t.Fatalf("StreamFieldValues error: %v", err)
+	}
+	if len(values) != 1 || values[0].Value != "api" || values[0].Hits != 7 {
+		t.Fatalf("unexpected values: %#v", values)
+	}
+
+	want := map[string]string{
+		"query":        "_time:5m",
+		"field":        "service",
+		"limit":        "10",
+		"ignore_pipes": "1",
+	}
+	for key, value := range want {
+		if got.Get(key) != value {
+			t.Fatalf("unexpected %s: got %q, want %q", key, got.Get(key), value)
+		}
+	}
+}

--- a/dskit/victorialogs/victorialogs_unit_test.go
+++ b/dskit/victorialogs/victorialogs_unit_test.go
@@ -46,8 +46,8 @@ func TestVictoriaLogs_QueryWithOffsetAddsOffset(t *testing.T) {
 
 	want := map[string]string{
 		"query":  "*",
-		"start":  "11",
-		"end":    "22",
+		"start":  "11000",
+		"end":    "22000",
 		"limit":  "10",
 		"offset": "30",
 	}
@@ -55,6 +55,46 @@ func TestVictoriaLogs_QueryWithOffsetAddsOffset(t *testing.T) {
 		if got.Get(key) != value {
 			t.Fatalf("unexpected %s: got %q, want %q", key, got.Get(key), value)
 		}
+	}
+}
+
+func TestFormatVictoriaLogsTimestamp(t *testing.T) {
+	cases := []struct {
+		name string
+		in   int64
+		want string
+	}{
+		{name: "seconds", in: 1710000000, want: "1710000000000"},
+		{name: "milliseconds", in: 1710000000000, want: "1710000000000"},
+		{name: "zero", in: 0, want: "0"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := formatVictoriaLogsTimestamp(c.in); got != c.want {
+				t.Fatalf("unexpected timestamp: got %q want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestVictoriaLogs_QueryWithOffsetKeepsMillisecondRange(t *testing.T) {
+	var got url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatal(err)
+		}
+		got = r.Form
+		fmt.Fprintln(w, `{"_msg":"ok"}`)
+	}))
+	defer server.Close()
+
+	_, err := newTestVictoriaLogs(server.URL).QueryWithOffset(context.Background(), "*", 1784526946385, 1784537746385, 10, 0)
+	if err != nil {
+		t.Fatalf("QueryWithOffset error: %v", err)
+	}
+	if got.Get("start") != "1784526946385" || got.Get("end") != "1784537746385" {
+		t.Fatalf("unexpected range: start=%q end=%q", got.Get("start"), got.Get("end"))
 	}
 }
 
@@ -81,6 +121,9 @@ func TestVictoriaLogs_HitsLogsAddsStep(t *testing.T) {
 	}
 	if got.Get("step") != "1s" {
 		t.Fatalf("unexpected step: got %q, want %q", got.Get("step"), "1s")
+	}
+	if got.Get("start") != "11000" || got.Get("end") != "22000" {
+		t.Fatalf("unexpected range: start=%q end=%q", got.Get("start"), got.Get("end"))
 	}
 }
 
@@ -216,8 +259,8 @@ func TestVictoriaLogs_FieldNames(t *testing.T) {
 
 	want := map[string]string{
 		"query":        "service:api",
-		"start":        "11",
-		"end":          "22",
+		"start":        "11000",
+		"end":          "22000",
 		"limit":        "50",
 		"filter":       "sta",
 		"ignore_pipes": "1",

--- a/dskit/victorialogs/victorialogs_unit_test.go
+++ b/dskit/victorialogs/victorialogs_unit_test.go
@@ -58,6 +58,32 @@ func TestVictoriaLogs_QueryWithOffsetAddsOffset(t *testing.T) {
 	}
 }
 
+func TestVictoriaLogs_HitsLogsAddsStep(t *testing.T) {
+	var got url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/select/logsql/hits" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatal(err)
+		}
+		got = r.Form
+		fmt.Fprintln(w, `{"hits":[{"total":12345,"fields":{},"timestamps":[],"values":[]}]}`)
+	}))
+	defer server.Close()
+
+	total, err := newTestVictoriaLogs(server.URL).HitsLogs(context.Background(), "*", 11, 22)
+	if err != nil {
+		t.Fatalf("HitsLogs error: %v", err)
+	}
+	if total != 12345 {
+		t.Fatalf("unexpected total: %d", total)
+	}
+	if got.Get("step") != "1s" {
+		t.Fatalf("unexpected step: got %q, want %q", got.Get("step"), "1s")
+	}
+}
+
 func TestVictoriaLogs_QueryHitsWithFieldsLimit(t *testing.T) {
 	var got url.Values
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -153,6 +179,87 @@ func TestVictoriaLogs_StreamFieldValues(t *testing.T) {
 		"query":        "_time:5m",
 		"field":        "service",
 		"limit":        "10",
+		"ignore_pipes": "1",
+	}
+	for key, value := range want {
+		if got.Get(key) != value {
+			t.Fatalf("unexpected %s: got %q, want %q", key, got.Get(key), value)
+		}
+	}
+}
+
+func TestVictoriaLogs_FieldNames(t *testing.T) {
+	var got url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/select/logsql/field_names" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatal(err)
+		}
+		got = r.Form
+		fmt.Fprintln(w, `{"values":[{"value":"status","hits":4},{"value":"domain","hits":2}]}`)
+	}))
+	defer server.Close()
+
+	fields, err := newTestVictoriaLogs(server.URL).FieldNames(context.Background(), "service:api", 11, 22, 50, "sta")
+	if err != nil {
+		t.Fatalf("FieldNames error: %v", err)
+	}
+	wantFields := []StreamFieldValue{
+		{Value: "status", Hits: 4},
+		{Value: "domain", Hits: 2},
+	}
+	if !reflect.DeepEqual(fields, wantFields) {
+		t.Fatalf("unexpected fields: %#v", fields)
+	}
+
+	want := map[string]string{
+		"query":        "service:api",
+		"start":        "11",
+		"end":          "22",
+		"limit":        "50",
+		"filter":       "sta",
+		"ignore_pipes": "1",
+	}
+	for key, value := range want {
+		if got.Get(key) != value {
+			t.Fatalf("unexpected %s: got %q, want %q", key, got.Get(key), value)
+		}
+	}
+}
+
+func TestVictoriaLogs_FieldValues(t *testing.T) {
+	var got url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/select/logsql/field_values" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatal(err)
+		}
+		got = r.Form
+		fmt.Fprintln(w, `{"values":[{"value":"200","hits":123},{"value":"404","hits":31}]}`)
+	}))
+	defer server.Close()
+
+	values, err := newTestVictoriaLogs(server.URL).FieldValues(context.Background(), "service:api", 11, 22, "status", 20, "20")
+	if err != nil {
+		t.Fatalf("FieldValues error: %v", err)
+	}
+	wantValues := []StreamFieldValue{
+		{Value: "200", Hits: 123},
+		{Value: "404", Hits: 31},
+	}
+	if !reflect.DeepEqual(values, wantValues) {
+		t.Fatalf("unexpected values: %#v", values)
+	}
+
+	want := map[string]string{
+		"query":        "service:api",
+		"field":        "status",
+		"limit":        "20",
+		"filter":       "20",
 		"ignore_pipes": "1",
 	}
 	for key, value := range want {


### PR DESCRIPTION
## Summary
- Add Loki as a log datasource with label/parsed-field/histogram/log-query APIs and register it into dscache.
- Enhance VictoriaLogs: stream fields APIs, hits-based histogram with group-by/step, `field_names` / `field_values` APIs, and `offset` for log paging.
- Extract a shared histogram step helper (`dskit/types.DefaultHistogramStep`) reused by both VictoriaLogs and Loki.
