### PR TITLE
feat(mysql): let datasources append extra params to the DSN

### DIFF
--- a/datasource/mysql/mysql.go
+++ b/datasource/mysql/mysql.go
@@ -116,6 +116,10 @@ func (m *MySQL) Equal(p datasource.Datasource) bool {
 		return false
 	}
 
+	if oldShard.DsnExtraParams != newShard.DsnExtraParams {
+		return false
+	}
+
 	return true
 }
 

--- a/datasource/mysql/mysql_test.go
+++ b/datasource/mysql/mysql_test.go
@@ -1,0 +1,28 @@
+package mysql
+
+import (
+	"testing"
+
+	dsmysql "github.com/ccfos/nightingale/v6/dskit/mysql"
+)
+
+func newMySQL(shard dsmysql.Shard) *MySQL {
+	m := new(MySQL)
+	m.Shards = []dsmysql.Shard{shard}
+	return m
+}
+
+func TestEqualDetectsDsnExtraParamsChange(t *testing.T) {
+	base := dsmysql.Shard{Addr: "127.0.0.1:3306", User: "root"}
+
+	old := newMySQL(base)
+	if !old.Equal(newMySQL(base)) {
+		t.Fatal("identical shards should be equal")
+	}
+
+	changed := base
+	changed.DsnExtraParams = "sessionVariables=ob_read_consistency=WEAK"
+	if old.Equal(newMySQL(changed)) {
+		t.Fatal("changing dsn_extra_params must invalidate the cached datasource")
+	}
+}

--- a/dskit/mysql/dsn_params.go
+++ b/dskit/mysql/dsn_params.go
@@ -1,0 +1,125 @@
+package mysql
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// NormalizeDSNExtraParams turns a user-supplied MySQL DSN query fragment into a
+// fragment go-sql-driver/mysql can parse, so that unknown keys are issued as
+// `SET key = value` right after the connection is established.
+//
+// JDBC packs several assignments into one sessionVariables=k1=v1,k2=v2 pair,
+// which the Go driver has no equivalent for; that one key is expanded into
+// separate k1=%27v1%27&k2=%27v2%27 pairs. Every other key is passed through as
+// written, so callers use plain go-sql-driver syntax for the rest.
+func NormalizeDSNExtraParams(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	raw = strings.TrimPrefix(raw, "?")
+	raw = strings.TrimPrefix(raw, "&")
+	if raw == "" {
+		return "", nil
+	}
+
+	var parts []string
+	for _, segment := range strings.Split(raw, "&") {
+		segment = strings.TrimSpace(segment)
+		if segment == "" {
+			continue
+		}
+		key, value, found := strings.Cut(segment, "=")
+		if !found {
+			return "", fmt.Errorf("invalid segment %q: missing '='", segment)
+		}
+		key = strings.TrimSpace(key)
+		if key == "" {
+			return "", fmt.Errorf("invalid segment %q: empty key", segment)
+		}
+
+		if key == "sessionVariables" {
+			expanded, err := expandSessionVariables(value)
+			if err != nil {
+				return "", err
+			}
+			parts = append(parts, expanded...)
+			continue
+		}
+		parts = append(parts, segment)
+	}
+
+	return strings.Join(parts, "&"), nil
+}
+
+func expandSessionVariables(value string) ([]string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil, fmt.Errorf("sessionVariables value is empty")
+	}
+
+	var parts []string
+	for _, item := range strings.Split(value, ",") {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			continue
+		}
+		subKey, subValue, found := strings.Cut(item, "=")
+		if !found {
+			return nil, fmt.Errorf("invalid sessionVariables entry %q: missing '='", item)
+		}
+		subKey = strings.TrimSpace(subKey)
+		if subKey == "" {
+			return nil, fmt.Errorf("invalid sessionVariables entry %q: empty key", item)
+		}
+
+		encoded, err := encodeDSNParamValue(strings.TrimSpace(subValue))
+		if err != nil {
+			return nil, err
+		}
+		parts = append(parts, subKey+"="+encoded)
+	}
+	if len(parts) == 0 {
+		return nil, fmt.Errorf("sessionVariables value is empty")
+	}
+	return parts, nil
+}
+
+// encodeDSNParamValue quotes string values with %27 as the driver requires, and
+// leaves numbers and booleans bare.
+func encodeDSNParamValue(value string) (string, error) {
+	if value == "" {
+		return "", fmt.Errorf("empty session variable value")
+	}
+	if len(value) >= 6 && strings.HasPrefix(value, "%27") && strings.HasSuffix(value, "%27") {
+		if _, err := url.QueryUnescape(value); err != nil {
+			return "", fmt.Errorf("invalid url-encoded session variable value %q: %w", value, err)
+		}
+		return value, nil
+	}
+
+	unquoted := value
+	if len(value) >= 2 && value[0] == '\'' && value[len(value)-1] == '\'' {
+		unquoted = value[1 : len(value)-1]
+	}
+
+	if isUnquotedDSNValue(unquoted) {
+		return unquoted, nil
+	}
+
+	return "%27" + url.QueryEscape(unquoted) + "%27", nil
+}
+
+func isUnquotedDSNValue(value string) bool {
+	switch strings.ToLower(value) {
+	case "true", "false":
+		return true
+	}
+	if _, err := strconv.ParseInt(value, 10, 64); err == nil {
+		return true
+	}
+	if _, err := strconv.ParseFloat(value, 64); err == nil {
+		return true
+	}
+	return false
+}

