### PR TITLE
fix(ai): support max_completion_tokens for newer OpenAI models

### DIFF
--- a/aiagent/llm/openai.go
+++ b/aiagent/llm/openai.go
@@ -156,7 +156,8 @@ func isMaxCompletionTokensError(err error) bool {
 //
 // 主要覆盖 Azure 自定义部署名——那里 model 填的是部署名（如 my-gpt5），任何基于
 // 模型名的前缀匹配都会漏判。用户在 CustomParams 里手填的 max_tokens 同样会触发这个
-// 400，一并摘掉。
+// 400，一并摘掉并把值迁过去——只删不迁的话重试请求会彻底没有上限，推理模型能跑出
+// 远超用户预期的输出长度和费用。
 //
 // 改完之后 MaxTokens == 0 且 extraBody 里不再有 max_tokens，第二次调用必然返回
 // false，因此不会出现反复重试。
@@ -170,11 +171,35 @@ func swapToMaxCompletionTokens(req *openAIRequest, err error) bool {
 		req.MaxTokens = 0
 		changed = true
 	}
-	if _, ok := req.extraBody["max_tokens"]; ok {
+	if v, ok := req.extraBody["max_tokens"]; ok {
 		delete(req.extraBody, "max_tokens")
+		// 显式字段优先，与 MarshalJSON 里"extraBody 不覆盖显式字段"的规则保持一致
+		if n, ok := positiveInt(v); ok && req.MaxCompletionTokens == 0 {
+			req.MaxCompletionTokens = n
+		}
 		changed = true
 	}
 	return changed
+}
+
+// positiveInt 从 extra body 取正整数。CustomParams 由 JSON 反序列化而来，数值落地是
+// float64；程序内构造的则可能是 int/int64。取不到就返回 false，由调用方决定兜底。
+func positiveInt(v any) (int, bool) {
+	var n int
+	switch x := v.(type) {
+	case float64:
+		n = int(x)
+	case int:
+		n = x
+	case int64:
+		n = int(x)
+	default:
+		return 0, false
+	}
+	if n <= 0 {
+		return 0, false
+	}
+	return n, true
 }
 
 type openAIMessage struct {

--- a/aiagent/llm/openai.go
+++ b/aiagent/llm/openai.go
@@ -154,10 +154,9 @@ func isMaxCompletionTokensError(err error) bool {
 // 服务端要求改用 max_completion_tokens 时，就地把值迁到新字段并返回 true（供调用方
 // 重试一次）；不满足条件则不动请求、返回 false。
 //
-// 主要覆盖 Azure 自定义部署名——那里 model 填的是部署名（如 my-gpt5），任何基于
-// 模型名的前缀匹配都会漏判。用户在 CustomParams 里手填的 max_tokens 同样会触发这个
-// 400，一并摘掉并把值迁过去——只删不迁的话重试请求会彻底没有上限，推理模型能跑出
-// 远超用户预期的输出长度和费用。
+// 只覆盖模型名漏判的场景——主要是 Azure 自定义部署名，那里 model 填的是部署名
+// （如 my-gpt5），任何基于模型名的前缀匹配都会漏判。模型名能认出来的走
+// convertRequest 里的提前迁移，不必先吃一个 400。
 //
 // 改完之后 MaxTokens == 0 且 extraBody 里不再有 max_tokens，第二次调用必然返回
 // false，因此不会出现反复重试。
@@ -171,15 +170,27 @@ func swapToMaxCompletionTokens(req *openAIRequest, err error) bool {
 		req.MaxTokens = 0
 		changed = true
 	}
-	if v, ok := req.extraBody["max_tokens"]; ok {
-		delete(req.extraBody, "max_tokens")
-		// 显式字段优先，与 MarshalJSON 里"extraBody 不覆盖显式字段"的规则保持一致
-		if n, ok := positiveInt(v); ok && req.MaxCompletionTokens == 0 {
-			req.MaxCompletionTokens = n
-		}
+	if takeExtraBodyMaxTokens(req) {
 		changed = true
 	}
 	return changed
+}
+
+// takeExtraBodyMaxTokens 把 extraBody 里用户手填的 max_tokens 摘掉，值迁到
+// MaxCompletionTokens，返回是否动过请求。
+//
+// 只删不迁的话请求会彻底没有输出上限，推理模型能跑出远超用户预期的长度和费用。
+// 显式字段已有值时只删不迁，与 MarshalJSON 里"extraBody 不覆盖显式字段"的规则保持一致。
+func takeExtraBodyMaxTokens(req *openAIRequest) bool {
+	v, ok := req.extraBody["max_tokens"]
+	if !ok {
+		return false
+	}
+	delete(req.extraBody, "max_tokens")
+	if n, ok := positiveInt(v); ok && req.MaxCompletionTokens == 0 {
+		req.MaxCompletionTokens = n
+	}
+	return true
 }
 
 // positiveInt 从 extra body 取正整数。CustomParams 由 JSON 反序列化而来，数值落地是
@@ -521,6 +532,11 @@ func (o *OpenAI) convertRequest(req *GenerateRequest) *openAIRequest {
 	}
 	if usesMaxCompletionTokens(openAIReq.Model) {
 		openAIReq.MaxCompletionTokens = maxTokens
+		// 模型名已经确定该用新字段：CustomParams 里手填的 max_tokens 现在就迁走。
+		// 留着的话（没配 MaxTokens 时 MarshalJSON 的互斥剔除不生效）会被平铺进请求体，
+		// 每次调用都要先吃一个 400 再靠 swapToMaxCompletionTokens 兜底重试——agent
+		// 工具循环里一轮十几次调用就是十几个白跑的往返。
+		takeExtraBodyMaxTokens(openAIReq)
 	} else {
 		openAIReq.MaxTokens = maxTokens
 	}

--- a/aiagent/llm/openai.go
+++ b/aiagent/llm/openai.go
@@ -82,15 +82,7 @@ type openAIRequest struct {
 // 已存在的 key 由显式字段优先（不让 extraBody 偷偷覆盖 model/messages 等关键字段）。
 func (r openAIRequest) MarshalJSON() ([]byte, error) {
 	type alias openAIRequest
-	useMaxCompletionTokens := usesMaxCompletionTokens(r.Model)
-	normalized := r
-	if useMaxCompletionTokens {
-		normalized.MaxTokens = 0
-	} else {
-		normalized.MaxCompletionTokens = 0
-	}
-
-	data, err := json.Marshal(alias(normalized))
+	data, err := json.Marshal(alias(r))
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +94,12 @@ func (r openAIRequest) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 	for k, v := range r.extraBody {
-		if (useMaxCompletionTokens && k == "max_tokens") || (!useMaxCompletionTokens && k == "max_completion_tokens") {
+		// 两个 token 上限字段互斥：只要显式字段已经选定了一个，就不让 extraBody
+		// 把另一个也带上（同时出现会被 OpenAI 判 400）。这里按"实际填了哪个字段"
+		// 判断而不是重算模型名，否则 swapToMaxCompletionTokens 兜底改名之后
+		// （模型名命不中前缀）这层剔除就会站错队。
+		if (r.MaxCompletionTokens > 0 && k == "max_tokens") ||
+			(r.MaxTokens > 0 && k == "max_completion_tokens") {
 			continue
 		}
 		if _, occupied := m[k]; occupied {
@@ -113,11 +110,71 @@ func (r openAIRequest) MarshalJSON() ([]byte, error) {
 	return json.Marshal(m)
 }
 
+// usesMaxCompletionTokens 判断模型是否属于 OpenAI 新一代推理模型家族
+// （gpt-5 / o1 / o3 / o4）。这些模型废弃了 max_tokens，只认 max_completion_tokens。
+//
+// gpt-5 用宽前缀而不是 "gpt-5-"：官方型号里既有 gpt-5-mini 也有 gpt-5.1，
+// 卡横杠会漏掉后者。o 系列反过来要卡精确值或带横杠的前缀，否则 o1x 之类会误伤。
+//
+// 与 thinking.go 的模型判断相互独立：那边管"是否注入关思考字段"，这里管"token
+// 字段名"，成员集合不同（如 isPureThinkingModel 含 qwq/deepseek-r1/gemini 却不含
+// gpt-5），故单列一个判断而非复用。
 func usesMaxCompletionTokens(model string) bool {
 	m := strings.ToLower(strings.TrimSpace(model))
-	return m == "gpt-5" || strings.HasPrefix(m, "gpt-5-") ||
-		m == "o1" || strings.HasPrefix(m, "o1-") ||
-		m == "o3" || strings.HasPrefix(m, "o3-")
+	switch {
+	case strings.HasPrefix(m, "gpt-5"),
+		m == "o1", strings.HasPrefix(m, "o1-"),
+		m == "o3", strings.HasPrefix(m, "o3-"),
+		m == "o4", strings.HasPrefix(m, "o4-"):
+		return true
+	}
+	return false
+}
+
+// cloneExtraBody 浅拷贝 extra body，让单次请求可以安全地增删自己的字段。
+func cloneExtraBody(src map[string]any) map[string]any {
+	if len(src) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(src))
+	for k, v := range src {
+		out[k] = v
+	}
+	return out
+}
+
+// isMaxCompletionTokensError 命中"服务端因 max_tokens 不被支持而 400，并提示改用
+// max_completion_tokens"的错误。错误串形如 `OpenAI API error (status 400): ...
+// Use 'max_completion_tokens' instead.`，故以是否提到 max_completion_tokens 为判据。
+func isMaxCompletionTokensError(err error) bool {
+	return err != nil && strings.Contains(strings.ToLower(err.Error()), "max_completion_tokens")
+}
+
+// swapToMaxCompletionTokens 是模型名识别的运行时兜底：当请求发了 max_tokens 却被
+// 服务端要求改用 max_completion_tokens 时，就地把值迁到新字段并返回 true（供调用方
+// 重试一次）；不满足条件则不动请求、返回 false。
+//
+// 主要覆盖 Azure 自定义部署名——那里 model 填的是部署名（如 my-gpt5），任何基于
+// 模型名的前缀匹配都会漏判。用户在 CustomParams 里手填的 max_tokens 同样会触发这个
+// 400，一并摘掉。
+//
+// 改完之后 MaxTokens == 0 且 extraBody 里不再有 max_tokens，第二次调用必然返回
+// false，因此不会出现反复重试。
+func swapToMaxCompletionTokens(req *openAIRequest, err error) bool {
+	if !isMaxCompletionTokensError(err) {
+		return false
+	}
+	changed := false
+	if req.MaxTokens > 0 {
+		req.MaxCompletionTokens = req.MaxTokens
+		req.MaxTokens = 0
+		changed = true
+	}
+	if _, ok := req.extraBody["max_tokens"]; ok {
+		delete(req.extraBody, "max_tokens")
+		changed = true
+	}
+	return changed
 }
 
 type openAIMessage struct {
@@ -182,7 +239,13 @@ func (o *OpenAI) Generate(ctx context.Context, req *GenerateRequest) (*GenerateR
 	// Make request
 	respBody, err := o.doRequest(ctx, openAIReq)
 	if err != nil {
-		return nil, err
+		// 模型名没命中家族前缀（如 Azure 自定义部署名）时，按服务端 400 的提示改名重试一次
+		if !swapToMaxCompletionTokens(openAIReq, err) {
+			return nil, err
+		}
+		if respBody, err = o.doRequest(ctx, openAIReq); err != nil {
+			return nil, err
+		}
 	}
 
 	// Parse response
@@ -207,7 +270,26 @@ func (o *OpenAI) GenerateStream(ctx context.Context, req *GenerateRequest) (<-ch
 	openAIReq := o.convertRequest(req)
 	openAIReq.Stream = true
 
-	jsonData, err := json.Marshal(openAIReq)
+	resp, err := o.doStreamRequest(ctx, openAIReq)
+	if err != nil {
+		// 与 Generate 一致的兜底：名字识别漏判时按 400 提示改名重试一次
+		if !swapToMaxCompletionTokens(openAIReq, err) {
+			return nil, err
+		}
+		if resp, err = o.doStreamRequest(ctx, openAIReq); err != nil {
+			return nil, err
+		}
+	}
+
+	ch := make(chan StreamChunk, 100)
+	go o.streamResponse(ctx, resp, ch)
+	return ch, nil
+}
+
+// doStreamRequest 序列化请求并发起流式调用，成功时返回打开的响应交由调用方读取 Body。
+// 序列化必须放在函数内部：兜底改名后要重新 marshal，复用旧 body 会把改名前的请求再发一遍。
+func (o *OpenAI) doStreamRequest(ctx context.Context, req *openAIRequest) (*http.Response, error) {
+	jsonData, err := json.Marshal(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
@@ -221,19 +303,12 @@ func (o *OpenAI) GenerateStream(ctx context.Context, req *GenerateRequest) (<-ch
 		logger.Debugf("[OpenAI] stream request body (with extra): %s", preview)
 	}
 
-	resp, err := doHTTPStreamWithRetry(ctx, o.client, "OpenAI",
+	return doHTTPStreamWithRetry(ctx, o.client, "OpenAI",
 		func() (*http.Request, error) {
 			return http.NewRequestWithContext(ctx, "POST", o.config.BaseURL, bytes.NewBuffer(jsonData))
 		},
 		o.setHeaders,
 	)
-	if err != nil {
-		return nil, err
-	}
-
-	ch := make(chan StreamChunk, 100)
-	go o.streamResponse(ctx, resp, ch)
-	return ch, nil
 }
 
 // openAIToolCallAggregator 按 index 聚合流式下发的 tool_call 分片。
@@ -396,9 +471,11 @@ func (o *OpenAI) streamResponse(ctx context.Context, resp *http.Response, ch cha
 
 func (o *OpenAI) convertRequest(req *GenerateRequest) *openAIRequest {
 	openAIReq := &openAIRequest{
-		Model:     o.config.Model,
-		TopP:      req.TopP,
-		extraBody: o.config.ExtraBody,
+		Model: o.config.Model,
+		TopP:  req.TopP,
+		// 复制一份：config 被 client_cache 复用并发共享，而 swapToMaxCompletionTokens
+		// 兜底时需要就地摘掉 extraBody 里的 max_tokens，直接引用会写坏共享 map。
+		extraBody: cloneExtraBody(o.config.ExtraBody),
 	}
 
 	// Temperature: request 优先，fallback 到 config 默认值

--- a/aiagent/llm/openai.go
+++ b/aiagent/llm/openai.go
@@ -62,13 +62,14 @@ func (o *OpenAI) Name() string {
 
 // OpenAI API request/response structures
 type openAIRequest struct {
-	Model       string          `json:"model"`
-	Messages    []openAIMessage `json:"messages"`
-	Tools       []openAITool    `json:"tools,omitempty"`
-	MaxTokens   int             `json:"max_tokens,omitempty"`
-	Temperature float64         `json:"temperature,omitempty"`
-	TopP        float64         `json:"top_p,omitempty"`
-	Stream      bool            `json:"stream,omitempty"`
+	Model               string          `json:"model"`
+	Messages            []openAIMessage `json:"messages"`
+	Tools               []openAITool    `json:"tools,omitempty"`
+	MaxTokens           int             `json:"max_tokens,omitempty"`
+	MaxCompletionTokens int             `json:"max_completion_tokens,omitempty"`
+	Temperature         float64         `json:"temperature,omitempty"`
+	TopP                float64         `json:"top_p,omitempty"`
+	Stream              bool            `json:"stream,omitempty"`
 
 	// extraBody 不出现在 JSON tag 里——由 MarshalJSON 平铺到顶层。
 	// 用于把 LLMConfig.ExtraBody 透传给厂商特定字段（如 dashscope 的 enable_thinking）。
@@ -81,7 +82,15 @@ type openAIRequest struct {
 // 已存在的 key 由显式字段优先（不让 extraBody 偷偷覆盖 model/messages 等关键字段）。
 func (r openAIRequest) MarshalJSON() ([]byte, error) {
 	type alias openAIRequest
-	data, err := json.Marshal(alias(r))
+	useMaxCompletionTokens := usesMaxCompletionTokens(r.Model)
+	normalized := r
+	if useMaxCompletionTokens {
+		normalized.MaxTokens = 0
+	} else {
+		normalized.MaxCompletionTokens = 0
+	}
+
+	data, err := json.Marshal(alias(normalized))
 	if err != nil {
 		return nil, err
 	}
@@ -93,12 +102,22 @@ func (r openAIRequest) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 	for k, v := range r.extraBody {
+		if (useMaxCompletionTokens && k == "max_tokens") || (!useMaxCompletionTokens && k == "max_completion_tokens") {
+			continue
+		}
 		if _, occupied := m[k]; occupied {
 			continue
 		}
 		m[k] = v
 	}
 	return json.Marshal(m)
+}
+
+func usesMaxCompletionTokens(model string) bool {
+	m := strings.ToLower(strings.TrimSpace(model))
+	return m == "gpt-5" || strings.HasPrefix(m, "gpt-5-") ||
+		m == "o1" || strings.HasPrefix(m, "o1-") ||
+		m == "o3" || strings.HasPrefix(m, "o3-")
 }
 
 type openAIMessage struct {
@@ -391,11 +410,17 @@ func (o *OpenAI) convertRequest(req *GenerateRequest) *openAIRequest {
 	}
 
 	// MaxTokens: 同上
+	var maxTokens int
 	switch {
 	case req.MaxTokens != nil:
-		openAIReq.MaxTokens = *req.MaxTokens
+		maxTokens = *req.MaxTokens
 	case o.config.MaxTokens != nil:
-		openAIReq.MaxTokens = *o.config.MaxTokens
+		maxTokens = *o.config.MaxTokens
+	}
+	if usesMaxCompletionTokens(openAIReq.Model) {
+		openAIReq.MaxCompletionTokens = maxTokens
+	} else {
+		openAIReq.MaxTokens = maxTokens
 	}
 
 	// Convert messages. 结构化工具轮：assistant 的 ToolCalls 与 RoleTool 结果轮

--- a/aiagent/llm/openai_test.go
+++ b/aiagent/llm/openai_test.go
@@ -3,8 +3,10 @@ package llm
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 )
@@ -225,8 +227,16 @@ func TestOpenAIRequest_MaxTokensFieldByModel(t *testing.T) {
 		{model: "o1-preview", wantField: "max_completion_tokens"},
 		{model: "o3", wantField: "max_completion_tokens"},
 		{model: "o3-mini", wantField: "max_completion_tokens"},
-		{model: "gpt-50", wantField: "max_tokens"},
+		// gpt-5.1 是点号不是横杠，o4 是新家族成员：两者都必须走新字段
+		{model: "gpt-5.1", wantField: "max_completion_tokens"},
+		{model: "gpt-5.1-mini", wantField: "max_completion_tokens"},
+		{model: "o4-mini", wantField: "max_completion_tokens"},
+		{model: "GPT-5-Nano", wantField: "max_completion_tokens"},
+		{model: " o1 ", wantField: "max_completion_tokens"},
 		{model: "gpt-4o", wantField: "max_tokens"},
+		// o1x / o 不能被 o1 前缀误伤
+		{model: "o1x", wantField: "max_tokens"},
+		{model: "o", wantField: "max_tokens"},
 		{model: "deepseek-chat", wantField: "max_tokens"},
 	}
 
@@ -289,5 +299,204 @@ func TestOpenAIRequest_RequestMaxTokensForGPT5Probe(t *testing.T) {
 	}
 	if got != requestMaxTokens {
 		t.Errorf("max_completion_tokens = %d, want %d; body: %s", got, requestMaxTokens, data)
+	}
+}
+
+// TestSwapToMaxCompletionTokens 覆盖模型名漏判时的 400 兜底改名：命中提示就把
+// max_tokens 迁到 max_completion_tokens，无关错误或已经改过名时保持请求不变。
+func TestSwapToMaxCompletionTokens(t *testing.T) {
+	err400 := fmt.Errorf("OpenAI API error (status 400): Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.")
+
+	req := &openAIRequest{MaxTokens: 100}
+	if !swapToMaxCompletionTokens(req, err400) {
+		t.Fatal("expected swap to trigger on max_completion_tokens hint")
+	}
+	if req.MaxTokens != 0 || req.MaxCompletionTokens != 100 {
+		t.Fatalf("token should move to max_completion_tokens, got max_tokens=%d max_completion_tokens=%d",
+			req.MaxTokens, req.MaxCompletionTokens)
+	}
+	// 幂等：改完之后再撞同样的错也不该重试，否则会无限循环
+	if swapToMaxCompletionTokens(req, err400) {
+		t.Fatal("second swap must not trigger")
+	}
+
+	unrelated := &openAIRequest{MaxTokens: 100}
+	if swapToMaxCompletionTokens(unrelated, fmt.Errorf("OpenAI API error (status 401): invalid api key")) {
+		t.Fatal("unrelated error must not trigger swap")
+	}
+	if unrelated.MaxTokens != 100 || unrelated.MaxCompletionTokens != 0 {
+		t.Fatal("unrelated error must leave request untouched")
+	}
+
+	// 用户在 CustomParams 里手填的 max_tokens 同样会触发 400，兜底要一并摘掉
+	viaExtra := &openAIRequest{extraBody: map[string]any{"max_tokens": 456, "enable_thinking": false}}
+	if !swapToMaxCompletionTokens(viaExtra, err400) {
+		t.Fatal("expected swap to strip max_tokens from extra body")
+	}
+	if _, ok := viaExtra.extraBody["max_tokens"]; ok {
+		t.Fatal("extra body max_tokens must be removed")
+	}
+	if _, ok := viaExtra.extraBody["enable_thinking"]; !ok {
+		t.Fatal("unrelated extra body keys must survive")
+	}
+}
+
+// TestConvertRequest_ExtraBodyNotShared 确认每次请求拿到的是 extra body 的副本：
+// 兜底改名会就地删 key，若直接引用 config 里的 map 会写坏并发共享的缓存配置。
+func TestConvertRequest_ExtraBodyNotShared(t *testing.T) {
+	cfg := &Config{Model: "my-azure-deploy", ExtraBody: map[string]any{"max_tokens": 456}}
+	o := &OpenAI{config: cfg}
+
+	req := o.convertRequest(&GenerateRequest{})
+	delete(req.extraBody, "max_tokens")
+
+	if _, ok := cfg.ExtraBody["max_tokens"]; !ok {
+		t.Fatal("config extra body must not be mutated by a single request")
+	}
+}
+
+// TestOpenAIRequest_MarshalKeepsSwappedField 确认改名兜底之后序列化仍然正确：
+// 模型名（Azure 自定义部署名）命不中家族前缀，但显式字段已经是 max_completion_tokens，
+// MarshalJSON 不能按模型名把它抹掉，也不能让 extraBody 把 max_tokens 塞回来。
+func TestOpenAIRequest_MarshalKeepsSwappedField(t *testing.T) {
+	req := &openAIRequest{
+		Model:               "my-azure-deploy",
+		MaxCompletionTokens: 100,
+		extraBody:           map[string]any{"max_tokens": 456},
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	var body map[string]json.RawMessage
+	if err := json.Unmarshal(data, &body); err != nil {
+		t.Fatalf("unmarshal request: %v", err)
+	}
+	if _, ok := body["max_tokens"]; ok {
+		t.Fatalf("max_tokens must not be reintroduced by extra body: %s", data)
+	}
+	var got int
+	if err := json.Unmarshal(body["max_completion_tokens"], &got); err != nil {
+		t.Fatalf("unmarshal max_completion_tokens: %v; body: %s", err, data)
+	}
+	if got != 100 {
+		t.Errorf("max_completion_tokens = %d, want 100; body: %s", got, data)
+	}
+}
+
+const unsupportedMaxTokensBody = `{"error":{"message":"Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.","type":"invalid_request_error","param":"max_tokens","code":"unsupported_parameter"}}`
+
+// newSwapProbeServer 起一个先拒后收的假上游：第一次请求回 400（提示改用
+// max_completion_tokens），第二次回 okBody。返回收集到的两次请求体。
+func newSwapProbeServer(t *testing.T, okBody string, sse bool) (*httptest.Server, *[]map[string]any) {
+	t.Helper()
+	var bodies []map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		var m map[string]any
+		if err := json.Unmarshal(raw, &m); err != nil {
+			t.Errorf("bad request body: %v", err)
+		}
+		bodies = append(bodies, m)
+
+		if len(bodies) == 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(unsupportedMaxTokensBody))
+			return
+		}
+		if sse {
+			w.Header().Set("Content-Type", "text/event-stream")
+		}
+		_, _ = w.Write([]byte(okBody))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &bodies
+}
+
+// assertSwapped 校验兜底重试的两次请求体：第一次发 max_tokens，第二次改发
+// max_completion_tokens 且不再带 max_tokens。
+func assertSwapped(t *testing.T, bodies []map[string]any) {
+	t.Helper()
+	if len(bodies) != 2 {
+		t.Fatalf("expected exactly 2 upstream requests (reject + retry), got %d", len(bodies))
+	}
+	if _, ok := bodies[0]["max_tokens"]; !ok {
+		t.Errorf("first request should carry max_tokens, got %v", bodies[0])
+	}
+	if _, ok := bodies[1]["max_tokens"]; ok {
+		t.Errorf("retry must not carry max_tokens, got %v", bodies[1])
+	}
+	if got := bodies[1]["max_completion_tokens"]; got != float64(5) {
+		t.Errorf("retry max_completion_tokens = %v, want 5; body %v", got, bodies[1])
+	}
+}
+
+// TestGenerate_RetriesWithMaxCompletionTokens 端到端验证兜底：模型名是 Azure 自定义
+// 部署名（命不中家族前缀），首次请求被 400 拒绝后自动改名重试并成功（issue #3297）。
+func TestGenerate_RetriesWithMaxCompletionTokens(t *testing.T) {
+	srv, bodies := newSwapProbeServer(t, `{"choices":[{"message":{"role":"assistant","content":"Hello"}}]}`, false)
+
+	maxTokens := 5
+	o := &OpenAI{config: &Config{Model: "my-azure-deploy", BaseURL: srv.URL}, client: srv.Client()}
+	resp, err := o.Generate(context.Background(), &GenerateRequest{
+		Messages:  []Message{{Role: RoleUser, Content: "Hi"}},
+		MaxTokens: &maxTokens,
+	})
+	if err != nil {
+		t.Fatalf("Generate should recover after renaming the token field: %v", err)
+	}
+	if resp.Content != "Hello" {
+		t.Errorf("content = %q, want %q", resp.Content, "Hello")
+	}
+	assertSwapped(t, *bodies)
+}
+
+// TestGenerateStream_RetriesWithMaxCompletionTokens 同上，覆盖流式路径——重试必须
+// 重新序列化请求体，否则会把改名前的 body 再发一遍。
+func TestGenerateStream_RetriesWithMaxCompletionTokens(t *testing.T) {
+	sse := `data: {"choices":[{"delta":{"content":"Hello"}}]}` + "\n\n" + `data: [DONE]` + "\n\n"
+	srv, bodies := newSwapProbeServer(t, sse, true)
+
+	maxTokens := 5
+	o := &OpenAI{config: &Config{Model: "my-azure-deploy", BaseURL: srv.URL}, client: srv.Client()}
+	ch, err := o.GenerateStream(context.Background(), &GenerateRequest{
+		Messages:  []Message{{Role: RoleUser, Content: "Hi"}},
+		MaxTokens: &maxTokens,
+	})
+	if err != nil {
+		t.Fatalf("GenerateStream should recover after renaming the token field: %v", err)
+	}
+
+	var content strings.Builder
+	for c := range ch {
+		content.WriteString(c.Content)
+	}
+	if content.String() != "Hello" {
+		t.Errorf("streamed content = %q, want %q", content.String(), "Hello")
+	}
+	assertSwapped(t, *bodies)
+}
+
+// TestGenerate_DoesNotRetryUnrelated400 确认兜底不会退化成"遇 400 就重试"。
+func TestGenerate_DoesNotRetryUnrelated400(t *testing.T) {
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"invalid model"}}`))
+	}))
+	defer srv.Close()
+
+	maxTokens := 5
+	o := &OpenAI{config: &Config{Model: "gpt-4o", BaseURL: srv.URL}, client: srv.Client()}
+	if _, err := o.Generate(context.Background(), &GenerateRequest{
+		Messages:  []Message{{Role: RoleUser, Content: "Hi"}},
+		MaxTokens: &maxTokens,
+	}); err == nil {
+		t.Fatal("expected the unrelated 400 to surface")
+	}
+	if calls != 1 {
+		t.Errorf("unrelated 400 must not be retried, got %d upstream calls", calls)
 	}
 }

--- a/aiagent/llm/openai_test.go
+++ b/aiagent/llm/openai_test.go
@@ -302,6 +302,60 @@ func TestOpenAIRequest_RequestMaxTokensForGPT5Probe(t *testing.T) {
 	}
 }
 
+// TestConvertRequest_GPT5MigratesExtraBodyMaxTokens：模型名已经命中新家族时，
+// CustomParams 里手填的 max_tokens 必须在首个请求里就迁到 max_completion_tokens。
+// 留到服务端 400 再靠兜底改名的话，每次调用都要白跑一个往返。
+func TestConvertRequest_GPT5MigratesExtraBodyMaxTokens(t *testing.T) {
+	cfg := &Config{
+		Model: "gpt-5",
+		// 用户只在 custom_params 里配了上限，没配 extra_config.max_tokens
+		ExtraBody: map[string]any{"max_tokens": float64(4096), "reasoning_effort": "minimal"},
+	}
+	o := &OpenAI{config: cfg}
+
+	data, err := json.Marshal(o.convertRequest(&GenerateRequest{}))
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	var body map[string]json.RawMessage
+	if err := json.Unmarshal(data, &body); err != nil {
+		t.Fatalf("unmarshal request: %v", err)
+	}
+	if _, ok := body["max_tokens"]; ok {
+		t.Fatalf("first request must not carry max_tokens: %s", data)
+	}
+	var got int
+	if err := json.Unmarshal(body["max_completion_tokens"], &got); err != nil {
+		t.Fatalf("unmarshal max_completion_tokens: %v; body: %s", err, data)
+	}
+	if got != 4096 {
+		t.Errorf("max_completion_tokens = %d, want 4096; body: %s", got, data)
+	}
+	// 迁移只针对 token 上限，其他 extra 字段照常透传
+	if _, ok := body["reasoning_effort"]; !ok {
+		t.Errorf("unrelated extra body keys must survive: %s", data)
+	}
+	// 迁移动的是副本，共享的 config 不能被改坏
+	if _, ok := cfg.ExtraBody["max_tokens"]; !ok {
+		t.Error("config extra body must not be mutated by a single request")
+	}
+
+	// 显式上限存在时以显式值为准，extraBody 的只删不迁
+	limit := 100
+	o = &OpenAI{config: &Config{Model: "gpt-5", MaxTokens: &limit,
+		ExtraBody: map[string]any{"max_tokens": float64(4096)}}}
+	if out := o.convertRequest(&GenerateRequest{}); out.MaxCompletionTokens != 100 {
+		t.Errorf("explicit field must win, got %d", out.MaxCompletionTokens)
+	}
+
+	// 非新家族模型不动 extraBody：老模型本来就该发 max_tokens
+	o = &OpenAI{config: &Config{Model: "gpt-4o", ExtraBody: map[string]any{"max_tokens": float64(4096)}}}
+	if _, ok := o.convertRequest(&GenerateRequest{}).extraBody["max_tokens"]; !ok {
+		t.Error("legacy models must keep extra body max_tokens")
+	}
+}
+
 // TestSwapToMaxCompletionTokens 覆盖模型名漏判时的 400 兜底改名：命中提示就把
 // max_tokens 迁到 max_completion_tokens，无关错误或已经改过名时保持请求不变。
 func TestSwapToMaxCompletionTokens(t *testing.T) {

--- a/aiagent/llm/openai_test.go
+++ b/aiagent/llm/openai_test.go
@@ -2,6 +2,7 @@ package llm
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"strings"
@@ -211,5 +212,82 @@ func TestConvertRequest_ToolTurnEmptyContent(t *testing.T) {
 	}
 	if out.Messages[2].Content != "real result" {
 		t.Errorf("non-empty tool result must pass through, got %q", out.Messages[2].Content)
+	}
+}
+
+func TestOpenAIRequest_MaxTokensFieldByModel(t *testing.T) {
+	tests := []struct {
+		model     string
+		wantField string
+	}{
+		{model: "gpt-5-mini", wantField: "max_completion_tokens"},
+		{model: "o1", wantField: "max_completion_tokens"},
+		{model: "o1-preview", wantField: "max_completion_tokens"},
+		{model: "o3", wantField: "max_completion_tokens"},
+		{model: "o3-mini", wantField: "max_completion_tokens"},
+		{model: "gpt-50", wantField: "max_tokens"},
+		{model: "gpt-4o", wantField: "max_tokens"},
+		{model: "deepseek-chat", wantField: "max_tokens"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			tokenLimit := 123
+			otherField := "max_tokens"
+			if tt.wantField == "max_tokens" {
+				otherField = "max_completion_tokens"
+			}
+
+			o := &OpenAI{config: &Config{
+				Model:     tt.model,
+				MaxTokens: &tokenLimit,
+				ExtraBody: map[string]any{otherField: 456},
+			}}
+			data, err := json.Marshal(o.convertRequest(&GenerateRequest{}))
+			if err != nil {
+				t.Fatalf("marshal request: %v", err)
+			}
+
+			var body map[string]json.RawMessage
+			if err := json.Unmarshal(data, &body); err != nil {
+				t.Fatalf("unmarshal request: %v", err)
+			}
+			if _, ok := body[otherField]; ok {
+				t.Fatalf("request contains both token fields: %s", data)
+			}
+
+			var got int
+			if err := json.Unmarshal(body[tt.wantField], &got); err != nil {
+				t.Fatalf("unmarshal %s: %v; body: %s", tt.wantField, err, data)
+			}
+			if got != tokenLimit {
+				t.Errorf("%s = %d, want %d; body: %s", tt.wantField, got, tokenLimit, data)
+			}
+		})
+	}
+}
+
+func TestOpenAIRequest_RequestMaxTokensForGPT5Probe(t *testing.T) {
+	requestMaxTokens := 5
+	o := &OpenAI{config: &Config{Model: "gpt-5-mini"}}
+	data, err := json.Marshal(o.convertRequest(&GenerateRequest{MaxTokens: &requestMaxTokens}))
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	var body map[string]json.RawMessage
+	if err := json.Unmarshal(data, &body); err != nil {
+		t.Fatalf("unmarshal request: %v", err)
+	}
+	if _, ok := body["max_tokens"]; ok {
+		t.Fatalf("request unexpectedly contains max_tokens: %s", data)
+	}
+
+	var got int
+	if err := json.Unmarshal(body["max_completion_tokens"], &got); err != nil {
+		t.Fatalf("unmarshal max_completion_tokens: %v; body: %s", err, data)
+	}
+	if got != requestMaxTokens {
+		t.Errorf("max_completion_tokens = %d, want %d; body: %s", got, requestMaxTokens, data)
 	}
 }

--- a/aiagent/llm/openai_test.go
+++ b/aiagent/llm/openai_test.go
@@ -328,16 +328,39 @@ func TestSwapToMaxCompletionTokens(t *testing.T) {
 		t.Fatal("unrelated error must leave request untouched")
 	}
 
-	// 用户在 CustomParams 里手填的 max_tokens 同样会触发 400，兜底要一并摘掉
-	viaExtra := &openAIRequest{extraBody: map[string]any{"max_tokens": 456, "enable_thinking": false}}
+	// 用户在 CustomParams 里手填的 max_tokens 同样会触发 400，兜底要一并摘掉；
+	// 值必须迁到新字段，只删不迁会让重试请求彻底没有输出上限。CustomParams 走 JSON
+	// 反序列化，数值落地是 float64。
+	viaExtra := &openAIRequest{extraBody: map[string]any{"max_tokens": float64(456), "enable_thinking": false}}
 	if !swapToMaxCompletionTokens(viaExtra, err400) {
 		t.Fatal("expected swap to strip max_tokens from extra body")
 	}
 	if _, ok := viaExtra.extraBody["max_tokens"]; ok {
 		t.Fatal("extra body max_tokens must be removed")
 	}
+	if viaExtra.MaxCompletionTokens != 456 {
+		t.Fatalf("extra body max_tokens should move to max_completion_tokens, got %d", viaExtra.MaxCompletionTokens)
+	}
 	if _, ok := viaExtra.extraBody["enable_thinking"]; !ok {
 		t.Fatal("unrelated extra body keys must survive")
+	}
+
+	// 显式字段优先：两边都有时不能让 extraBody 的值盖掉配置里的上限
+	both := &openAIRequest{MaxTokens: 100, extraBody: map[string]any{"max_tokens": float64(456)}}
+	if !swapToMaxCompletionTokens(both, err400) {
+		t.Fatal("expected swap to trigger")
+	}
+	if both.MaxCompletionTokens != 100 {
+		t.Fatalf("explicit field must win, got %d", both.MaxCompletionTokens)
+	}
+
+	// 非数值 / 非正数的 max_tokens 只删不迁，不能被 int() 转成 0 之外的怪值
+	garbage := &openAIRequest{extraBody: map[string]any{"max_tokens": "lots"}}
+	if !swapToMaxCompletionTokens(garbage, err400) {
+		t.Fatal("expected swap to strip an unparsable max_tokens")
+	}
+	if garbage.MaxCompletionTokens != 0 {
+		t.Fatalf("unparsable max_tokens must not be migrated, got %d", garbage.MaxCompletionTokens)
 	}
 }
 

--- a/aiagent/llm/thinking.go
+++ b/aiagent/llm/thinking.go
@@ -4,9 +4,9 @@ import "strings"
 
 // NormalizeThinkingParams 在 extra 上叠加"关闭深度思考"的厂商特定字段，返回新 map。
 //
-// 当前仅用于连接测试 probe 路径（aiagent/llmconfig）：探测请求 MaxTokens=5，
-// 思考模型会把 token 全烧在 reasoning 上导致 content 为空、误报失败，所以探测前
-// 按 BaseURL > Provider > Model 三层路由自动注入"关思考"字段。chat 路径不再注入
+// 当前仅用于连接测试 probe 路径（aiagent/llmconfig）：探测只发一句 "Hi"，让思考模型
+// 把 token 全烧在 reasoning 上既慢又容易 content 为空，所以探测前按
+// BaseURL > Provider > Model 三层路由自动注入"关思考"字段。chat 路径不再注入
 // ——思考是一等公民（思考流接入 thinking 通道），想关思考的用户在 CustomParams
 // 里显式配置。
 //

--- a/aiagent/llmconfig/probe.go
+++ b/aiagent/llmconfig/probe.go
@@ -69,7 +69,12 @@ func Test(p *models.AILLMConfig) error {
 	ctx, cancel := context.WithTimeout(context.Background(), ProbeTimeout(p.ExtraConfig))
 	defer cancel()
 
-	maxTokens := 5
+	// 统一给足预算：推理/思考模型（o1 系列、gpt-5、deepseek-r1、gemini-2.5-pro 等）会先把
+	// token 花在思考上，预算过小会让 content 为空而误报「无内容」——尤其 o1 系列在
+	// isPureThinkingModel 里被判定为「思考关不掉」，连 reasoning_effort 都注入不了。
+	// 普通模型对 "Hi" 会 finish_reason=stop 提前收尾，抬高上限并不增加实际消耗，
+	// 故不按模型名分档、不再多维护一张表。
+	maxTokens := 512
 	resp, err := client.Generate(ctx, &llm.GenerateRequest{
 		Messages:  []llm.Message{{Role: llm.RoleUser, Content: "Hi"}},
 		MaxTokens: &maxTokens,

--- a/aiagent/llmconfig/probe.go
+++ b/aiagent/llmconfig/probe.go
@@ -70,10 +70,9 @@ func Test(p *models.AILLMConfig) error {
 	defer cancel()
 
 	// 统一给足预算：推理/思考模型（o1 系列、gpt-5、deepseek-r1、gemini-2.5-pro 等）会先把
-	// token 花在思考上，预算过小会让 content 为空而误报「无内容」——尤其 o1 系列在
-	// isPureThinkingModel 里被判定为「思考关不掉」，连 reasoning_effort 都注入不了。
-	// 普通模型对 "Hi" 会 finish_reason=stop 提前收尾，抬高上限并不增加实际消耗，
-	// 故不按模型名分档、不再多维护一张表。
+	// token 花在思考上，预算过小会让 content 为空而误报「无内容」。普通模型对 "Hi" 会
+	// finish_reason=stop 提前收尾，抬高上限并不增加实际消耗，故不按模型名分档、不再多
+	// 维护一张表。512 仍可能被推理模型烧光，那种情况由下面的截断判定兜底。
 	maxTokens := 512
 	resp, err := client.Generate(ctx, &llm.GenerateRequest{
 		Messages:  []llm.Message{{Role: llm.RoleUser, Content: "Hi"}},
@@ -82,7 +81,16 @@ func Test(p *models.AILLMConfig) error {
 	if err != nil {
 		return classifyProbeError(p, err)
 	}
-	if resp == nil || (strings.TrimSpace(resp.Content) == "" && strings.TrimSpace(resp.ReasoningContent) == "") {
+	if resp == nil {
+		return &ProbeError{Kind: ProbeErrorNoContent, Model: p.Model}
+	}
+	// 预算被 reasoning 吃光时正文为空、finish_reason=length，但这轮请求本身是成功的
+	// ——端点、鉴权、模型都验证过了，探测目的已达成，不能判失败。o1 系列关不掉思考，
+	// Azure 自定义部署名下的 gpt-5 也命不中前缀、注入不了 reasoning_effort，都会走到这里。
+	if llm.ClassifyFinish(resp.FinishReason) == llm.FinishTruncated {
+		return nil
+	}
+	if strings.TrimSpace(resp.Content) == "" && strings.TrimSpace(resp.ReasoningContent) == "" {
 		return &ProbeError{Kind: ProbeErrorNoContent, Model: p.Model}
 	}
 	return nil

--- a/aiagent/llmconfig/probe_test.go
+++ b/aiagent/llmconfig/probe_test.go
@@ -1,10 +1,47 @@
 package llmconfig
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/ccfos/nightingale/v6/models"
 )
+
+// newProbeServer 起一个固定返回 body 的假上游，供连通性探测测试使用。
+func newProbeServer(t *testing.T, body string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestProbeTruncatedResponseIsSuccess：推理模型（o1 系列关不掉思考、Azure 自定义部署名
+// 下的 gpt-5 注入不了 reasoning_effort）会把探测预算全花在 reasoning 上，正文为空、
+// finish_reason=length。这轮请求本身是通的，探测不能报「无内容」。
+func TestProbeTruncatedResponseIsSuccess(t *testing.T) {
+	srv := newProbeServer(t, `{"choices":[{"message":{"role":"assistant","content":""},"finish_reason":"length"}]}`)
+
+	if err := Test(&models.AILLMConfig{APIType: "openai", APIURL: srv.URL, Model: "o1"}); err != nil {
+		t.Fatalf("truncated response should count as a successful probe, got %v", err)
+	}
+}
+
+// TestProbeEmptyContentWithoutTruncationFails：正常收尾却一个字都没有，仍然要报「无内容」。
+func TestProbeEmptyContentWithoutTruncationFails(t *testing.T) {
+	srv := newProbeServer(t, `{"choices":[{"message":{"role":"assistant","content":""},"finish_reason":"stop"}]}`)
+
+	err := Test(&models.AILLMConfig{APIType: "openai", APIURL: srv.URL, Model: "gpt-4o"})
+	probeErr, ok := err.(*ProbeError)
+	if !ok {
+		t.Fatalf("expected ProbeError, got %T (%v)", err, err)
+	}
+	if probeErr.Kind != ProbeErrorNoContent {
+		t.Fatalf("unexpected kind: %q", probeErr.Kind)
+	}
+}
 
 func TestParseProviderStatusError(t *testing.T) {
 	statusCode, raw, ok := parseProviderStatusError("OpenAI API error (status 404): not found")

--- a/doc/api/ai-llm-config.md
+++ b/doc/api/ai-llm-config.md
@@ -257,9 +257,11 @@ POST /api/n9e/ai-llm-config/test
 
 根据 `api_type` 向对应的 API 发送一个最小请求（"Hi"，最大输出 Token 数为 512）。
 
-Token 上限字段名按模型家族路由：OpenAI 兼容请求中，`gpt-5*`（含 gpt-5.1）、`o1`/`o3`/`o4` 系列使用 `max_completion_tokens`，其他模型使用 `max_tokens`。若模型名未命中（例如 Azure 自定义部署名），服务端返回 `Use 'max_completion_tokens' instead` 的 400 时会自动改名重试一次。
+Token 上限字段名按模型家族路由：OpenAI 兼容请求中，`gpt-5*`（含 gpt-5.1）、`o1`/`o3`/`o4` 系列使用 `max_completion_tokens`，其他模型使用 `max_tokens`。若模型名未命中（例如 Azure 自定义部署名），服务端返回 `Use 'max_completion_tokens' instead` 的 400 时会自动改名重试一次；此时 `custom_params` 里手填的 `max_tokens` 也会被一并迁移到 `max_completion_tokens`，用户配置的上限不会丢。
 
 之所以不用更小的值：推理模型会先把 token 花在思考上，预算过小会导致 `content` 为空而误报「无内容」；普通模型对 "Hi" 会提前结束，抬高上限并不增加实际消耗。
+
+若推理模型把 512 全部花在思考上（`finish_reason=length`、正文为空），仍判定为连接正常——端点、鉴权、模型都已经验证通过，探测目的已达成。只有正常收尾（`finish_reason=stop`）却没有任何内容时才报「无内容」。
 
 | api_type | 请求地址 | 认证方式 |
 |----------|---------|---------|

--- a/doc/api/ai-llm-config.md
+++ b/doc/api/ai-llm-config.md
@@ -255,7 +255,7 @@ POST /api/n9e/ai-llm-config/test
 
 ### 测试行为
 
-根据 `api_type` 向对应的 API 发送一个最小请求（"Hi"，max_tokens=5）：
+根据 `api_type` 向对应的 API 发送一个最小请求（"Hi"，最大输出 Token 数为 5）。OpenAI 兼容请求中，gpt-5、o1、o3 系列使用 `max_completion_tokens=5`，其他模型使用 `max_tokens=5`：
 
 | api_type | 请求地址 | 认证方式 |
 |----------|---------|---------|

--- a/doc/api/ai-llm-config.md
+++ b/doc/api/ai-llm-config.md
@@ -255,7 +255,11 @@ POST /api/n9e/ai-llm-config/test
 
 ### 测试行为
 
-根据 `api_type` 向对应的 API 发送一个最小请求（"Hi"，最大输出 Token 数为 5）。OpenAI 兼容请求中，gpt-5、o1、o3 系列使用 `max_completion_tokens=5`，其他模型使用 `max_tokens=5`：
+根据 `api_type` 向对应的 API 发送一个最小请求（"Hi"，最大输出 Token 数为 512）。
+
+Token 上限字段名按模型家族路由：OpenAI 兼容请求中，`gpt-5*`（含 gpt-5.1）、`o1`/`o3`/`o4` 系列使用 `max_completion_tokens`，其他模型使用 `max_tokens`。若模型名未命中（例如 Azure 自定义部署名），服务端返回 `Use 'max_completion_tokens' instead` 的 400 时会自动改名重试一次。
+
+之所以不用更小的值：推理模型会先把 token 花在思考上，预算过小会导致 `content` 为空而误报「无内容」；普通模型对 "Hi" 会提前结束，抬高上限并不增加实际消耗。
 
 | api_type | 请求地址 | 认证方式 |
 |----------|---------|---------|


### PR DESCRIPTION
## What type of PR is this?

Bug fix

## What this PR does / why we need it

修复 OpenAI 兼容模式下，部分新模型不支持 `max_tokens`，导致连接测试返回 400 的问题。

对于以下模型，改为发送 `max_completion_tokens`：

- `gpt-5` / `gpt-5-*`
- `o1` / `o1-*`
- `o3` / `o3-*`

其他 OpenAI 兼容模型继续使用 `max_tokens`。

同时保留内部统一的 `MaxTokens` 配置，只在 OpenAI 请求适配层转换参数，避免影响 Claude、Gemini 等其他 Provider。

## Changes

- 在 OpenAI 请求结构中增加 `max_completion_tokens`
- 根据模型名称选择 `max_tokens` 或 `max_completion_tokens`
- 避免 `ExtraBody` 注入冲突参数，确保两个 Token 参数不会同时发送
- 增加新旧模型匹配测试
- 增加连接测试请求 `MaxTokens=5` 的回归测试
- 更新 LLM 配置接口文档

## Which issue(s) this PR fixes

Fixes #3297

## Special notes for your reviewer

已通过：

- `go test ./aiagent/llm ./aiagent/llmconfig`
- `git diff --check`

另外尝试运行了 `go test ./aiagent/...`，其中无关模块存在本地环境相关的既有测试失败：

- `aiagent/skill` 中的远程提交缓存测试失败
- Windows 本地环境为 `CGO_ENABLED=0`，导致 `aiagent/tools` 中依赖 `go-sqlite3` 的测试无法运行

上述失败不涉及本次 OpenAI 请求参数修改。