### PR TITLE
fix: keep builtin metric translation out of the shared cache

### DIFF
--- a/center/integration/builtin_metrics_test.go
+++ b/center/integration/builtin_metrics_test.go
@@ -1,0 +1,64 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/ccfos/nightingale/v6/models"
+)
+
+// newMetricCache 造一份进程级缓存，元素带 zh_CN/en_US 两种翻译，
+// 且 Name/Note 的原始值与任何一种翻译都不相同，这样一旦缓存被就地改写就能被观察到。
+func newMetricCache() *BuiltinPayloadInFileType {
+	return &BuiltinPayloadInFileType{
+		BuiltinMetrics: map[string]*models.BuiltinMetric{
+			"cpu_usage_idle": {
+				Collector:  "categraf",
+				Typ:        "Node",
+				Name:       "raw_name",
+				Note:       "raw_note",
+				Expression: "cpu_usage_idle",
+				Translation: []models.Translation{
+					{Lang: "zh_CN", Name: "CPU空闲率", Note: "CPU空闲百分比"},
+					{Lang: "en_US", Name: "cpu idle", Note: "cpu idle percent"},
+				},
+			},
+		},
+	}
+}
+
+// 一次查询不应改写进程级缓存里的内容。缓存是所有请求共享的，
+// 就地写入会让后续请求看到上一次请求的语言。
+func TestBuiltinMetricGets_DoesNotMutateCache(t *testing.T) {
+	b := newMetricCache()
+	cached := b.BuiltinMetrics["cpu_usage_idle"]
+
+	if _, _, err := b.BuiltinMetricGets(nil, "zh_CN", "", "", "", "", 20, 0); err != nil {
+		t.Fatalf("BuiltinMetricGets: %v", err)
+	}
+
+	if cached.Name != "raw_name" || cached.Note != "raw_note" {
+		t.Errorf("cache mutated by query: Name=%q Note=%q, want raw_name/raw_note",
+			cached.Name, cached.Note)
+	}
+}
+
+// query 过滤跑在翻译之前，读的是缓存里的 Name/Note。若翻译被写回缓存，
+// 同一个 query 在第一次和后续请求会命中不同的行，total 随之漂移 —— 即 issue #3212
+// 里“翻到第二页总数就变了”的现象。
+func TestBuiltinMetricGets_QueryTotalIsStable(t *testing.T) {
+	b := newMetricCache()
+
+	_, firstTotal, err := b.BuiltinMetricGets(nil, "zh_CN", "", "", "raw_name", "", 20, 0)
+	if err != nil {
+		t.Fatalf("first query: %v", err)
+	}
+
+	_, secondTotal, err := b.BuiltinMetricGets(nil, "zh_CN", "", "", "raw_name", "", 20, 0)
+	if err != nil {
+		t.Fatalf("second query: %v", err)
+	}
+
+	if firstTotal != secondTotal {
+		t.Errorf("total drifted between identical queries: %d then %d", firstTotal, secondTotal)
+	}
+}

--- a/center/integration/init.go
+++ b/center/integration/init.go
@@ -528,10 +528,14 @@ func (b *BuiltinPayloadInFileType) BuiltinMetricGets(metricsInDB []*models.Built
 			logger.Errorf("Error getting translation for metric %s: %v", metric.Name, err)
 			continue // Skip if translation not found
 		}
-		metric.Name = trans.Name
-		metric.Note = trans.Note
 
-		filteredMetrics = append(filteredMetrics, metric)
+		// 译文写在副本上：b.BuiltinMetrics 是所有请求共享的进程级缓存，就地改写
+		// 会让后续请求的 applyFilter 拿上一次请求留下的译文去匹配 query。
+		translated := *metric
+		translated.Name = trans.Name
+		translated.Note = trans.Note
+
+		filteredMetrics = append(filteredMetrics, &translated)
 	}
 
 	// Sort metrics


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`BuiltinPayloadInFileType.BuiltinMetricGets` applied the per-request translation by writing `Name` and `Note` straight onto the `*models.BuiltinMetric` held in `b.BuiltinMetrics` — a process-wide cache shared by every request:

```go
metric.Name = trans.Name
metric.Note = trans.Note
```

`applyFilter` runs earlier in the same loop and matches the `query` parameter against those very fields (`applyQueryFilter` reads `metric.Name` / `metric.Note`). So once a request had rewritten them, a later request filtered against the text left behind by the previous one and produced a different result set — and therefore a different `total`. Concurrent requests also wrote these shared fields without any lock.

This is the drifting count reported in #3212: the metric list shows 482 on page 1 and 481 once you page forward, with no data change in between.

The fix applies the translation to a copy, leaving the cache untouched. It is a shallow copy of the struct, and only the two string fields are reassigned, so nothing else is aliased.

**Which issue(s) this PR fixes**:

Fixes #3212

**Special notes for your reviewer**:

Added `center/integration/builtin_metrics_test.go` with two regression tests. Both fail on `main` and pass with this change:

- `TestBuiltinMetricGets_DoesNotMutateCache` — on main the cached entry comes back as `CPU空闲率` / `CPU空闲百分比` instead of its original text.
- `TestBuiltinMetricGets_QueryTotalIsStable` — on main two identical queries return `total` 1 and then 0.

Verified with `go vet ./center/...`, `go build ./cmd/center/ ./cmd/edge/`, `go test ./center/integration/` and `go test -race ./center/integration/`.

AI tooling assisted with the investigation and patch; reviewed and verified by the author.