### PR TITLE
perf: perf git url ai skill import

### DIFF
--- a/center/router/router_ai_skill_git.go
+++ b/center/router/router_ai_skill_git.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -286,6 +287,11 @@ func (rt *Router) gitConfigForInstall(req aiSkillGitRequest) (skill.GitConfig, a
 	if err := cfg.Validate(authType == skill.GitAuthToken); err != nil {
 		return cfg, aiSkillGitFields{}, err
 	}
+	if normalized, ok, err := normalizeGitHubSkillURL(cfg); err != nil {
+		return cfg, aiSkillGitFields{}, err
+	} else if ok {
+		cfg = normalized
+	}
 	fields := aiSkillGitFields{
 		URL:      cfg.URL,
 		RefType:  cfg.RefType,
@@ -295,6 +301,53 @@ func (rt *Router) gitConfigForInstall(req aiSkillGitRequest) (skill.GitConfig, a
 		Subdir:   cfg.Subdir,
 	}
 	return cfg, fields, nil
+}
+
+func normalizeGitHubSkillURL(cfg skill.GitConfig) (skill.GitConfig, bool, error) {
+	u, err := url.Parse(strings.TrimSpace(cfg.URL))
+	if err != nil {
+		return cfg, false, nil
+	}
+	host := strings.ToLower(u.Hostname())
+	if host != "github.com" && host != "www.github.com" {
+		return cfg, false, nil
+	}
+	parts := splitGitHubURLPath(u.Path)
+	if len(parts) < 2 {
+		return cfg, false, nil
+	}
+	owner := parts[0]
+	repo := strings.TrimSuffix(parts[1], ".git")
+	if owner == "" || repo == "" {
+		return cfg, false, nil
+	}
+	normalized := cfg
+	normalized.URL = fmt.Sprintf("https://github.com/%s/%s.git", owner, repo)
+	if len(parts) >= 4 && parts[2] == "tree" {
+		if cfg.RefType != "" && cfg.RefType != skill.GitRefBranch {
+			return cfg, false, fmt.Errorf("github tree urls only support git_ref_type=branch")
+		}
+		if strings.TrimSpace(cfg.Ref) == "" {
+			normalized.RefType = skill.GitRefBranch
+			normalized.Ref = parts[3]
+		}
+		if strings.TrimSpace(cfg.Subdir) == "" && len(parts) > 4 {
+			normalized.Subdir = strings.Join(parts[4:], "/")
+		}
+	}
+	changed := normalized.URL != cfg.URL || normalized.RefType != cfg.RefType || normalized.Ref != cfg.Ref || normalized.Subdir != cfg.Subdir
+	return normalized, changed, nil
+}
+
+func splitGitHubURLPath(p string) []string {
+	parts := strings.Split(strings.Trim(strings.TrimSpace(p), "/"), "/")
+	ret := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part = strings.TrimSpace(part); part != "" {
+			ret = append(ret, part)
+		}
+	}
+	return ret
 }
 
 func (rt *Router) gitConfigForUpdate(current *models.AISkill, req aiSkillGitRequest, builtin bool) (skill.GitConfig, aiSkillGitFields, error) {

--- a/center/router/router_ai_skill_test.go
+++ b/center/router/router_ai_skill_test.go
@@ -143,3 +143,62 @@ func TestDoSkillImportUpdatePersistsAuthForGitSkill(t *testing.T) {
 		t.Fatalf("git skill auth not persisted: private=%d teams=%v", got.Private, got.UserGroupIds)
 	}
 }
+
+func TestNormalizeGitHubSkillURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     skill.GitConfig
+		want    skill.GitConfig
+		wantOK  bool
+		wantErr string
+	}{
+		{
+			name:   "tree url fills repo ref and subdir",
+			cfg:    skill.GitConfig{URL: "https://github.com/openclaw/agent-skills/tree/main/skills/demo", AuthType: skill.GitAuthNone},
+			want:   skill.GitConfig{URL: "https://github.com/openclaw/agent-skills.git", RefType: skill.GitRefBranch, Ref: "main", AuthType: skill.GitAuthNone, Subdir: "skills/demo"},
+			wantOK: true,
+		},
+		{
+			name:   "repo url normalizes git suffix only",
+			cfg:    skill.GitConfig{URL: "https://github.com/openclaw/agent-skills", RefType: skill.GitRefBranch, Ref: "main", AuthType: skill.GitAuthNone},
+			want:   skill.GitConfig{URL: "https://github.com/openclaw/agent-skills.git", RefType: skill.GitRefBranch, Ref: "main", AuthType: skill.GitAuthNone},
+			wantOK: true,
+		},
+		{
+			name:   "explicit ref wins over tree branch",
+			cfg:    skill.GitConfig{URL: "https://github.com/openclaw/agent-skills/tree/main/skills/demo", RefType: skill.GitRefBranch, Ref: "release", AuthType: skill.GitAuthNone},
+			want:   skill.GitConfig{URL: "https://github.com/openclaw/agent-skills.git", RefType: skill.GitRefBranch, Ref: "release", AuthType: skill.GitAuthNone, Subdir: "skills/demo"},
+			wantOK: true,
+		},
+		{
+			name:    "tree url rejects non branch ref type",
+			cfg:     skill.GitConfig{URL: "https://github.com/openclaw/agent-skills/tree/main/skills/demo", RefType: skill.GitRefTag, Ref: "v1.0.0", AuthType: skill.GitAuthNone},
+			wantErr: "github tree urls only support git_ref_type=branch",
+		},
+		{
+			name:   "non github url ignored",
+			cfg:    skill.GitConfig{URL: "https://gitlab.example.com/team/skills.git", RefType: skill.GitRefBranch, Ref: "main", AuthType: skill.GitAuthNone},
+			want:   skill.GitConfig{URL: "https://gitlab.example.com/team/skills.git", RefType: skill.GitRefBranch, Ref: "main", AuthType: skill.GitAuthNone},
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		got, ok, err := normalizeGitHubSkillURL(tt.cfg)
+		if tt.wantErr != "" {
+			if err == nil || err.Error() != tt.wantErr {
+				t.Fatalf("%s: err=%v want %q", tt.name, err, tt.wantErr)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("%s: unexpected err: %v", tt.name, err)
+		}
+		if ok != tt.wantOK {
+			t.Fatalf("%s: ok=%v want %v", tt.name, ok, tt.wantOK)
+		}
+		if got != tt.want {
+			t.Fatalf("%s: got=%+v want=%+v", tt.name, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
perf

**What this PR does / why we need it**:
Improves the existing AI skill git installation flow instead of introducing a parallel URL import path. This change lets `POST /api/n9e/ai-skills/git/install` accept common GitHub repository and skill tree URLs, then normalizes them into the existing `git_url`, `git_ref_type`, `git_ref`, and `git_subdir` fields. The implementation stays within Nightingale's current git-based install/update lifecycle, so imported skills retain commit tracking and upgradeability without adding a separate HTTP download, archive extraction, or HTML-scraping pipeline.

**Which issue(s) this PR fixes**:
N/A
 
**Special notes for your reviewer**:
This PR was narrowed after review to align with the existing git-backed skill workflow. The standalone `/ai-skills/url/import` endpoint and related downloader logic were removed. The remaining change is limited to GitHub URL normalization for the existing git install entrypoint, with targeted router tests covering the normalization behavior.
