### PR TITLE
feat(doris): add doris.internal_addr for edge process FE MySQL (backport to main)

### DIFF
--- a/datasource/datasource.go
+++ b/datasource/datasource.go
@@ -108,6 +108,12 @@ type Datasource interface {
 	QueryMapData(ctx context.Context, query interface{}) ([]map[string]string, error)
 }
 
+// ReadAddrApplier is optional: datasources with a local read addr implement this.
+// Called once at init with the process identity (isCenter). Write addresses must not be touched.
+type ReadAddrApplier interface {
+	ApplyReadAddr(isCenter bool) (usedLocal bool)
+}
+
 func RegisterDatasource(typ string, p Datasource) {
 	if _, found := datasourceRegister[typ]; found {
 		return

--- a/datasource/doris/doris.go
+++ b/datasource/doris/doris.go
@@ -31,6 +31,8 @@ type Doris struct {
 	doris.Doris `json:",inline" mapstructure:",squash"`
 }
 
+var _ datasource.ReadAddrApplier = (*Doris)(nil)
+
 type QueryParam struct {
 	Ref        string          `json:"ref" mapstructure:"ref"`
 	Database   string          `json:"database" mapstructure:"database"`
@@ -83,6 +85,7 @@ func (d *Doris) Equal(p datasource.Datasource) bool {
 	}
 
 	return d.Addr == newest.Addr &&
+		d.InternalAddr == newest.InternalAddr &&
 		d.FeAddr == newest.FeAddr &&
 		d.User == newest.User &&
 		d.Password == newest.Password &&

--- a/dscache/sync.go
+++ b/dscache/sync.go
@@ -31,9 +31,11 @@ var FromAPIHook func()
 
 var DatasourceProcessHook func(items []datasource.DatasourceInfo) []datasource.DatasourceInfo
 
-// engineName 保存当前进程所属告警引擎集群名；edge 模式下用于过滤掉不属于本集群的数据源，
-// 避免对无关数据源做 InitClient 而产生连接报错（issue #3159）。center 不参与过滤。
-var engineName string
+var (
+	// engineName 保存当前进程所属告警引擎集群名；edge 模式下用于过滤掉不属于本集群的数据源，
+	// 避免对无关数据源做 InitClient 而产生连接报错（issue #3159）。center 不参与过滤。
+	engineName string
+)
 
 func Init(ctx *ctx.Context, fromAPI bool, engineNameArg string) {
 	engineName = engineNameArg
@@ -163,7 +165,7 @@ func getDatasourcesFromDBLoop(ctx *ctx.Context, fromAPI bool) {
 				dss = DatasourceProcessHook(dss)
 			}
 
-			PutDatasources(dss)
+			PutDatasources(dss, ctx.IsCenter)
 		} else {
 			FromAPIHook()
 		}
@@ -244,7 +246,7 @@ func esN9eToDatasourceInfo(ds *datasource.DatasourceInfo, item models.Datasource
 	ds.Settings["es.enable_write"] = item.SettingsJson["enable_write"]
 }
 
-func PutDatasources(items []datasource.DatasourceInfo) {
+func PutDatasources(items []datasource.DatasourceInfo, isCenter bool) {
 	// 记录当前有效的数据源 ID，按类型分组
 	validIds := make(map[string]map[int64]struct{})
 	ids := make([]int64, 0)
@@ -265,6 +267,8 @@ func PutDatasources(items []datasource.DatasourceInfo) {
 			logger.Debugf("get plugin:%+v fail: %v", item, err)
 			continue
 		}
+
+		applyReadAddr(ds, item.Id, isCenter)
 
 		err = ds.Validate(context.Background())
 		if err != nil {
@@ -305,4 +309,20 @@ func PutDatasources(items []datasource.DatasourceInfo) {
 	}
 
 	// logger.Debugf("get plugin by type success Ids:%v", ids)
+}
+
+// applyReadAddr asks each ReadAddrApplier to pick its effective read address for this process.
+// Logs at Debug: PutDatasources runs every ~2s; Info would flood the edge process log.
+func applyReadAddr(ds datasource.Datasource, dsId int64, isCenter bool) {
+	a, ok := ds.(datasource.ReadAddrApplier)
+	if !ok {
+		return
+	}
+	if a.ApplyReadAddr(isCenter) {
+		logger.Debugf("datasource use local read addr, datasource_id=%d", dsId)
+		return
+	}
+	if !isCenter {
+		logger.Debugf("datasource local read addr empty, fallback to addr, datasource_id=%d", dsId)
+	}
 }

--- a/dskit/doris/addr_test.go
+++ b/dskit/doris/addr_test.go
@@ -1,0 +1,57 @@
+package doris
+
+import "testing"
+
+func TestResolveReadAddr(t *testing.T) {
+	tests := []struct {
+		name       string
+		isCenter   bool
+		centerAddr string
+		localAddr  string
+		want       string
+	}{
+		{name: "center ignores local", isCenter: true, centerAddr: "pub:9030", localAddr: "local:9030", want: "pub:9030"},
+		{name: "center empty local", isCenter: true, centerAddr: "pub:9030", localAddr: "", want: "pub:9030"},
+		{name: "edge uses local", isCenter: false, centerAddr: "pub:9030", localAddr: "local:9030", want: "local:9030"},
+		{name: "edge fallback when empty", isCenter: false, centerAddr: "pub:9030", localAddr: "", want: "pub:9030"},
+		{name: "edge trims local", isCenter: false, centerAddr: "pub:9030", localAddr: "  local:9030  ", want: "local:9030"},
+		{name: "edge whitespace-only local falls back", isCenter: false, centerAddr: "pub:9030", localAddr: "   ", want: "pub:9030"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ResolveReadAddr(tt.isCenter, tt.centerAddr, tt.localAddr)
+			if got != tt.want {
+				t.Fatalf("ResolveReadAddr() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyReadAddr(t *testing.T) {
+	d := &Doris{Addr: "pub:9030", InternalAddr: "local:9030", FeAddr: "local:8030"}
+	if used := d.ApplyReadAddr(true); used {
+		t.Fatalf("center should not use local")
+	}
+	if d.Addr != "pub:9030" || d.FeAddr != "local:8030" {
+		t.Fatalf("center rewrite mutated unexpectedly: %+v", d)
+	}
+
+	d = &Doris{Addr: "pub:9030", InternalAddr: "local:9030", FeAddr: "local:8030"}
+	if used := d.ApplyReadAddr(false); !used {
+		t.Fatalf("edge with local should report usedLocal")
+	}
+	if d.Addr != "local:9030" {
+		t.Fatalf("edge Addr = %q, want local:9030", d.Addr)
+	}
+	if d.FeAddr != "local:8030" {
+		t.Fatalf("FeAddr must stay untouched, got %q", d.FeAddr)
+	}
+
+	d = &Doris{Addr: "pub:9030", InternalAddr: "", FeAddr: "local:8030"}
+	if used := d.ApplyReadAddr(false); used {
+		t.Fatalf("edge without local should not report usedLocal")
+	}
+	if d.Addr != "pub:9030" {
+		t.Fatalf("edge fallback Addr = %q, want pub:9030", d.Addr)
+	}
+}

--- a/dskit/doris/doris.go
+++ b/dskit/doris/doris.go
@@ -30,11 +30,12 @@ const (
 
 // Doris struct to hold connection details and the connection object
 type Doris struct {
-	Addr            string `json:"doris.addr" mapstructure:"doris.addr"`         // fe mysql endpoint
-	FeAddr          string `json:"doris.fe_addr" mapstructure:"doris.fe_addr"`   // fe http endpoint
-	User            string `json:"doris.user" mapstructure:"doris.user"`         //
-	Password        string `json:"doris.password" mapstructure:"doris.password"` //
-	Timeout         int    `json:"doris.timeout" mapstructure:"doris.timeout"`   // ms
+	Addr            string `json:"doris.addr" mapstructure:"doris.addr"`                   // fe mysql endpoint (center-reachable)
+	InternalAddr    string `json:"doris.internal_addr" mapstructure:"doris.internal_addr"` // fe mysql endpoint for edge process
+	FeAddr          string `json:"doris.fe_addr" mapstructure:"doris.fe_addr"`             // fe http endpoint
+	User            string `json:"doris.user" mapstructure:"doris.user"`                   //
+	Password        string `json:"doris.password" mapstructure:"doris.password"`           //
+	Timeout         int    `json:"doris.timeout" mapstructure:"doris.timeout"`             // ms
 	MaxIdleConns    int    `json:"doris.max_idle_conns" mapstructure:"doris.max_idle_conns"`
 	MaxOpenConns    int    `json:"doris.max_open_conns" mapstructure:"doris.max_open_conns"`
 	ConnMaxLifetime int    `json:"doris.conn_max_lifetime" mapstructure:"doris.conn_max_lifetime"`
@@ -44,6 +45,31 @@ type Doris struct {
 	// 写用户，用来区分读写用户，减少数据源
 	UserWrite     string `json:"doris.user_write" mapstructure:"doris.user_write"`
 	PasswordWrite string `json:"doris.password_write" mapstructure:"doris.password_write"`
+}
+
+// ResolveReadAddr returns the effective FE MySQL read address for the current process.
+// Edge (isCenter=false) prefers localAddr when non-empty; otherwise falls back to centerAddr.
+// Write path (FeAddr) is independent and never selected here.
+func ResolveReadAddr(isCenter bool, centerAddr, localAddr string) string {
+	if !isCenter {
+		if la := strings.TrimSpace(localAddr); la != "" {
+			return la
+		}
+	}
+	return strings.TrimSpace(centerAddr)
+}
+
+// ApplyReadAddr rewrites Addr in-process to the effective read address for edge/center identity.
+// Does not persist settings; call once at datasource init before opening connections.
+func (d *Doris) ApplyReadAddr(isCenter bool) (usedLocal bool) {
+	if d == nil {
+		return false
+	}
+	local := strings.TrimSpace(d.InternalAddr)
+	resolved := ResolveReadAddr(isCenter, d.Addr, local)
+	usedLocal = !isCenter && local != ""
+	d.Addr = resolved
+	return usedLocal
 }
 
 // NewDorisWithSettings initializes a new Doris instance with the given settings


### PR DESCRIPTION
Cherry-pick of #3265 (already merged to `dev`) onto `main`.

- Original PR: https://github.com/ccfos/nightingale/pull/3265
- Original commit: bb6faebe
- Patch-id equivalent to the merged dev version; no conflicts on rebase against current upstream/main.

Downstream projects (n9e-plus / fc-insight edge-client) depend on `PutDatasources(items, isCenter)` + `Doris.InternalAddr` being available on `main` to backport their edge-mode Doris addr feature to their release branches.

Made with [Cursor](https://cursor.com)