--- a/dskit/mysql/dsn_params_test.go
+++ b/dskit/mysql/dsn_params_test.go
@@ -1,0 +1,76 @@
+package mysql
+
+import "testing"
+
+func TestNormalizeDSNExtraParams(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"empty", "", ""},
+		{"blank", "   ", ""},
+		{"leading question mark", "?timeout=5s", "timeout=5s"},
+		{"leading ampersand", "&timeout=5s", "timeout=5s"},
+		{"go syntax passes through", "charset=utf8mb4&timeout=5s&tls=true", "charset=utf8mb4&timeout=5s&tls=true"},
+		{
+			"jdbc session variables",
+			"sessionVariables=ob_read_consistency=WEAK,@proxy_route_policy=follower_first",
+			"ob_read_consistency=%27WEAK%27&@proxy_route_policy=%27follower_first%27",
+		},
+		{
+			"mixed",
+			"readTimeout=30s&sessionVariables=ob_read_consistency=WEAK",
+			"readTimeout=30s&ob_read_consistency=%27WEAK%27",
+		},
+		{
+			"numeric and boolean stay bare",
+			"sessionVariables=isolation_level=1,autocommit=true,ratio=0.5",
+			"isolation_level=1&autocommit=true&ratio=0.5",
+		},
+		{
+			"already single quoted",
+			"sessionVariables=time_zone='+08:00'",
+			"time_zone=%27%2B08%3A00%27",
+		},
+		{
+			"already percent encoded",
+			"sessionVariables=time_zone=%27UTC%27",
+			"time_zone=%27UTC%27",
+		},
+		{"empty segments skipped", "timeout=5s&&", "timeout=5s"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := NormalizeDSNExtraParams(c.raw)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != c.want {
+				t.Fatalf("got %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeDSNExtraParamsInvalid(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{"segment without equals", "timeout"},
+		{"empty key", "=5s"},
+		{"empty session variables", "sessionVariables="},
+		{"session variable without equals", "sessionVariables=ob_read_consistency"},
+		{"session variable empty key", "sessionVariables==WEAK"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if _, err := NormalizeDSNExtraParams(c.raw); err == nil {
+				t.Fatalf("expected error for %q", c.raw)
+			}
+		})
+	}
+}

--- a/dskit/mysql/mysql.go
+++ b/dskit/mysql/mysql.go
@@ -34,6 +34,7 @@ type Shard struct {
 	MaxOpenConns    int    `json:"mysql.max_open_conns" mapstructure:"mysql.max_open_conns"`
 	ConnMaxLifetime int    `json:"mysql.conn_max_lifetime" mapstructure:"mysql.conn_max_lifetime"`
 	MaxQueryRows    int    `json:"mysql.max_query_rows" mapstructure:"mysql.max_query_rows"`
+	DsnExtraParams  string `json:"mysql.dsn_extra_params" mapstructure:"mysql.dsn_extra_params"`
 }
 
 func NewMySQLWithSettings(ctx context.Context, settings interface{}) (*MySQL, error) {
@@ -98,13 +99,20 @@ func (m *MySQL) NewConn(ctx context.Context, database string) (*gorm.DB, error) 
 	if len(shard.Addr) == 0 {
 		return nil, errors.New("empty addr")
 	}
+	extraParams, err := NormalizeDSNExtraParams(shard.DsnExtraParams)
+	if err != nil {
+		return nil, fmt.Errorf("mysql connect: invalid mysql.dsn_extra_params: %w", err)
+	}
+
 	var keys []string
-	var err error
 	keys = append(keys, shard.Addr)
 
 	keys = append(keys, shard.Password, shard.User)
 	if len(database) > 0 {
 		keys = append(keys, database)
+	}
+	if extraParams != "" {
+		keys = append(keys, extraParams)
 	}
 	cachedKey := strings.Join(keys, ":")
 	// cache conn with database
@@ -120,6 +128,9 @@ func (m *MySQL) NewConn(ctx context.Context, database string) (*gorm.DB, error) 
 	}()
 
 	dsn := fmt.Sprintf("%s:%s@tcp(%s)/%s?charset=utf8&parseTime=True", shard.User, shard.Password, shard.Addr, database)
+	if extraParams != "" {
+		dsn += "&" + extraParams
+	}
 	db, err = sqlbase.NewDB(
 		ctx,
 		mysql.Open(dsn),


### PR DESCRIPTION
Connecting a MySQL datasource to OceanBase requires the session to run SET ob_read_consistency = 'WEAK' and SET @proxy_route_policy = 'follower_first' before any query, otherwise every read is served by the leader. go-sql-driver already turns unknown DSN query keys into such SET statements, but the DSN was assembled from a fixed template with no way to add anything.

Add mysql.dsn_extra_params, a raw DSN query fragment appended to the generated DSN. JDBC packs several assignments into one sessionVariables=k1=v1,k2=v2 pair, which the Go driver has no equivalent for, so that key is expanded into separate pairs; everything else is passed through as written.

The fragment also joins the connection-pool cache key and Equal, so editing it rebuilds the pooled connection instead of silently reusing a session configured by the previous value.

**What type of PR is this?**

**What this PR does / why we need it**:
<!--
"Nice to have" "You need it" is not a good reason. :)
-->

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or "Fixes (paste link of issue)"
-->
Fixes #
 
**Special notes for your reviewer**: