### PR TITLE
feat: ai_summary processor reuse centralized LLM config

### DIFF
--- a/aiagent/llmconfig/probe.go
+++ b/aiagent/llmconfig/probe.go
@@ -61,12 +61,12 @@ func (e *ProbeError) Unwrap() error {
 // Test sends a real chat request to the target LLM provider to verify connectivity,
 // credentials, and model availability. Returns a ProbeError for classified failures.
 func Test(p *models.AILLMConfig) error {
-	client, err := llm.New(buildLLMConfig(p))
+	client, err := llm.New(BuildLLMConfig(p))
 	if err != nil {
 		return err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), probeTimeout(p.ExtraConfig))
+	ctx, cancel := context.WithTimeout(context.Background(), ProbeTimeout(p.ExtraConfig))
 	defer cancel()
 
 	maxTokens := 5
@@ -85,14 +85,18 @@ func Test(p *models.AILLMConfig) error {
 
 var providerStatusErrPattern = regexp.MustCompile(`(?i)^(?:[a-z0-9_ -]+) API error \(status (\d+)\):\s*(.*)$`)
 
-func buildLLMConfig(p *models.AILLMConfig) *llm.Config {
+// BuildLLMConfig maps a stored AILLMConfig into an llm.Config usable by the
+// unified aiagent/llm client. Exported so other consumers (e.g. the workflow
+// AI summary processor) can reuse a centrally-managed LLM config instead of
+// re-implementing the mapping.
+func BuildLLMConfig(p *models.AILLMConfig) *llm.Config {
 	return &llm.Config{
 		Provider:      p.APIType,
 		BaseURL:       p.APIURL,
 		APIKey:        p.APIKey,
 		Model:         p.Model,
 		Headers:       cloneStringMap(p.ExtraConfig.CustomHeaders),
-		Timeout:       int(probeTimeout(p.ExtraConfig) / time.Millisecond),
+		Timeout:       int(ProbeTimeout(p.ExtraConfig) / time.Millisecond),
 		SkipSSLVerify: p.ExtraConfig.SkipTLSVerify,
 		Proxy:         p.ExtraConfig.Proxy,
 		Temperature:   p.ExtraConfig.Temperature,
@@ -101,7 +105,9 @@ func buildLLMConfig(p *models.AILLMConfig) *llm.Config {
 	}
 }
 
-func probeTimeout(extra models.LLMExtraConfig) time.Duration {
+// ProbeTimeout resolves the request timeout from a config's extra settings,
+// defaulting to 30s when unset.
+func ProbeTimeout(extra models.LLMExtraConfig) time.Duration {
 	timeout := 30 * time.Second
 	if extra.TimeoutSeconds > 0 {
 		timeout = time.Duration(extra.TimeoutSeconds) * time.Second

--- a/alert/pipeline/processor/aisummary/ai_summary.go
+++ b/alert/pipeline/processor/aisummary/ai_summary.go
@@ -2,6 +2,7 @@ package aisummary
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
@@ -13,6 +14,8 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/ccfos/nightingale/v6/aiagent/llm"
+	"github.com/ccfos/nightingale/v6/aiagent/llmconfig"
 	"github.com/ccfos/nightingale/v6/alert/pipeline/processor/callback"
 	"github.com/ccfos/nightingale/v6/alert/pipeline/processor/common"
 	"github.com/ccfos/nightingale/v6/models"
@@ -24,9 +27,18 @@ const (
 	HTTP_STATUS_SUCCESS_MAX = 299
 )
 
+// summaryClientCache caches LLM clients keyed by config fingerprint so repeated
+// events reusing the same centralized LLM config don't rebuild the client.
+var summaryClientCache = llm.NewClientCache()
+
 // AISummaryConfig 配置结构体
 type AISummaryConfig struct {
 	callback.HTTPConfig
+	// LLMConfigId, when > 0, makes the node reuse a centrally-managed
+	// ai_llm_config (model/api_key/url/params) via the aiagent/llm client.
+	// When 0 (default), the inline ModelName/APIKey/URL fields are used,
+	// preserving backward compatibility with existing pipelines.
+	LLMConfigId    int64                  `json:"llm_config_id"`
 	ModelName      string                 `json:"model_name"`
 	APIKey         string                 `json:"api_key"`
 	PromptTemplate string                 `json:"prompt_template"`
@@ -57,11 +69,6 @@ func (c *AISummaryConfig) Init(settings interface{}) (models.Processor, error) {
 
 func (c *AISummaryConfig) Process(ctx *ctx.Context, wfCtx *models.WorkflowContext) (*models.WorkflowContext, string, error) {
 	event := wfCtx.Event
-	if c.Client == nil {
-		if err := c.initHTTPClient(); err != nil {
-			return wfCtx, "", fmt.Errorf("failed to initialize HTTP client: %v processor: %v", err, c)
-		}
-	}
 
 	// 准备告警事件信息
 	eventInfo, err := c.prepareEventInfo(wfCtx)
@@ -69,8 +76,20 @@ func (c *AISummaryConfig) Process(ctx *ctx.Context, wfCtx *models.WorkflowContex
 		return wfCtx, "", fmt.Errorf("failed to prepare event info: %v processor: %v", err, c)
 	}
 
-	// 调用AI模型生成总结
-	summary, err := c.generateAISummary(eventInfo)
+	// 调用AI模型生成总结：
+	// - LLMConfigId > 0：复用集中式 LLM 配置（ai_llm_config），走统一的 aiagent/llm 客户端
+	// - 否则：回退到内联的 model/api_key/url 手写 HTTP 调用（向后兼容）
+	var summary string
+	if c.LLMConfigId > 0 {
+		summary, err = c.generateWithLLMConfig(ctx, eventInfo)
+	} else {
+		if c.Client == nil {
+			if err := c.initHTTPClient(); err != nil {
+				return wfCtx, "", fmt.Errorf("failed to initialize HTTP client: %v processor: %v", err, c)
+			}
+		}
+		summary, err = c.generateAISummary(eventInfo)
+	}
 	if err != nil {
 		return wfCtx, "", fmt.Errorf("failed to generate AI summary: %v processor: %v", err, c)
 	}
@@ -130,6 +149,31 @@ func (c *AISummaryConfig) prepareEventInfo(wfCtx *models.WorkflowContext) (strin
 	}
 
 	return body.String(), nil
+}
+
+// generateWithLLMConfig 复用集中式 LLM 配置（ai_llm_config）生成总结，
+// 走统一的 aiagent/llm 客户端，从而支持 openai/claude/gemini 等各类 provider。
+func (c *AISummaryConfig) generateWithLLMConfig(dbCtx *ctx.Context, eventInfo string) (string, error) {
+	cfg, err := models.AILLMConfigGetById(dbCtx, c.LLMConfigId)
+	if err != nil {
+		return "", fmt.Errorf("failed to load llm config %d: %v", c.LLMConfigId, err)
+	}
+	if cfg == nil {
+		return "", fmt.Errorf("llm config %d not found", c.LLMConfigId)
+	}
+	if !cfg.Enabled {
+		return "", fmt.Errorf("llm config %d (%s) is disabled", cfg.Id, cfg.Name)
+	}
+
+	client, err := summaryClientCache.GetOrCreate(llmconfig.BuildLLMConfig(cfg))
+	if err != nil {
+		return "", fmt.Errorf("failed to create llm client: %v", err)
+	}
+
+	reqCtx, cancel := context.WithTimeout(context.Background(), llmconfig.ProbeTimeout(cfg.ExtraConfig))
+	defer cancel()
+
+	return llm.Chat(reqCtx, client, []llm.Message{{Role: llm.RoleUser, Content: eventInfo}})
 }
 
 func (c *AISummaryConfig) generateAISummary(eventInfo string) (string, error) {

--- a/alert/pipeline/processor/aisummary/ai_summary_test.go
+++ b/alert/pipeline/processor/aisummary/ai_summary_test.go
@@ -1,19 +1,137 @@
 package aisummary
 
 import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/ccfos/nightingale/v6/alert/pipeline/processor/callback"
 	"github.com/ccfos/nightingale/v6/models"
 	"github.com/ccfos/nightingale/v6/pkg/ctx"
 	"github.com/stretchr/testify/assert"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
 )
 
+// newFakeOpenAIServer starts an httptest server that answers an OpenAI-style
+// chat completion. It records the last request body so tests can assert what
+// model/prompt was sent. summary is the content returned to the caller.
+func newFakeOpenAIServer(t *testing.T, summary string, gotBody *[]byte) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if gotBody != nil {
+			*gotBody = body
+		}
+		resp := map[string]interface{}{
+			"choices": []map[string]interface{}{
+				{"message": map[string]string{"role": "assistant", "content": summary}},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+}
+
+func newTestWfCtx() *models.WorkflowContext {
+	return &models.WorkflowContext{
+		Event: &models.AlertCurEvent{
+			RuleName:        "Test Rule",
+			Severity:        1,
+			TagsMap:         map[string]string{"host": "test-host"},
+			AnnotationsJSON: map[string]string{"description": "Test alert"},
+		},
+		Inputs: map[string]string{},
+	}
+}
+
+// TestAISummary_InlineMode verifies the backward-compatible path: with
+// LLMConfigId==0 the node uses the inline URL/model and produces a summary.
+func TestAISummary_InlineMode(t *testing.T) {
+	var gotBody []byte
+	srv := newFakeOpenAIServer(t, "inline summary", &gotBody)
+	defer srv.Close()
+
+	config := &AISummaryConfig{
+		HTTPConfig:     callback.HTTPConfig{URL: srv.URL, Timeout: 5000},
+		ModelName:      "inline-model",
+		APIKey:         "sk-inline",
+		PromptTemplate: "rule: {{$event.RuleName}}",
+	}
+
+	result, _, err := config.Process(&ctx.Context{}, newTestWfCtx())
+	assert.NoError(t, err)
+	assert.Equal(t, "inline summary", result.Event.AnnotationsJSON["ai_summary"])
+	assert.Contains(t, string(gotBody), "inline-model")
+}
+
+// TestAISummary_ReuseLLMConfig verifies that with LLMConfigId>0 the node loads
+// the centralized ai_llm_config and calls its endpoint/model.
+func TestAISummary_ReuseLLMConfig(t *testing.T) {
+	var gotBody []byte
+	srv := newFakeOpenAIServer(t, "centralized summary", &gotBody)
+	defer srv.Close()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	assert.NoError(t, err)
+	assert.NoError(t, db.AutoMigrate(&models.AILLMConfig{}))
+	dbCtx := &ctx.Context{DB: db}
+
+	llmCfg := &models.AILLMConfig{
+		Name:    "central",
+		APIType: "openai",
+		APIURL:  srv.URL + "/chat/completions",
+		APIKey:  "sk-central",
+		Model:   "central-model",
+		Enabled: true,
+	}
+	assert.NoError(t, db.Create(llmCfg).Error)
+	assert.NotZero(t, llmCfg.Id)
+
+	config := &AISummaryConfig{
+		LLMConfigId:    llmCfg.Id,
+		PromptTemplate: "rule: {{$event.RuleName}}",
+	}
+
+	result, _, err := config.Process(dbCtx, newTestWfCtx())
+	assert.NoError(t, err)
+	assert.Equal(t, "centralized summary", result.Event.AnnotationsJSON["ai_summary"])
+	assert.Contains(t, string(gotBody), "central-model")
+}
+
+// TestAISummary_LLMConfigNotFoundOrDisabled verifies clear errors instead of panics.
+func TestAISummary_LLMConfigNotFoundOrDisabled(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	assert.NoError(t, err)
+	assert.NoError(t, db.AutoMigrate(&models.AILLMConfig{}))
+	dbCtx := &ctx.Context{DB: db}
+
+	// not found
+	cfgMissing := &AISummaryConfig{LLMConfigId: 999, PromptTemplate: "x"}
+	_, _, err = cfgMissing.Process(dbCtx, newTestWfCtx())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+
+	// disabled
+	disabled := &models.AILLMConfig{Name: "off", APIType: "openai", APIURL: "http://x/chat/completions", APIKey: "k", Model: "m", Enabled: false}
+	assert.NoError(t, db.Create(disabled).Error)
+	cfgDisabled := &AISummaryConfig{LLMConfigId: disabled.Id, PromptTemplate: "x"}
+	_, _, err = cfgDisabled.Process(dbCtx, newTestWfCtx())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "disabled")
+}
+
 func TestAISummaryConfig_Process(t *testing.T) {
+	srv := newFakeOpenAIServer(t, "generated summary", nil)
+	defer srv.Close()
+
 	// 创建测试配置
 	config := &AISummaryConfig{
 		HTTPConfig: callback.HTTPConfig{
-			URL:           "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions",
+			URL:           srv.URL,
 			Timeout:       30000,
 			SkipSSLVerify: true,
 			Headers: map[string]string{


### PR DESCRIPTION
**What type of PR is this?**
feature

**What this PR does / why we need it**:
The workflow AI summary node kept its own inline model/api_key/url and did not read the centralized ai_llm_config, forcing users to re-enter model credentials per node and only supporting the OpenAI wire format.

Add an optional llm_config_id to AISummaryConfig. When set (>0), the node resolves the referenced ai_llm_config and calls it through the shared aiagent/llm client (openai/claude/gemini/... all supported), reusing a cached client. When unset (0, the default), it falls back to the existing inline HTTP path, so existing pipelines are unaffected.

Export llmconfig.BuildLLMConfig / ProbeTimeout (previously private) so the AILLMConfig -> llm.Config mapping is shared with the probe path instead of duplicated.

**Which issue(s) this PR fixes**:
Fixes #3199
 
**Special notes for your reviewer**:
  - New field `llm_config_id` defaults to 0, keeping existing behavior (backward compatible).
  - Unit tests cover three paths: inline fallback, reuse centralized config, and config-not-found / disabled error
  handling.
  - The frontend counterpart (a "Reuse LLM Config" dropdown on the AI summary node form) will be submitted as a
  separate PR to n9e/fe.