### PR TITLE
fix(aiagent): stable tool ordering for LLM requests

### DIFF
--- a/aiagent/agent.go
+++ b/aiagent/agent.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"sort"
 	"time"
 
 	"github.com/ccfos/nightingale/v6/aiagent/llm"
@@ -289,6 +290,7 @@ func (a *Agent) appendSkillTools(base []AgentTool, skills []*SkillContent) []Age
 			for name := range toolDescriptions {
 				toolNames = append(toolNames, name)
 			}
+			sort.Strings(toolNames)
 		}
 
 		for _, toolName := range toolNames {

--- a/aiagent/tool_executor.go
+++ b/aiagent/tool_executor.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 	"text/template"
 	"time"
@@ -211,7 +212,14 @@ func (a *Agent) appendMCPTools(ctx context.Context, base []AgentTool) []AgentToo
 	}
 	result := base
 
-	for serverName, serverConfig := range a.mcpServers {
+	serverNames := make([]string, 0, len(a.mcpServers))
+	for name := range a.mcpServers {
+		serverNames = append(serverNames, name)
+	}
+	sort.Strings(serverNames)
+
+	for _, serverName := range serverNames {
+		serverConfig := a.mcpServers[serverName]
 		client, err := a.mcpClientManager.GetOrCreateClient(ctx, serverConfig)
 		if err != nil {
 			logger.Warningf("Failed to connect to MCP server '%s': %v", serverName, err)


### PR DESCRIPTION
LLM 请求中 tools 列表的顺序存在两个非确定性来源，导致以下问题：

1. **prompt cache 命中率下降**：同一 session 内 tools 顺序随机变化，LLM provider
   无法复用缓存的 prompt prefix，增加延迟和成本。

2. **模型行为不可复现**：LLM 对 tool 顺序存在 primacy bias（前面的工具更容易被选中），
   随机顺序导致同样的问题在不同运行中产生不同的工具调用路径，根因分析结果不一致。

具体修了两处：

- **appendSkillTools（agent.go）**：Skill 未显式指定 RecommendedTools 时，fallback
  路径遍历 `toolDescriptions` map，顺序随机。修复：收集 key 后 `sort.Strings`。

- **appendMCPTools（tool_executor.go）**：遍历 `a.mcpServers` map，不同 MCP Server
  注册的工具顺序不稳定。修复：收集 serverName 后 `sort.Strings` 再按序遍历。

改动保留了三层工具分层（配置工具 → skill/MCP 工具 → 系统元工具），仅稳定层内顺序。