### PR TITLE
feat(ai-skill): pick builtin skill README by UI language

### DIFF
--- a/center/integration/i18n.go
+++ b/center/integration/i18n.go
@@ -18,6 +18,7 @@ import (
 // 词条缺失时按单字段粒度回退源语言原文。
 const (
 	LangSource = "zh_CN"
+	LangZhHK   = "zh_HK"
 	LangEnUS   = "en_US"
 )
 
@@ -28,11 +29,36 @@ type ComponentDict map[string]string
 // 其余（含 en 前缀和未支持语言）归入 en_US——en_US 桶对全部内置内容完整存在
 // （无词条的组件为 pass-through），因此不需要列表级回退。
 // 大小写不敏感：前端只发 zh_CN，但第三方直连 API 可能传 ZH-CN
+//
+// 注意：integrations 词条只有 zh_CN / en_US 两桶，故繁体 zh_HK 也归入 zh_CN。
+// Skill README 有独立繁体文件，请用 ClassifySkillReadmeLang，勿复用本函数。
 func NormalizeLang(lang string) string {
 	if lang == "" || strings.HasPrefix(strings.ToLower(lang), "zh") {
 		return LangSource
 	}
 	return LangEnUS
+}
+
+// ClassifySkillReadmeLang 将 X-Language 映射到 Skill 面向用户 README 桶：
+//   - 简体（空 / zh / zh_CN / 其它非繁体 zh_*）→ zh_CN → README.md
+//   - 繁体（zh_HK / zh_TW / *-Hant*）→ zh_HK → README.zh_HK.md
+//   - 其余语言一律 → en_US → README.en_US.md
+//
+// 与 languageDetector 输出对齐（zh_HK / zh_CN / en / 透传其它），大小写与 -/_ 不敏感。
+func ClassifySkillReadmeLang(lang string) string {
+	l := strings.ToLower(strings.ReplaceAll(strings.TrimSpace(lang), "-", "_"))
+	switch {
+	case l == "" || l == "zh" || l == "zh_cn" || strings.HasPrefix(l, "zh_cn_"):
+		return LangSource
+	case strings.HasPrefix(l, "zh_hk") || strings.HasPrefix(l, "zh_tw") ||
+		strings.Contains(l, "hant"):
+		return LangZhHK
+	case strings.HasPrefix(l, "zh"):
+		// 其它 zh_*（如 zh_SG）按简体
+		return LangSource
+	default:
+		return LangEnUS
+	}
 }
 
 // LoadComponentDicts 读取组件目录下 i18n/<lang>.json 词条文件

--- a/center/integration/i18n_test.go
+++ b/center/integration/i18n_test.go
@@ -390,6 +390,35 @@ func TestPickReadmeFiles(t *testing.T) {
 	if source != "mysql.md" || variants["en_US"] != "README.en_US.md" {
 		t.Errorf("fallback source = %q, variants = %v", source, variants)
 	}
+
+	// 含繁体副本
+	source, variants = PickReadmeFiles([]string{"README.zh_HK.md", "README.en_US.md", "README.md"})
+	if source != "README.md" || variants["zh_HK"] != "README.zh_HK.md" {
+		t.Errorf("zh_HK pick source = %q, variants = %v", source, variants)
+	}
+}
+
+func TestClassifySkillReadmeLang(t *testing.T) {
+	cases := map[string]string{
+		"":         LangSource,
+		"zh_CN":    LangSource,
+		"zh":       LangSource,
+		"ZH-CN":    LangSource,
+		"zh_SG":    LangSource,
+		"zh_HK":    LangZhHK,
+		"zh-HK":    LangZhHK,
+		"zh_TW":    LangZhHK,
+		"zh-Hant":  LangZhHK,
+		"en":       LangEnUS,
+		"en_US":    LangEnUS,
+		"ja_JP":    LangEnUS,
+		"fr":       LangEnUS,
+	}
+	for in, want := range cases {
+		if got := ClassifySkillReadmeLang(in); got != want {
+			t.Errorf("ClassifySkillReadmeLang(%q) = %q, want %q", in, got, want)
+		}
+	}
 }
 
 func TestRenderVariantUnknownTypePassThrough(t *testing.T) {

--- a/center/router/router_ai_skill.go
+++ b/center/router/router_ai_skill.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/ccfos/nightingale/v6/aiagent/skill"
+	"github.com/ccfos/nightingale/v6/center/integration"
 	"github.com/ccfos/nightingale/v6/models"
 	"github.com/ccfos/nightingale/v6/pkg/ctx"
 	"github.com/ccfos/nightingale/v6/pkg/ginx"
@@ -316,17 +317,42 @@ func (rt *Router) aiSkillGet(c *gin.Context) {
 	obj.CanEdit = obj.CanBeEditedBy(me, gids)
 
 	if obj.CreatedBy == "system" {
-		// 内置 skill 不需要看 skill 细节，只能看 readme 文档
+		// 内置 skill 不需要看 skill 细节，只能看面向用户的 README（按 UI 语言选文件）
 		files, err := models.AISkillFileGets(rt.Ctx, id)
 		ginx.Dangerous(err)
+		// 勿用 NormalizeLang：它会把 zh_HK 并进简体；Skill README 有独立繁体文件。
+		bucket := integration.ClassifySkillReadmeLang(c.GetHeader("X-Language"))
+		names := make([]string, 0, len(files))
+		byLower := make(map[string]int64, len(files))
 		for _, file := range files {
-			if strings.EqualFold(file.Name, "readme.md") {
-				filedetail, err := models.AISkillFileGetById(rt.Ctx, file.Id)
-				ginx.Dangerous(err)
-				if filedetail != nil {
-					obj.Instructions = filedetail.Content
-				}
-				break
+			names = append(names, file.Name)
+			byLower[strings.ToLower(file.Name)] = file.Id
+		}
+		_, variants := integration.PickReadmeFiles(names)
+		pickName := "README.md"
+		switch bucket {
+		case integration.LangZhHK:
+			if v, ok := variants[integration.LangZhHK]; ok {
+				pickName = v
+			} else if v, ok := variants["zh_TW"]; ok {
+				pickName = v
+			}
+			// 缺繁体副本时回退简体 README.md
+		case integration.LangEnUS:
+			if v, ok := variants[integration.LangEnUS]; ok {
+				pickName = v
+			}
+			// 缺英文副本时回退简体 README.md
+		}
+		fileId, ok := byLower[strings.ToLower(pickName)]
+		if !ok {
+			fileId, ok = byLower["readme.md"]
+		}
+		if ok {
+			filedetail, err := models.AISkillFileGetById(rt.Ctx, fileId)
+			ginx.Dangerous(err)
+			if filedetail != nil {
+				obj.Instructions = filedetail.Content
 			}
 		}
 	} else {


### PR DESCRIPTION
## Summary
- Builtin Skill detail previously only matched `readme.md`, so English / Traditional Chinese UIs still showed Simplified Chinese usage docs.
- Select the user-facing README by `X-Language` (after `languageDetector`):
  - Simplified Chinese (`zh_CN`, other non-traditional `zh_*`) → `README.md`
  - Traditional Chinese (`zh_HK` / `zh_TW` / Hant) → `README.zh_HK.md` (filename fallback `zh_TW`)
  - **All other locales** → `README.en_US.md`
- Missing locale file falls back to `README.md`.
- Add `ClassifySkillReadmeLang` — do **not** reuse `NormalizeLang` (it folds `zh_HK` into Simplified Chinese for integrations’ two-bucket dictionaries). Reuse existing `PickReadmeFiles` for `README.<locale>.md`.

## Mechanism
1. Frontend sends UI language via `X-Language` (e.g. `zh_CN` / `zh_HK` / `en_US`).
2. In `aiSkillGet`, for `CreatedBy == "system"`, call `ClassifySkillReadmeLang` to pick the language bucket.
3. Resolve the matching README from the skill’s attached files and put its content into `Instructions` for Skill Manager.
4. Content side must ship `README.md` / `README.zh_HK.md` / `README.en_US.md` with the builtin skill package; without them the API safely falls back to Simplified Chinese.

## Test plan
- [ ] `go test ./center/integration/ -run 'TestClassifySkillReadmeLang|TestPickReadmeFiles'`
- [ ] With all three README files installed: switch UI to Simplified / Traditional / English and confirm Skill Manager usage docs match
- [ ] Switch UI to Japanese (or any non-zh) → English README
- [ ] Only `README.md` present → all locales fall back to Simplified Chinese (no 500)


Made with [Cursor](https://cursor.com)