### PR TITLE
feat: add v2 multi-datasource batch query API with KQL support

### DIFF
--- a/center/router/router.go
+++ b/center/router/router.go
@@ -274,6 +274,7 @@ func (rt *Router) Config(r *gin.Engine) {
 		pages.DELETE("/datasource/series", rt.auth(), rt.admin(), rt.deleteDatasourceSeries)
 		if rt.Center.AnonymousAccess.PromQuerier {
 			pages.Any("/proxy/:id/*url", rt.dsProxy)
+			pages.POST("/v2/query-batch", rt.queryBatchV2)
 			pages.POST("/query-range-batch", rt.promBatchQueryRange)
 			pages.POST("/query-instant-batch", rt.promBatchQueryInstant)
 			pages.GET("/datasource/brief", rt.datasourceBriefs)
@@ -311,6 +312,7 @@ func (rt *Router) Config(r *gin.Engine) {
 			pages.POST("/es-cluster-info", rt.ESClusterInfo)
 		} else {
 			pages.Any("/proxy/:id/*url", rt.auth(), rt.dsProxy)
+			pages.POST("/v2/query-batch", rt.auth(), rt.user(), rt.queryBatchV2)
 			pages.POST("/query-range-batch", rt.auth(), rt.promBatchQueryRange)
 			pages.POST("/query-instant-batch", rt.auth(), rt.promBatchQueryInstant)
 			pages.GET("/datasource/brief", rt.auth(), rt.user(), rt.datasourceBriefs)

--- a/center/router/router_query_batch_v2.go
+++ b/center/router/router_query_batch_v2.go
@@ -24,6 +24,7 @@ import (
 	n9eprom "github.com/ccfos/nightingale/v6/prom"
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/common/model"
+	"github.com/toolkits/pkg/logger"
 )
 
 // Keep per-request fan-out bounded: datasource clients may target the same
@@ -909,7 +910,10 @@ func queryBatchV2EvaluateMath(
 			input["$"+refID] = value
 		}
 		number, err := parser.MathCalc(expression, input)
-		if err == nil && queryBatchV2Finite(number) {
+		if err != nil {
+			return result, fmt.Errorf("expression evaluation failed: %s", err.Error())
+		}
+		if queryBatchV2Finite(number) {
 			result.Scalar = &number
 			result.Series = append(result.Series, QueryBatchV2Series{
 				Labels:  map[string]string{},
@@ -925,6 +929,12 @@ func queryBatchV2EvaluateMath(
 	}
 	sort.Strings(groupKeys)
 	evaluationPoints := 0
+	evaluationAttempts := 0
+	// A failure that depends on the sample values must not discard the points
+	// that did evaluate, so the error is only reported when nothing evaluated
+	// at all, which is what a broken expression such as an unknown function
+	// produces.
+	var evaluationError error
 	for _, groupKey := range groupKeys {
 		group := groups[groupKey]
 		timestamps := make(map[int64]struct{})
@@ -979,8 +989,15 @@ func queryBatchV2EvaluateMath(
 			if !matched {
 				continue
 			}
+			evaluationAttempts++
 			number, err := parser.MathCalc(expression, input)
-			if err != nil || !queryBatchV2Finite(number) {
+			if err != nil {
+				if evaluationError == nil {
+					evaluationError = err
+				}
+				continue
+			}
+			if !queryBatchV2Finite(number) {
 				continue
 			}
 			output.Samples = append(output.Samples, QueryBatchV2Sample{Timestamp: timestamp, Value: number})
@@ -988,6 +1005,30 @@ func queryBatchV2EvaluateMath(
 		if len(output.Samples) > 0 {
 			result.Series = append(result.Series, output)
 		}
+	}
+	// Empty or unjoinable series otherwise never reach MathCalc, allowing an
+	// invalid runtime expression (for example an unknown function) to look like
+	// a successful empty result. Probe once with the same float-shaped inputs
+	// used for series points; this is validation only and never creates a sample.
+	if evaluationAttempts == 0 {
+		input := make(map[string]interface{}, len(dependencies))
+		for _, dependency := range dependencies {
+			if scalar, ok := scalars[dependency]; ok {
+				input["$"+dependency] = scalar
+			} else {
+				input["$"+dependency] = float64(0)
+			}
+		}
+		if _, err := parser.MathCalc(expression, input); err != nil {
+			return result, fmt.Errorf("expression evaluation failed: %s", err.Error())
+		}
+	}
+	if evaluationError != nil {
+		if len(result.Series) == 0 {
+			return result, fmt.Errorf("expression evaluation failed: %s", evaluationError.Error())
+		}
+		logger.Warningf("query-batch-v2 expression %q skipped points that failed to evaluate: %v",
+			expression, evaluationError)
 	}
 	return result, nil
 }

--- a/center/router/router_query_batch_v2.go
+++ b/center/router/router_query_batch_v2.go
@@ -1,0 +1,993 @@
+package router
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"net"
+	"net/http"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ccfos/nightingale/v6/datasource"
+	"github.com/ccfos/nightingale/v6/dscache"
+	"github.com/ccfos/nightingale/v6/models"
+	"github.com/ccfos/nightingale/v6/pkg/ginx"
+	"github.com/ccfos/nightingale/v6/pkg/parser"
+	pkgprom "github.com/ccfos/nightingale/v6/pkg/prom"
+	n9eprom "github.com/ccfos/nightingale/v6/prom"
+	"github.com/gin-gonic/gin"
+	"github.com/prometheus/common/model"
+)
+
+// Keep per-request fan-out bounded: datasource clients may target the same
+// backend and each batch request can already contain many queries.
+const queryBatchV2Workers = 3
+
+const (
+	queryBatchV2MaxQueries          = 100
+	queryBatchV2MaxExpressionDepth  = 64
+	queryBatchV2MaxExpressionGroups = 10000
+	queryBatchV2MaxExpressionPoints = 50000
+)
+
+type queryBatchV2ExpressionLimitError struct {
+	message string
+}
+
+func (e *queryBatchV2ExpressionLimitError) Error() string {
+	return e.message
+}
+
+const (
+	queryKindDatasource = "query"
+	queryKindExpression = "expression"
+
+	resultTypeTimeSeries = "time_series"
+	resultTypeLogs       = "logs"
+
+	resultStatusSuccess = "success"
+	resultStatusError   = "error"
+	resultStatusSkipped = "skipped"
+)
+
+var (
+	queryBatchV2RefPattern = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_]*$`)
+)
+
+// QueryBatchV2Options lets an embedding product provide its datasource
+// permission implementation while reusing the common protocol.
+type QueryBatchV2Options struct {
+	CheckDsPerm func(*gin.Context, int64, string, interface{}) bool
+}
+
+type QueryBatchV2Request struct {
+	From    int64               `json:"from"`
+	To      int64               `json:"to"`
+	Queries []QueryBatchV2Query `json:"queries"`
+}
+
+type QueryBatchV2Query struct {
+	Kind       string                     `json:"kind"`
+	RefID      string                     `json:"ref_id"`
+	Datasource *QueryBatchV2DatasourceRef `json:"datasource,omitempty"`
+	ResultType string                     `json:"result_type,omitempty"`
+	Query      json.RawMessage            `json:"query,omitempty"`
+	Expression string                     `json:"expression,omitempty"`
+}
+
+type QueryBatchV2DatasourceRef struct {
+	Cate string `json:"cate"`
+	ID   int64  `json:"id"`
+}
+
+type QueryBatchV2Response struct {
+	Results []QueryBatchV2Result `json:"results"`
+}
+
+type QueryBatchV2Result struct {
+	RefID      string                `json:"ref_id"`
+	Status     string                `json:"status"`
+	ResultType string                `json:"result_type,omitempty"`
+	Series     *[]QueryBatchV2Series `json:"series,omitempty"`
+	Records    *[]QueryBatchV2Record `json:"records,omitempty"`
+	Error      *QueryBatchV2Error    `json:"error,omitempty"`
+}
+
+type QueryBatchV2Series struct {
+	Labels  map[string]string    `json:"labels"`
+	Samples []QueryBatchV2Sample `json:"samples"`
+}
+
+type QueryBatchV2Sample struct {
+	Timestamp int64
+	Value     float64
+}
+
+func (s QueryBatchV2Sample) MarshalJSON() ([]byte, error) {
+	return json.Marshal([2]interface{}{s.Timestamp, s.Value})
+}
+
+type QueryBatchV2Record struct {
+	Fields map[string]interface{} `json:"fields"`
+}
+
+type QueryBatchV2Error struct {
+	Code             string   `json:"code"`
+	Message          string   `json:"message"`
+	Retryable        bool     `json:"retryable"`
+	DependencyRefIDs []string `json:"dependency_ref_ids,omitempty"`
+}
+
+type queryBatchV2Value struct {
+	ResultType string
+	Series     []QueryBatchV2Series
+	Records    []QueryBatchV2Record
+	Scalar     *float64
+}
+
+type queryBatchV2Executor struct {
+	anonymousAccess bool
+	promClients     *n9eprom.PromClientMap
+	getDatasource   func(string, int64) (datasource.Datasource, bool)
+	checkDsPerm     func(*gin.Context, int64, string, interface{}) bool
+}
+
+type queryBatchV2CodedError struct {
+	code string
+	err  error
+}
+
+func (e *queryBatchV2CodedError) Error() string {
+	return e.err.Error()
+}
+
+func (e *queryBatchV2CodedError) Unwrap() error {
+	return e.err
+}
+
+func (rt *Router) queryBatchV2(c *gin.Context) {
+	QueryBatchV2(c, rt.Center.AnonymousAccess.PromQuerier, rt.PromClients, nil)
+}
+
+// QueryBatchV2 serves the common V2 batch-query protocol. It is exported so
+// n9e-plus can mount the same implementation under /api/n9e-plus/v2/query-batch.
+func QueryBatchV2(c *gin.Context, anonymousAccess bool, promClients *n9eprom.PromClientMap, options *QueryBatchV2Options) {
+	var req QueryBatchV2Request
+	ginx.BindJSON(c, &req)
+	if err := validateQueryBatchV2Request(req); err != nil {
+		ginx.Bomb(http.StatusBadRequest, "%v", err)
+	}
+
+	executor := queryBatchV2Executor{
+		anonymousAccess: anonymousAccess,
+		promClients:     promClients,
+		getDatasource:   dscache.DsCache.Get,
+		checkDsPerm:     CheckDsPerm,
+	}
+	if options != nil {
+		if options.CheckDsPerm != nil {
+			executor.checkDsPerm = options.CheckDsPerm
+		}
+	}
+	resp := executor.execute(c, req)
+	ginx.NewRender(c).Data(resp, nil)
+}
+
+func validateQueryBatchV2Request(req QueryBatchV2Request) error {
+	if req.To < req.From {
+		return fmt.Errorf("to must be greater than or equal to from")
+	}
+	if len(req.Queries) == 0 {
+		return fmt.Errorf("queries is empty")
+	}
+	if len(req.Queries) > queryBatchV2MaxQueries {
+		return fmt.Errorf("queries exceeds maximum count %d", queryBatchV2MaxQueries)
+	}
+
+	refs := make(map[string]struct{}, len(req.Queries))
+	for i, query := range req.Queries {
+		if !queryBatchV2RefPattern.MatchString(query.RefID) {
+			return fmt.Errorf("queries[%d].ref_id is invalid", i)
+		}
+		if _, exists := refs[query.RefID]; exists {
+			return fmt.Errorf("duplicate ref_id: %s", query.RefID)
+		}
+		refs[query.RefID] = struct{}{}
+
+		switch query.Kind {
+		case queryKindDatasource:
+			if query.Datasource == nil || strings.TrimSpace(query.Datasource.Cate) == "" || query.Datasource.ID <= 0 {
+				return fmt.Errorf("queries[%d].datasource is invalid", i)
+			}
+			if query.ResultType != resultTypeTimeSeries && query.ResultType != resultTypeLogs {
+				return fmt.Errorf("queries[%d].result_type is invalid", i)
+			}
+			if len(query.Query) == 0 || string(query.Query) == "null" {
+				return fmt.Errorf("queries[%d].query is required", i)
+			}
+			var payload map[string]interface{}
+			if err := json.Unmarshal(query.Query, &payload); err != nil || payload == nil {
+				return fmt.Errorf("queries[%d].query must be a JSON object", i)
+			}
+		case queryKindExpression:
+			if strings.TrimSpace(query.Expression) == "" {
+				return fmt.Errorf("queries[%d].expression is required", i)
+			}
+		default:
+			return fmt.Errorf("queries[%d].kind is invalid", i)
+		}
+	}
+	return nil
+}
+
+func (e queryBatchV2Executor) execute(c *gin.Context, req QueryBatchV2Request) QueryBatchV2Response {
+	results := make([]QueryBatchV2Result, len(req.Queries))
+	values := make(map[string]queryBatchV2Value, len(req.Queries))
+	queryValues := make([]queryBatchV2Value, len(req.Queries))
+	payloads := make([]map[string]interface{}, len(req.Queries))
+	runnable := make([]int, 0, len(req.Queries))
+	operator := ginUser(c)
+
+	// Permission checks stay serial because injected Plus permission hooks may
+	// inspect gin.Context and may themselves perform datasource metadata calls.
+	for i, query := range req.Queries {
+		if query.Kind != queryKindDatasource {
+			continue
+		}
+		payload, err := queryBatchV2Payload(req, query)
+		if err != nil {
+			results[i] = queryBatchV2FailureFromError(query.RefID, "INVALID_QUERY", err)
+			continue
+		}
+		payloads[i] = payload
+		if !e.anonymousAccess && !e.hasDatasourcePermission(c, query.Datasource.ID, query.Datasource.Cate, payload) {
+			results[i] = queryBatchV2Failed(query.RefID, resultStatusError, "FORBIDDEN",
+				"no permission for datasource", false, nil)
+			continue
+		}
+		runnable = append(runnable, i)
+	}
+
+	jobs := make(chan int)
+	var wg sync.WaitGroup
+	for worker := 0; worker < queryBatchV2Workers; worker++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := range jobs {
+				// Each index is dispatched once, so workers only write distinct
+				// results[i] and queryValues[i] slots.
+				query := req.Queries[i]
+				func() {
+					defer func() {
+						if recovered := recover(); recovered != nil {
+							results[i] = queryBatchV2Failed(query.RefID, resultStatusError, "DATASOURCE_ERROR",
+								fmt.Sprintf("query panic: %v", recovered), false, nil)
+						}
+					}()
+					if err := c.Request.Context().Err(); err != nil {
+						results[i] = queryBatchV2FailureFromError(query.RefID, "DATASOURCE_TIMEOUT", err)
+						return
+					}
+					value, result := e.executeDatasourceQuery(c.Request.Context(), operator, req, query, payloads[i])
+					results[i] = result
+					if result.Status == resultStatusSuccess {
+						queryValues[i] = value
+					}
+				}()
+			}
+		}()
+	}
+
+dispatch:
+	for position, i := range runnable {
+		if err := c.Request.Context().Err(); err != nil {
+			for _, remaining := range runnable[position:] {
+				results[remaining] = queryBatchV2FailureFromError(req.Queries[remaining].RefID, "DATASOURCE_TIMEOUT", err)
+			}
+			break
+		}
+		select {
+		case jobs <- i:
+		case <-c.Request.Context().Done():
+			err := c.Request.Context().Err()
+			for _, remaining := range runnable[position:] {
+				results[remaining] = queryBatchV2FailureFromError(req.Queries[remaining].RefID, "DATASOURCE_TIMEOUT", err)
+			}
+			break dispatch
+		}
+	}
+	close(jobs)
+	wg.Wait()
+
+	for _, i := range runnable {
+		if results[i].Status != resultStatusSuccess {
+			continue
+		}
+		values[req.Queries[i].RefID] = queryValues[i]
+	}
+
+	e.evaluateExpressions(req, results, values)
+	return QueryBatchV2Response{Results: results}
+}
+
+func (e queryBatchV2Executor) hasDatasourcePermission(c *gin.Context, id int64, cate string, query interface{}) bool {
+	checkDsPerm := e.checkDsPerm
+	if checkDsPerm == nil {
+		checkDsPerm = CheckDsPerm
+	}
+	return checkDsPerm(c, id, cate, query)
+}
+
+func (e queryBatchV2Executor) executeDatasourceQuery(
+	ctx context.Context,
+	operator string,
+	req QueryBatchV2Request,
+	query QueryBatchV2Query,
+	payload map[string]interface{},
+) (queryBatchV2Value, QueryBatchV2Result) {
+	queryCtx := withCallContext(ctx, query.Datasource.ID, operator)
+	if query.Datasource.Cate == "prometheus" {
+		if query.ResultType != resultTypeTimeSeries {
+			err := fmt.Errorf("prometheus does not support logs result_type")
+			return queryBatchV2Value{}, queryBatchV2FailureFromError(query.RefID, "INVALID_QUERY", err)
+		}
+		value, err := e.queryPrometheus(queryCtx, req, query)
+		if err != nil {
+			return queryBatchV2Value{}, queryBatchV2FailureFromError(query.RefID, queryBatchV2DatasourceErrorCode(err), err)
+		}
+		return value, queryBatchV2Success(query.RefID, value)
+	}
+
+	plug, exists := e.getDatasource(query.Datasource.Cate, query.Datasource.ID)
+	if !exists {
+		normalizedCate := strings.TrimSuffix(query.Datasource.Cate, ".logging")
+		if normalizedCate != query.Datasource.Cate {
+			plug, exists = e.getDatasource(normalizedCate, query.Datasource.ID)
+		}
+	}
+	if !exists {
+		err := fmt.Errorf("datasource %d not found", query.Datasource.ID)
+		return queryBatchV2Value{}, queryBatchV2Failed(query.RefID, resultStatusError,
+			"DATASOURCE_NOT_FOUND", err.Error(), false, nil)
+	}
+
+	if query.ResultType == resultTypeLogs {
+		items, _, err := plug.QueryLog(queryCtx, payload)
+		if err != nil {
+			return queryBatchV2Value{}, queryBatchV2FailureFromError(query.RefID, queryBatchV2DatasourceErrorCode(err), err)
+		}
+		records := queryBatchV2Records(query.Datasource.Cate, items)
+		value := queryBatchV2Value{ResultType: resultTypeLogs, Records: records}
+		return value, queryBatchV2Success(query.RefID, value)
+	}
+
+	items, err := plug.QueryData(queryCtx, payload)
+	if err != nil {
+		return queryBatchV2Value{}, queryBatchV2FailureFromError(query.RefID, queryBatchV2DatasourceErrorCode(err), err)
+	}
+	series := queryBatchV2DataRespSeries(items)
+	value := queryBatchV2Value{ResultType: resultTypeTimeSeries, Series: series}
+	return value, queryBatchV2Success(query.RefID, value)
+}
+
+type queryBatchV2PromQuery struct {
+	Expr    string `json:"expr"`
+	Instant bool   `json:"instant"`
+	Step    int64  `json:"step"`
+}
+
+func (e queryBatchV2Executor) queryPrometheus(
+	ctx context.Context,
+	req QueryBatchV2Request,
+	query QueryBatchV2Query,
+) (queryBatchV2Value, error) {
+	var config queryBatchV2PromQuery
+	if err := json.Unmarshal(query.Query, &config); err != nil {
+		return queryBatchV2Value{}, &queryBatchV2CodedError{
+			code: "INVALID_QUERY",
+			err:  fmt.Errorf("decode prometheus query: %w", err),
+		}
+	}
+	if strings.TrimSpace(config.Expr) == "" {
+		return queryBatchV2Value{}, &queryBatchV2CodedError{code: "INVALID_QUERY", err: fmt.Errorf("expr is required")}
+	}
+	if !config.Instant && config.Step <= 0 {
+		return queryBatchV2Value{}, &queryBatchV2CodedError{
+			code: "INVALID_QUERY",
+			err:  fmt.Errorf("step must be greater than zero"),
+		}
+	}
+	if e.promClients == nil {
+		return queryBatchV2Value{}, &queryBatchV2CodedError{
+			code: "DATASOURCE_NOT_FOUND",
+			err:  fmt.Errorf("prometheus datasource %d not found", query.Datasource.ID),
+		}
+	}
+	client := e.promClients.GetCli(query.Datasource.ID)
+	if client == nil {
+		return queryBatchV2Value{}, &queryBatchV2CodedError{
+			code: "DATASOURCE_NOT_FOUND",
+			err:  fmt.Errorf("prometheus datasource %d not found", query.Datasource.ID),
+		}
+	}
+
+	var value model.Value
+	var err error
+	if config.Instant {
+		value, _, err = client.Query(ctx, config.Expr, time.Unix(req.To, 0))
+	} else {
+		value, _, err = client.QueryRange(ctx, config.Expr, pkgprom.Range{
+			Start: time.Unix(req.From, 0),
+			End:   time.Unix(req.To, 0),
+			Step:  time.Duration(config.Step) * time.Second,
+		})
+	}
+	if err != nil {
+		return queryBatchV2Value{}, err
+	}
+	return queryBatchV2PromValue(value, req.To), nil
+}
+
+func queryBatchV2PromValue(value model.Value, scalarTimestamp int64) queryBatchV2Value {
+	result := queryBatchV2Value{ResultType: resultTypeTimeSeries, Series: make([]QueryBatchV2Series, 0)}
+	if value == nil {
+		return result
+	}
+	switch value.Type() {
+	case model.ValScalar:
+		scalar, ok := value.(*model.Scalar)
+		if !ok || !queryBatchV2Finite(float64(scalar.Value)) {
+			return result
+		}
+		number := float64(scalar.Value)
+		result.Scalar = &number
+		result.Series = append(result.Series, QueryBatchV2Series{
+			Labels:  map[string]string{},
+			Samples: []QueryBatchV2Sample{{Timestamp: scalarTimestamp, Value: number}},
+		})
+	case model.ValVector:
+		vector, ok := value.(model.Vector)
+		if !ok {
+			return result
+		}
+		for _, sample := range vector {
+			if !queryBatchV2Finite(float64(sample.Value)) {
+				continue
+			}
+			number := float64(sample.Value)
+			result.Series = append(result.Series, QueryBatchV2Series{
+				Labels:  queryBatchV2MetricLabels(sample.Metric),
+				Samples: []QueryBatchV2Sample{{Timestamp: sample.Timestamp.Unix(), Value: number}},
+			})
+		}
+	case model.ValMatrix:
+		matrix, ok := value.(model.Matrix)
+		if !ok {
+			return result
+		}
+		for _, stream := range matrix {
+			series := QueryBatchV2Series{Labels: queryBatchV2MetricLabels(stream.Metric), Samples: make([]QueryBatchV2Sample, 0, len(stream.Values))}
+			for _, pair := range stream.Values {
+				if !queryBatchV2Finite(float64(pair.Value)) {
+					continue
+				}
+				number := float64(pair.Value)
+				series.Samples = append(series.Samples, QueryBatchV2Sample{Timestamp: pair.Timestamp.Unix(), Value: number})
+			}
+			result.Series = append(result.Series, series)
+		}
+	}
+	queryBatchV2SortSeries(result.Series)
+	return result
+}
+
+func queryBatchV2Payload(req QueryBatchV2Request, query QueryBatchV2Query) (map[string]interface{}, error) {
+	var payload map[string]interface{}
+	if err := json.Unmarshal(query.Query, &payload); err != nil {
+		return nil, err
+	}
+	if query.Datasource.Cate == "prometheus" {
+		// Plus applies datasource-level permission to Prometheus and does not
+		// inspect query fields, so keep its permission payload identical to the
+		// client request instead of injecting adapter-only fields.
+		return payload, nil
+	}
+	payload["ref"] = query.RefID
+	queryBatchV2SetTimeRange(payload, query.Datasource.Cate, req.From, req.To)
+	return payload, nil
+}
+
+func queryBatchV2SetTimeRange(payload map[string]interface{}, cate string, from, to int64) {
+	switch strings.TrimSuffix(cate, ".logging") {
+	case "elasticsearch", "opensearch", "loki", "victorialogs", "zabbix":
+		payload["start"] = from
+		payload["end"] = to
+	case "tdengine":
+		payload["from"] = time.Unix(from, 0).UTC().Format(time.RFC3339)
+		payload["to"] = time.Unix(to, 0).UTC().Format(time.RFC3339)
+	default:
+		payload["from"] = from
+		payload["to"] = to
+	}
+}
+
+func queryBatchV2DataRespSeries(items []models.DataResp) []QueryBatchV2Series {
+	series := make([]QueryBatchV2Series, 0, len(items))
+	for _, item := range items {
+		output := QueryBatchV2Series{
+			Labels:  queryBatchV2MetricLabels(item.Metric),
+			Samples: make([]QueryBatchV2Sample, 0, len(item.Values)),
+		}
+		for _, pair := range item.Values {
+			if len(pair) != 2 || !queryBatchV2Finite(pair[1]) {
+				continue
+			}
+			number := pair[1]
+			output.Samples = append(output.Samples, QueryBatchV2Sample{Timestamp: int64(pair[0]), Value: number})
+		}
+		series = append(series, output)
+	}
+	queryBatchV2SortSeries(series)
+	return series
+}
+
+func queryBatchV2MetricLabels(metric model.Metric) map[string]string {
+	labels := make(map[string]string, len(metric))
+	for key, value := range metric {
+		labels[string(key)] = string(value)
+	}
+	return labels
+}
+
+func queryBatchV2Records(cate string, items []interface{}) []QueryBatchV2Record {
+	records := make([]QueryBatchV2Record, 0, len(items))
+	for _, item := range items {
+		fields, ok := item.(map[string]interface{})
+		if !ok {
+			encoded, err := json.Marshal(item)
+			if err == nil {
+				_ = json.Unmarshal(encoded, &fields)
+			}
+		}
+		if fields == nil {
+			fields = map[string]interface{}{"value": item}
+		}
+		// Elasticsearch QueryLog returns SearchHit objects. V2 ES records expose
+		// only the source document; ES metadata (_id, _index and sort) remains
+		// available on the legacy logs-query endpoint used for pagination.
+		if queryBatchV2IsElasticsearchCate(cate) {
+			source, _ := fields["_source"].(map[string]interface{})
+			if source == nil {
+				source = map[string]interface{}{}
+			}
+			fields = source
+		}
+		records = append(records, QueryBatchV2Record{Fields: fields})
+	}
+	return records
+}
+
+func queryBatchV2IsElasticsearchCate(cate string) bool {
+	switch strings.TrimSuffix(cate, ".logging") {
+	case "elasticsearch", "opensearch":
+		return true
+	default:
+		return false
+	}
+}
+
+func queryBatchV2Success(refID string, value queryBatchV2Value) QueryBatchV2Result {
+	result := QueryBatchV2Result{RefID: refID, Status: resultStatusSuccess, ResultType: value.ResultType}
+	if value.ResultType == resultTypeLogs {
+		records := value.Records
+		if records == nil {
+			records = make([]QueryBatchV2Record, 0)
+		}
+		result.Records = &records
+	} else {
+		series := value.Series
+		if series == nil {
+			series = make([]QueryBatchV2Series, 0)
+		}
+		result.Series = &series
+	}
+	return result
+}
+
+func queryBatchV2Failed(refID, status, code, message string, retryable bool, dependencies []string) QueryBatchV2Result {
+	return QueryBatchV2Result{
+		RefID:  refID,
+		Status: status,
+		Error: &QueryBatchV2Error{
+			Code:             code,
+			Message:          message,
+			Retryable:        retryable,
+			DependencyRefIDs: dependencies,
+		},
+	}
+}
+
+func queryBatchV2FailureFromError(refID, code string, err error) QueryBatchV2Result {
+	return queryBatchV2Failed(refID, resultStatusError, code, err.Error(), queryBatchV2Retryable(err), nil)
+}
+
+func queryBatchV2DatasourceErrorCode(err error) string {
+	var coded *queryBatchV2CodedError
+	if errors.As(err, &coded) {
+		return coded.code
+	}
+	if queryBatchV2Retryable(err) {
+		return "DATASOURCE_TIMEOUT"
+	}
+	return "DATASOURCE_ERROR"
+}
+
+func queryBatchV2Retryable(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return true
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
+}
+
+func queryBatchV2Finite(value float64) bool {
+	return !math.IsNaN(value) && !math.IsInf(value, 0)
+}
+
+func queryBatchV2SortSeries(series []QueryBatchV2Series) {
+	sort.SliceStable(series, func(i, j int) bool {
+		return queryBatchV2LabelKey(series[i].Labels, false) < queryBatchV2LabelKey(series[j].Labels, false)
+	})
+}
+
+func queryBatchV2LabelKey(labels map[string]string, ignoreMetricName bool) string {
+	keys := make([]string, 0, len(labels))
+	for key := range labels {
+		if ignoreMetricName && key == string(model.MetricNameLabel) {
+			continue
+		}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	var builder strings.Builder
+	for _, key := range keys {
+		builder.WriteString(strconv.Itoa(len(key)))
+		builder.WriteByte(':')
+		builder.WriteString(key)
+		builder.WriteByte(':')
+		builder.WriteString(strconv.Itoa(len(labels[key])))
+		builder.WriteByte(':')
+		builder.WriteString(labels[key])
+		builder.WriteByte(';')
+	}
+	return builder.String()
+}
+
+func queryBatchV2Dependencies(expression string) []string {
+	seen := make(map[string]struct{})
+	dependencies := make([]string, 0)
+	var quote rune
+	escaped := false
+	runes := []rune(expression)
+	for i := 0; i < len(runes); i++ {
+		current := runes[i]
+		if quote != 0 {
+			if escaped {
+				escaped = false
+				continue
+			}
+			if current == '\\' {
+				escaped = true
+				continue
+			}
+			if current == quote {
+				quote = 0
+			}
+			continue
+		}
+		if current == '\'' || current == '"' {
+			quote = current
+			continue
+		}
+		if current != '$' || i+1 >= len(runes) || !queryBatchV2IsRefStart(runes[i+1]) {
+			continue
+		}
+		start := i + 1
+		i = start
+		for i+1 < len(runes) && queryBatchV2IsRefPart(runes[i+1]) {
+			i++
+		}
+		refID := string(runes[start : i+1])
+		if _, ok := seen[refID]; ok {
+			continue
+		}
+		seen[refID] = struct{}{}
+		dependencies = append(dependencies, refID)
+	}
+	return dependencies
+}
+
+func queryBatchV2IsRefStart(value rune) bool {
+	return value >= 'A' && value <= 'Z' || value >= 'a' && value <= 'z'
+}
+
+func queryBatchV2IsRefPart(value rune) bool {
+	return queryBatchV2IsRefStart(value) || value >= '0' && value <= '9' || value == '_'
+}
+
+func (e queryBatchV2Executor) evaluateExpressions(
+	req QueryBatchV2Request,
+	results []QueryBatchV2Result,
+	values map[string]queryBatchV2Value,
+) {
+	indexByRef := make(map[string]int, len(req.Queries))
+	expressions := make(map[string]QueryBatchV2Query)
+	for i, query := range req.Queries {
+		indexByRef[query.RefID] = i
+		if query.Kind == queryKindExpression {
+			expressions[query.RefID] = query
+		}
+	}
+	cycles := queryBatchV2ExpressionCycles(expressions)
+	state := make(map[string]uint8, len(expressions))
+
+	var evaluate func(string, int)
+	evaluate = func(refID string, depth int) {
+		if state[refID] == 2 {
+			return
+		}
+		if state[refID] == 1 {
+			return
+		}
+		query := expressions[refID]
+		resultIndex := indexByRef[refID]
+		if depth > queryBatchV2MaxExpressionDepth {
+			results[resultIndex] = queryBatchV2Failed(refID, resultStatusError, "EXPRESSION_DEPTH_EXCEEDED",
+				fmt.Sprintf("expression dependency depth exceeds maximum %d", queryBatchV2MaxExpressionDepth), false, nil)
+			state[refID] = 2
+			return
+		}
+		state[refID] = 1
+		if cycles[refID] {
+			results[resultIndex] = queryBatchV2Failed(refID, resultStatusError, "DEPENDENCY_CYCLE",
+				"expression has a circular dependency", false, nil)
+			state[refID] = 2
+			return
+		}
+
+		dependencies := queryBatchV2Dependencies(query.Expression)
+		if err := parser.ValidateExp(query.Expression); err != nil {
+			results[resultIndex] = queryBatchV2Failed(refID, resultStatusError, "EXPRESSION_INVALID",
+				err.Error(), false, nil)
+			state[refID] = 2
+			return
+		}
+
+		failedDependencies := make([]string, 0)
+		for _, dependency := range dependencies {
+			dependencyIndex, exists := indexByRef[dependency]
+			if !exists {
+				results[resultIndex] = queryBatchV2Failed(refID, resultStatusError, "DEPENDENCY_NOT_FOUND",
+					fmt.Sprintf("expression dependency %s was not found", dependency), false, []string{dependency})
+				state[refID] = 2
+				return
+			}
+			if _, isExpression := expressions[dependency]; isExpression {
+				evaluate(dependency, depth+1)
+			}
+			dependencyResult := results[dependencyIndex]
+			if dependencyResult.Status != resultStatusSuccess {
+				failedDependencies = append(failedDependencies, dependency)
+				continue
+			}
+			if dependencyResult.ResultType == resultTypeLogs {
+				results[resultIndex] = queryBatchV2Failed(refID, resultStatusError, "DEPENDENCY_TYPE_MISMATCH",
+					fmt.Sprintf("expression dependency %s is logs", dependency), false, []string{dependency})
+				state[refID] = 2
+				return
+			}
+		}
+		if len(failedDependencies) > 0 {
+			retryable := false
+			for _, dependency := range failedDependencies {
+				dependencyResult := results[indexByRef[dependency]]
+				retryable = retryable || (dependencyResult.Error != nil && dependencyResult.Error.Retryable)
+			}
+			results[resultIndex] = queryBatchV2Failed(refID, resultStatusSkipped, "DEPENDENCY_FAILED",
+				"one or more expression dependencies failed", retryable, failedDependencies)
+			state[refID] = 2
+			return
+		}
+
+		value, err := queryBatchV2EvaluateMath(query.Expression, dependencies, values, req.To)
+		if err != nil {
+			code := "EXPRESSION_EVALUATION_ERROR"
+			var limitErr *queryBatchV2ExpressionLimitError
+			if errors.As(err, &limitErr) {
+				code = "EXPRESSION_LIMIT_EXCEEDED"
+			}
+			results[resultIndex] = queryBatchV2Failed(refID, resultStatusError, code, err.Error(), false, dependencies)
+			state[refID] = 2
+			return
+		}
+		values[refID] = value
+		results[resultIndex] = queryBatchV2Success(refID, value)
+		state[refID] = 2
+	}
+
+	for _, query := range req.Queries {
+		if query.Kind == queryKindExpression {
+			evaluate(query.RefID, 1)
+		}
+	}
+}
+
+func queryBatchV2ExpressionCycles(expressions map[string]QueryBatchV2Query) map[string]bool {
+	color := make(map[string]uint8, len(expressions))
+	stack := make([]string, 0, len(expressions))
+	stackIndex := make(map[string]int, len(expressions))
+	cycles := make(map[string]bool)
+	var visit func(string)
+	visit = func(refID string) {
+		if color[refID] == 2 {
+			return
+		}
+		if color[refID] == 1 {
+			for i := stackIndex[refID]; i < len(stack); i++ {
+				cycles[stack[i]] = true
+			}
+			return
+		}
+		color[refID] = 1
+		stackIndex[refID] = len(stack)
+		stack = append(stack, refID)
+		for _, dependency := range queryBatchV2Dependencies(expressions[refID].Expression) {
+			if _, ok := expressions[dependency]; ok {
+				visit(dependency)
+			}
+		}
+		stack = stack[:len(stack)-1]
+		delete(stackIndex, refID)
+		color[refID] = 2
+	}
+	for refID := range expressions {
+		visit(refID)
+	}
+	return cycles
+}
+
+func queryBatchV2EvaluateMath(
+	expression string,
+	dependencies []string,
+	values map[string]queryBatchV2Value,
+	scalarTimestamp int64,
+) (queryBatchV2Value, error) {
+	result := queryBatchV2Value{ResultType: resultTypeTimeSeries, Series: make([]QueryBatchV2Series, 0)}
+	hasSeries := false
+	groups := make(map[string]map[string]QueryBatchV2Series)
+	groupLabels := make(map[string]map[string]string)
+	scalars := make(map[string]float64)
+
+	for _, dependency := range dependencies {
+		value := values[dependency]
+		if value.Scalar != nil {
+			scalars[dependency] = *value.Scalar
+			continue
+		}
+		hasSeries = true
+		for _, series := range value.Series {
+			key := queryBatchV2LabelKey(series.Labels, true)
+			if groups[key] == nil {
+				if len(groups) >= queryBatchV2MaxExpressionGroups {
+					return result, &queryBatchV2ExpressionLimitError{message: fmt.Sprintf(
+						"expression exceeds maximum group count %d", queryBatchV2MaxExpressionGroups)}
+				}
+				groups[key] = make(map[string]QueryBatchV2Series)
+				labels := make(map[string]string, len(series.Labels))
+				for label, labelValue := range series.Labels {
+					if label != string(model.MetricNameLabel) {
+						labels[label] = labelValue
+					}
+				}
+				groupLabels[key] = labels
+			}
+			groups[key][dependency] = series
+		}
+	}
+
+	if !hasSeries {
+		input := make(map[string]interface{}, len(scalars))
+		for refID, value := range scalars {
+			input["$"+refID] = value
+		}
+		number, err := parser.MathCalc(expression, input)
+		if err == nil && queryBatchV2Finite(number) {
+			result.Scalar = &number
+			result.Series = append(result.Series, QueryBatchV2Series{
+				Labels:  map[string]string{},
+				Samples: []QueryBatchV2Sample{{Timestamp: scalarTimestamp, Value: number}},
+			})
+		}
+		return result, nil
+	}
+
+	groupKeys := make([]string, 0, len(groups))
+	for key := range groups {
+		groupKeys = append(groupKeys, key)
+	}
+	sort.Strings(groupKeys)
+	evaluationPoints := 0
+	for _, groupKey := range groupKeys {
+		group := groups[groupKey]
+		timestamps := make(map[int64]struct{})
+		sampleValues := make(map[string]map[int64]float64)
+		complete := true
+		for _, dependency := range dependencies {
+			if _, scalar := scalars[dependency]; scalar {
+				continue
+			}
+			series, exists := group[dependency]
+			if !exists {
+				complete = false
+				break
+			}
+			byTimestamp := make(map[int64]float64, len(series.Samples))
+			for _, sample := range series.Samples {
+				byTimestamp[sample.Timestamp] = sample.Value
+				timestamps[sample.Timestamp] = struct{}{}
+			}
+			sampleValues[dependency] = byTimestamp
+		}
+		if !complete {
+			continue
+		}
+		if len(timestamps) > queryBatchV2MaxExpressionPoints-evaluationPoints {
+			return result, &queryBatchV2ExpressionLimitError{message: fmt.Sprintf(
+				"expression exceeds maximum evaluation point count %d", queryBatchV2MaxExpressionPoints)}
+		}
+		evaluationPoints += len(timestamps)
+
+		sortedTimestamps := make([]int64, 0, len(timestamps))
+		for timestamp := range timestamps {
+			sortedTimestamps = append(sortedTimestamps, timestamp)
+		}
+		sort.Slice(sortedTimestamps, func(i, j int) bool { return sortedTimestamps[i] < sortedTimestamps[j] })
+		output := QueryBatchV2Series{Labels: groupLabels[groupKey], Samples: make([]QueryBatchV2Sample, 0, len(sortedTimestamps))}
+		for _, timestamp := range sortedTimestamps {
+			input := make(map[string]interface{}, len(dependencies))
+			matched := true
+			for _, dependency := range dependencies {
+				if scalar, ok := scalars[dependency]; ok {
+					input["$"+dependency] = scalar
+					continue
+				}
+				number, ok := sampleValues[dependency][timestamp]
+				if !ok {
+					matched = false
+					break
+				}
+				input["$"+dependency] = number
+			}
+			if !matched {
+				continue
+			}
+			number, err := parser.MathCalc(expression, input)
+			if err != nil || !queryBatchV2Finite(number) {
+				continue
+			}
+			output.Samples = append(output.Samples, QueryBatchV2Sample{Timestamp: timestamp, Value: number})
+		}
+		if len(output.Samples) > 0 {
+			result.Series = append(result.Series, output)
+		}
+	}
+	return result, nil
+}

--- a/center/router/router_query_batch_v2_test.go
+++ b/center/router/router_query_batch_v2_test.go
@@ -1,0 +1,652 @@
+package router
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ccfos/nightingale/v6/datasource"
+	esdatasource "github.com/ccfos/nightingale/v6/datasource/es"
+	"github.com/ccfos/nightingale/v6/dscache"
+	"github.com/ccfos/nightingale/v6/models"
+	"github.com/gin-gonic/gin"
+	"github.com/prometheus/common/model"
+)
+
+func TestQueryBatchV2HTTPEndpoint(t *testing.T) {
+	const datasourceID = int64(987654321)
+	dscache.DsCache.Put("iotdb", datasourceID, &queryBatchV2FakeDatasource{})
+	t.Cleanup(func() { dscache.DsCache.Delete("iotdb", datasourceID) })
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	engine.POST("/api/n9e/v2/query-batch", func(c *gin.Context) {
+		QueryBatchV2(c, true, nil, nil)
+	})
+	body := []byte(`{"from":100,"to":200,"queries":[{"kind":"query","ref_id":"LOGS","datasource":{"cate":"iotdb","id":987654321},"result_type":"logs","query":{"sql":"select 1"}}]}`)
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/api/n9e/v2/query-batch", bytes.NewReader(body))
+	request.Header.Set("Content-Type", "application/json")
+	engine.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+
+	var response struct {
+		Err string               `json:"err"`
+		Dat QueryBatchV2Response `json:"dat"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	if response.Err != "" || len(response.Dat.Results) != 1 {
+		t.Fatalf("response = %s", recorder.Body.String())
+	}
+	result := response.Dat.Results[0]
+	if result.Status != resultStatusSuccess || result.Records == nil || len(*result.Records) != 1 || (*result.Records)[0].Fields["message"] != "ok" {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+// This exercises the public V2 HTTP endpoint, the Elasticsearch adapter and
+// the generated Query DSL against an HTTP Elasticsearch double. It guards the
+// contract that KQL is not sent to query_string and that only _source reaches
+// records[].fields.
+func TestQueryBatchV2ElasticsearchKQLEndToEnd(t *testing.T) {
+	var receivedQuery map[string]interface{}
+	esServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || !strings.HasSuffix(r.URL.Path, "/_search") {
+			http.NotFound(w, r)
+			return
+		}
+		var request map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Errorf("decode ES request: %v", err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		receivedQuery, _ = request["query"].(map[string]interface{})
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"hits":{"total":{"value":1,"relation":"eq"},"hits":[{"_id":"doc-1","_index":"logs-2026","_source":{"message":"timeout error","level":"ERROR"},"sort":[123]}]}}`))
+	}))
+	defer esServer.Close()
+
+	const datasourceID = int64(987654322)
+	dscache.DsCache.Put("elasticsearch", datasourceID, &esdatasource.Elasticsearch{
+		Nodes:   []string{esServer.URL},
+		Timeout: 1000,
+		Version: "7.10+",
+	})
+	t.Cleanup(func() { dscache.DsCache.Delete("elasticsearch", datasourceID) })
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	engine.POST("/api/n9e/v2/query-batch", func(c *gin.Context) {
+		QueryBatchV2(c, true, nil, nil)
+	})
+	body := []byte(`{"from":1710000000,"to":1710003600,"queries":[{"kind":"query","ref_id":"ES","datasource":{"cate":"elasticsearch","id":987654322},"result_type":"logs","query":{"index_type":"index","index":"logs-*","date_field":"@timestamp","limit":10,"filter_language":"kql","filter":"message: *timeout*"}}]}`)
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/api/n9e/v2/query-batch", bytes.NewReader(body))
+	request.Header.Set("Content-Type", "application/json")
+	engine.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+
+	var response struct {
+		Dat QueryBatchV2Response `json:"dat"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	result := response.Dat.Results[0]
+	if result.Status != resultStatusSuccess || result.Records == nil || (*result.Records)[0].Fields["message"] != "timeout error" {
+		t.Fatalf("result = %#v, body = %s", result, recorder.Body.String())
+	}
+	filters := receivedQuery["bool"].(map[string]interface{})["filter"].([]interface{})
+	if len(filters) != 2 {
+		t.Fatalf("ES filters = %#v", filters)
+	}
+	wildcard := filters[1].(map[string]interface{})["wildcard"].(map[string]interface{})["message"].(map[string]interface{})
+	if wildcard["value"] != "*timeout*" {
+		t.Fatalf("KQL was not compiled to wildcard DSL: %#v", receivedQuery)
+	}
+}
+
+type queryBatchV2FakeDatasource struct {
+	current int32
+	max     int32
+	calls   int32
+}
+
+func (f *queryBatchV2FakeDatasource) Init(map[string]interface{}) (datasource.Datasource, error) {
+	return f, nil
+}
+
+func (f *queryBatchV2FakeDatasource) InitClient() error {
+	return nil
+}
+
+func (f *queryBatchV2FakeDatasource) Validate(context.Context) error {
+	return nil
+}
+
+func (f *queryBatchV2FakeDatasource) Equal(datasource.Datasource) bool {
+	return true
+}
+
+func (f *queryBatchV2FakeDatasource) MakeLogQuery(context.Context, interface{}, []string, int64, int64) (interface{}, error) {
+	return nil, nil
+}
+
+func (f *queryBatchV2FakeDatasource) MakeTSQuery(context.Context, interface{}, []string, int64, int64) (interface{}, error) {
+	return nil, nil
+}
+
+func (f *queryBatchV2FakeDatasource) QueryData(_ context.Context, query interface{}) ([]models.DataResp, error) {
+	atomic.AddInt32(&f.calls, 1)
+	current := atomic.AddInt32(&f.current, 1)
+	for {
+		max := atomic.LoadInt32(&f.max)
+		if current <= max || atomic.CompareAndSwapInt32(&f.max, max, current) {
+			break
+		}
+	}
+	time.Sleep(10 * time.Millisecond)
+	atomic.AddInt32(&f.current, -1)
+
+	payload := query.(map[string]interface{})
+	ref := payload["ref"].(string)
+	return []models.DataResp{{
+		Ref:    ref,
+		Metric: model.Metric{"host": "node-1"},
+		Values: [][]float64{{10, 2}},
+	}}, nil
+}
+
+func (f *queryBatchV2FakeDatasource) QueryLog(context.Context, interface{}) ([]interface{}, int64, error) {
+	return []interface{}{map[string]interface{}{"message": "ok"}}, 1, nil
+}
+
+func (f *queryBatchV2FakeDatasource) QueryMapData(context.Context, interface{}) ([]map[string]string, error) {
+	return nil, nil
+}
+
+func queryBatchV2Raw(value string) json.RawMessage {
+	return json.RawMessage(value)
+}
+
+func queryBatchV2Number(value float64) float64 {
+	return value
+}
+
+func TestValidateQueryBatchV2Request(t *testing.T) {
+	valid := QueryBatchV2Request{
+		From: 10,
+		To:   20,
+		Queries: []QueryBatchV2Query{{
+			Kind:       queryKindDatasource,
+			RefID:      "A_1",
+			Datasource: &QueryBatchV2DatasourceRef{Cate: "iotdb", ID: 1},
+			ResultType: resultTypeTimeSeries,
+			Query:      queryBatchV2Raw(`{"sql":"select 1"}`),
+		}},
+	}
+	if err := validateQueryBatchV2Request(valid); err != nil {
+		t.Fatalf("valid request rejected: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		edit func(*QueryBatchV2Request)
+	}{
+		{"invalid range", func(req *QueryBatchV2Request) { req.To = 9 }},
+		{"invalid ref", func(req *QueryBatchV2Request) { req.Queries[0].RefID = "A-B" }},
+		{"duplicate ref", func(req *QueryBatchV2Request) { req.Queries = append(req.Queries, req.Queries[0]) }},
+		{"invalid result type", func(req *QueryBatchV2Request) { req.Queries[0].ResultType = "table" }},
+		{"non-object query", func(req *QueryBatchV2Request) { req.Queries[0].Query = queryBatchV2Raw(`[]`) }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := valid
+			req.Queries = append([]QueryBatchV2Query(nil), valid.Queries...)
+			test.edit(&req)
+			if err := validateQueryBatchV2Request(req); err == nil {
+				t.Fatal("expected validation error")
+			}
+		})
+	}
+
+	tooMany := valid
+	tooMany.Queries = make([]QueryBatchV2Query, queryBatchV2MaxQueries+1)
+	if err := validateQueryBatchV2Request(tooMany); err == nil || !strings.Contains(err.Error(), "maximum count") {
+		t.Fatalf("query count error = %v", err)
+	}
+}
+
+func TestQueryBatchV2PayloadInjectsCanonicalRange(t *testing.T) {
+	req := QueryBatchV2Request{From: 1710000000, To: 1710003600}
+	tests := []struct {
+		cate     string
+		fromKey  string
+		toKey    string
+		fromWant interface{}
+		toWant   interface{}
+	}{
+		{"elasticsearch.logging", "start", "end", int64(1710000000), int64(1710003600)},
+		{"opensearch.logging", "start", "end", int64(1710000000), int64(1710003600)},
+		{"loki.logging", "start", "end", int64(1710000000), int64(1710003600)},
+		{"victorialogs.logging", "start", "end", int64(1710000000), int64(1710003600)},
+		{"zabbix", "start", "end", int64(1710000000), int64(1710003600)},
+		{"tdengine.logging", "from", "to", "2024-03-09T16:00:00Z", "2024-03-09T17:00:00Z"},
+		{"aliyun-sls.logging", "from", "to", int64(1710000000), int64(1710003600)},
+		{"tencent-cls.logging", "from", "to", int64(1710000000), int64(1710003600)},
+		{"cloudwatchlogs.logging", "from", "to", int64(1710000000), int64(1710003600)},
+		{"cloudwatch", "from", "to", int64(1710000000), int64(1710003600)},
+		{"gcm", "from", "to", int64(1710000000), int64(1710003600)},
+		{"mysql", "from", "to", int64(1710000000), int64(1710003600)},
+	}
+	for _, test := range tests {
+		t.Run(test.cate, func(t *testing.T) {
+			payload, err := queryBatchV2Payload(req, QueryBatchV2Query{
+				RefID:      "A",
+				Datasource: &QueryBatchV2DatasourceRef{Cate: test.cate, ID: 1},
+				Query:      queryBatchV2Raw(`{"from":"old","to":"old","start":1,"end":2}`),
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if payload["ref"] != "A" || payload[test.fromKey] != test.fromWant || payload[test.toKey] != test.toWant {
+				t.Fatalf("unexpected payload: %#v", payload)
+			}
+		})
+	}
+
+	promPayload, err := queryBatchV2Payload(req, QueryBatchV2Query{
+		RefID:      "PROM",
+		Datasource: &QueryBatchV2DatasourceRef{Cate: "prometheus", ID: 1},
+		Query:      queryBatchV2Raw(`{"expr":"up","instant":true}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, exists := promPayload["ref"]; exists {
+		t.Fatalf("Prometheus permission payload must remain unchanged: %#v", promPayload)
+	}
+}
+
+func TestQueryBatchV2ExecutorUsesRegisteredDatasourceOrderAndConcurrency(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(nil)
+	// Call the executor directly: the empty request body is intentional because
+	// only its context is used here; handler JSON binding is covered separately.
+	c.Request, _ = httpNewRequestWithContext(t.Context())
+
+	fake := &queryBatchV2FakeDatasource{}
+	executor := queryBatchV2Executor{
+		anonymousAccess: true,
+		getDatasource: func(cate string, id int64) (datasource.Datasource, bool) {
+			return fake, true
+		},
+	}
+	req := QueryBatchV2Request{From: 1, To: 10}
+	for i := 0; i < 6; i++ {
+		req.Queries = append(req.Queries, QueryBatchV2Query{
+			Kind:       queryKindDatasource,
+			RefID:      string(rune('A' + i)),
+			Datasource: &QueryBatchV2DatasourceRef{Cate: "iotdb", ID: int64(i + 1)},
+			ResultType: resultTypeTimeSeries,
+			Query:      queryBatchV2Raw(`{"sql":"select 1"}`),
+		})
+	}
+	req.Queries = append(req.Queries, QueryBatchV2Query{
+		Kind:       queryKindDatasource,
+		RefID:      "G",
+		Datasource: &QueryBatchV2DatasourceRef{Cate: "aliyun-sls", ID: 7},
+		ResultType: resultTypeTimeSeries,
+		Query:      queryBatchV2Raw(`{"sql":"select 1"}`),
+	})
+
+	resp := executor.execute(c, req)
+	if got := atomic.LoadInt32(&fake.max); got != queryBatchV2Workers {
+		t.Fatalf("max concurrency = %d, want %d", got, queryBatchV2Workers)
+	}
+	for i := 0; i < 6; i++ {
+		if resp.Results[i].RefID != req.Queries[i].RefID || resp.Results[i].Status != resultStatusSuccess {
+			t.Fatalf("result order/status mismatch at %d: %#v", i, resp.Results[i])
+		}
+	}
+	if result := resp.Results[6]; result.Status != resultStatusSuccess {
+		t.Fatalf("registered commercial datasource result = %#v", result)
+	}
+}
+
+func TestQueryBatchV2LoggingCateUsesNormalizedCacheKey(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(nil)
+	c.Request, _ = httpNewRequestWithContext(t.Context())
+
+	fake := &queryBatchV2FakeDatasource{}
+	executor := queryBatchV2Executor{
+		anonymousAccess: true,
+		getDatasource: func(cate string, id int64) (datasource.Datasource, bool) {
+			if cate == "aliyun-sls" && id == 9 {
+				return fake, true
+			}
+			return nil, false
+		},
+	}
+	req := QueryBatchV2Request{From: 1, To: 10, Queries: []QueryBatchV2Query{{
+		Kind:       queryKindDatasource,
+		RefID:      "SLS",
+		Datasource: &QueryBatchV2DatasourceRef{Cate: "aliyun-sls.logging", ID: 9},
+		ResultType: resultTypeLogs,
+		Query:      queryBatchV2Raw(`{"project":"p","logstore":"l"}`),
+	}}}
+
+	resp := executor.execute(c, req)
+	if resp.Results[0].Status != resultStatusSuccess {
+		t.Fatalf("logging cate result = %#v", resp.Results[0])
+	}
+}
+
+func TestQueryBatchV2CancellationStopsRemainingDispatch(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(nil)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	c.Request, _ = httpNewRequestWithContext(ctx)
+
+	fake := &queryBatchV2FakeDatasource{}
+	executor := queryBatchV2Executor{
+		anonymousAccess: true,
+		getDatasource: func(string, int64) (datasource.Datasource, bool) {
+			return fake, true
+		},
+	}
+	req := QueryBatchV2Request{From: 1, To: 10}
+	for i := 0; i < 5; i++ {
+		req.Queries = append(req.Queries, QueryBatchV2Query{
+			Kind:       queryKindDatasource,
+			RefID:      string(rune('A' + i)),
+			Datasource: &QueryBatchV2DatasourceRef{Cate: "iotdb", ID: int64(i + 1)},
+			ResultType: resultTypeTimeSeries,
+			Query:      queryBatchV2Raw(`{"sql":"select 1"}`),
+		})
+	}
+
+	resp := executor.execute(c, req)
+	if calls := atomic.LoadInt32(&fake.calls); calls != 0 {
+		t.Fatalf("datasource calls after cancellation = %d, want 0", calls)
+	}
+	for i, result := range resp.Results {
+		if result.Error == nil || result.Error.Code != "DATASOURCE_TIMEOUT" {
+			t.Fatalf("result %d = %#v", i, result)
+		}
+	}
+}
+
+func TestQueryBatchV2Expressions(t *testing.T) {
+	values := map[string]queryBatchV2Value{
+		"A": {
+			ResultType: resultTypeTimeSeries,
+			Series: []QueryBatchV2Series{{
+				Labels: map[string]string{"__name__": "cpu", "host": "node-1"},
+				Samples: []QueryBatchV2Sample{
+					{Timestamp: 10, Value: queryBatchV2Number(4)},
+					{Timestamp: 20, Value: queryBatchV2Number(8)},
+				},
+			}},
+		},
+		"B": {
+			ResultType: resultTypeTimeSeries,
+			Series: []QueryBatchV2Series{{
+				Labels: map[string]string{"__name__": "quota", "host": "node-1"},
+				Samples: []QueryBatchV2Sample{
+					{Timestamp: 10, Value: queryBatchV2Number(2)},
+					{Timestamp: 30, Value: queryBatchV2Number(2)},
+				},
+			}},
+		},
+	}
+	req := QueryBatchV2Request{
+		From: 1,
+		To:   30,
+		Queries: []QueryBatchV2Query{
+			{Kind: queryKindDatasource, RefID: "A"},
+			{Kind: queryKindDatasource, RefID: "B"},
+			{Kind: queryKindExpression, RefID: "C", Expression: "$A / $B"},
+			{Kind: queryKindExpression, RefID: "D", Expression: "$C * 100"},
+		},
+	}
+	results := []QueryBatchV2Result{
+		queryBatchV2Success("A", values["A"]),
+		queryBatchV2Success("B", values["B"]),
+		{},
+		{},
+	}
+	queryBatchV2Executor{}.evaluateExpressions(req, results, values)
+
+	if results[2].Status != resultStatusSuccess || results[3].Status != resultStatusSuccess {
+		t.Fatalf("expression results: %#v", results)
+	}
+	cSeries := values["C"].Series
+	if len(cSeries) != 1 || len(cSeries[0].Samples) != 1 || cSeries[0].Samples[0].Value != 2 {
+		t.Fatalf("unexpected C value: %#v", cSeries)
+	}
+	dSeries := values["D"].Series
+	if len(dSeries) != 1 || dSeries[0].Samples[0].Value != 200 {
+		t.Fatalf("unexpected chained value: %#v", dSeries)
+	}
+	if _, exists := dSeries[0].Labels["__name__"]; exists || dSeries[0].Labels["host"] != "node-1" {
+		t.Fatalf("expression labels = %#v", dSeries[0].Labels)
+	}
+}
+
+func TestQueryBatchV2RecordsUsesElasticsearchSource(t *testing.T) {
+	records := queryBatchV2Records("elasticsearch", []interface{}{map[string]interface{}{
+		"_id":     "document-id",
+		"_index":  "logs-2026.07.25",
+		"_source": map[string]interface{}{"message": "hello", "status": "200"},
+		"sort":    []interface{}{float64(1784971399013)},
+	}})
+	if len(records) != 1 {
+		t.Fatalf("record count = %d, want 1", len(records))
+	}
+	if records[0].Fields["message"] != "hello" || records[0].Fields["_id"] != nil {
+		t.Fatalf("unexpected fields: %#v", records[0].Fields)
+	}
+
+	withoutSource := queryBatchV2Records("elasticsearch.logging", []interface{}{map[string]interface{}{
+		"_id": "document-without-source", "_index": "logs-2026.07.25",
+	}})
+	if len(withoutSource[0].Fields) != 0 {
+		t.Fatalf("ES metadata leaked without _source: %#v", withoutSource[0].Fields)
+	}
+
+	generic := queryBatchV2Records("loki", []interface{}{map[string]interface{}{"message": "hello"}})
+	if generic[0].Fields["message"] != "hello" {
+		t.Fatalf("generic log record = %#v", generic[0].Fields)
+	}
+
+	openSearch := queryBatchV2Records("opensearch.logging", []interface{}{map[string]interface{}{
+		"_id": "document-id", "_index": "logs", "_source": map[string]interface{}{"message": "opensearch"},
+	}})
+	if openSearch[0].Fields["message"] != "opensearch" || openSearch[0].Fields["_id"] != nil {
+		t.Fatalf("OpenSearch record = %#v", openSearch[0].Fields)
+	}
+
+	nonES := queryBatchV2Records("mongodb", []interface{}{map[string]interface{}{
+		"_id": "document-id", "_index": "business-index", "message": "preserve",
+	}})
+	if nonES[0].Fields["message"] != "preserve" || nonES[0].Fields["_id"] != "document-id" {
+		t.Fatalf("non-ES record was stripped: %#v", nonES[0].Fields)
+	}
+}
+
+func TestQueryBatchV2ExpressionScalarAndFailures(t *testing.T) {
+	scalar := float64(2)
+	values := map[string]queryBatchV2Value{
+		"A": {
+			ResultType: resultTypeTimeSeries,
+			Series: []QueryBatchV2Series{{
+				Labels:  map[string]string{"host": "node-1"},
+				Samples: []QueryBatchV2Sample{{Timestamp: 10, Value: queryBatchV2Number(4)}},
+			}},
+		},
+		"S": {ResultType: resultTypeTimeSeries, Scalar: &scalar},
+		"L": {ResultType: resultTypeLogs},
+	}
+	req := QueryBatchV2Request{To: 20, Queries: []QueryBatchV2Query{
+		{Kind: queryKindDatasource, RefID: "A"},
+		{Kind: queryKindDatasource, RefID: "S"},
+		{Kind: queryKindDatasource, RefID: "L"},
+		{Kind: queryKindExpression, RefID: "B", Expression: "$A * $S"},
+		{Kind: queryKindExpression, RefID: "C", Expression: "$L + 1"},
+		{Kind: queryKindExpression, RefID: "D", Expression: "$UNKNOWN + 1"},
+		{Kind: queryKindExpression, RefID: "E", Expression: "$F + 1"},
+		{Kind: queryKindExpression, RefID: "F", Expression: "$E + 1"},
+	}}
+	results := []QueryBatchV2Result{
+		queryBatchV2Success("A", values["A"]),
+		queryBatchV2Success("S", values["S"]),
+		queryBatchV2Success("L", values["L"]),
+		{}, {}, {}, {}, {},
+	}
+	queryBatchV2Executor{}.evaluateExpressions(req, results, values)
+
+	if got := values["B"].Series[0].Samples[0].Value; got != 8 {
+		t.Fatalf("scalar broadcast value = %v", got)
+	}
+	if results[4].Error.Code != "DEPENDENCY_TYPE_MISMATCH" {
+		t.Fatalf("logs dependency result = %#v", results[4])
+	}
+	if results[5].Error.Code != "DEPENDENCY_NOT_FOUND" {
+		t.Fatalf("unknown dependency result = %#v", results[5])
+	}
+	if results[6].Error.Code != "DEPENDENCY_CYCLE" || results[7].Error.Code != "DEPENDENCY_CYCLE" {
+		t.Fatalf("cycle results = %#v / %#v", results[6], results[7])
+	}
+}
+
+func TestQueryBatchV2ExpressionValidationDoesNotExecute(t *testing.T) {
+	values := map[string]queryBatchV2Value{
+		"A": {
+			ResultType: resultTypeTimeSeries,
+			Series: []QueryBatchV2Series{{
+				Labels:  map[string]string{},
+				Samples: []QueryBatchV2Sample{{Timestamp: 10, Value: 4}},
+			}},
+		},
+	}
+	req := QueryBatchV2Request{To: 20, Queries: []QueryBatchV2Query{
+		{Kind: queryKindDatasource, RefID: "A"},
+		{Kind: queryKindExpression, RefID: "B", Expression: "$A / 0"},
+		{Kind: queryKindExpression, RefID: "C", Expression: "$A +"},
+	}}
+	results := []QueryBatchV2Result{queryBatchV2Success("A", values["A"]), {}, {}}
+
+	queryBatchV2Executor{}.evaluateExpressions(req, results, values)
+	if results[1].Status != resultStatusSuccess {
+		t.Fatalf("runtime-dependent expression was rejected during validation: %#v", results[1])
+	}
+	if results[2].Error == nil || results[2].Error.Code != "EXPRESSION_INVALID" {
+		t.Fatalf("invalid syntax result = %#v", results[2])
+	}
+}
+
+func TestQueryBatchV2ExpressionEvaluationLimit(t *testing.T) {
+	samples := make([]QueryBatchV2Sample, queryBatchV2MaxExpressionPoints+1)
+	for i := range samples {
+		samples[i] = QueryBatchV2Sample{Timestamp: int64(i), Value: 1}
+	}
+	values := map[string]queryBatchV2Value{
+		"A": {
+			ResultType: resultTypeTimeSeries,
+			Series:     []QueryBatchV2Series{{Labels: map[string]string{}, Samples: samples}},
+		},
+	}
+	req := QueryBatchV2Request{Queries: []QueryBatchV2Query{
+		{Kind: queryKindDatasource, RefID: "A"},
+		{Kind: queryKindExpression, RefID: "B", Expression: "$A + 1"},
+	}}
+	results := []QueryBatchV2Result{queryBatchV2Success("A", values["A"]), {}}
+
+	queryBatchV2Executor{}.evaluateExpressions(req, results, values)
+	if results[1].Error == nil || results[1].Error.Code != "EXPRESSION_LIMIT_EXCEEDED" {
+		t.Fatalf("expression limit result = %#v", results[1])
+	}
+}
+
+func TestQueryBatchV2ExpressionDepthLimit(t *testing.T) {
+	values := map[string]queryBatchV2Value{
+		"A": {
+			ResultType: resultTypeTimeSeries,
+			Series: []QueryBatchV2Series{{
+				Labels:  map[string]string{},
+				Samples: []QueryBatchV2Sample{{Timestamp: 1, Value: 1}},
+			}},
+		},
+	}
+	req := QueryBatchV2Request{}
+	for depth := queryBatchV2MaxExpressionDepth + 1; depth >= 1; depth-- {
+		dependency := "A"
+		if depth > 1 {
+			dependency = fmt.Sprintf("E%d", depth-1)
+		}
+		req.Queries = append(req.Queries, QueryBatchV2Query{
+			Kind:       queryKindExpression,
+			RefID:      fmt.Sprintf("E%d", depth),
+			Expression: "$" + dependency + " + 1",
+		})
+	}
+	req.Queries = append(req.Queries, QueryBatchV2Query{Kind: queryKindDatasource, RefID: "A"})
+	results := make([]QueryBatchV2Result, len(req.Queries))
+	results[len(results)-1] = queryBatchV2Success("A", values["A"])
+
+	queryBatchV2Executor{}.evaluateExpressions(req, results, values)
+	deepestIndex := queryBatchV2MaxExpressionDepth
+	if results[deepestIndex].Error == nil || results[deepestIndex].Error.Code != "EXPRESSION_DEPTH_EXCEEDED" {
+		t.Fatalf("expression depth result = %#v", results[deepestIndex])
+	}
+}
+
+func TestQueryBatchV2DependenciesIgnoreStringLiterals(t *testing.T) {
+	dependencies := queryBatchV2Dependencies(`$A + "$B" + '$C' + $D`)
+	if len(dependencies) != 2 || dependencies[0] != "A" || dependencies[1] != "D" {
+		t.Fatalf("dependencies = %#v", dependencies)
+	}
+}
+
+func TestQueryBatchV2LabelKeyUsesLengthPrefixes(t *testing.T) {
+	left := queryBatchV2LabelKey(map[string]string{"a": "b\x00c"}, false)
+	right := queryBatchV2LabelKey(map[string]string{"a": "b", "c": ""}, false)
+	if left == right {
+		t.Fatalf("label keys collided: %q", left)
+	}
+}
+
+func TestQueryBatchV2PromScalarInstantTimestamp(t *testing.T) {
+	value := queryBatchV2PromValue(&model.Scalar{
+		Timestamp: model.Time(1000),
+		Value:     model.SampleValue(3),
+	}, 123)
+	if value.Scalar == nil || *value.Scalar != 3 || len(value.Series) != 1 {
+		t.Fatalf("scalar value = %#v", value)
+	}
+	sample := value.Series[0].Samples[0]
+	if sample.Timestamp != 123 || sample.Value != 3 {
+		t.Fatalf("instant scalar sample = %#v", sample)
+	}
+}
+
+func httpNewRequestWithContext(ctx context.Context) (*http.Request, error) {
+	return http.NewRequestWithContext(ctx, http.MethodPost, "/api/n9e/v2/query-batch", nil)
+}

--- a/center/router/router_query_batch_v2_test.go
+++ b/center/router/router_query_batch_v2_test.go
@@ -91,7 +91,7 @@ func TestQueryBatchV2ElasticsearchKQLEndToEnd(t *testing.T) {
 	engine.POST("/api/n9e/v2/query-batch", func(c *gin.Context) {
 		QueryBatchV2(c, true, nil, nil)
 	})
-	body := []byte(`{"from":1710000000,"to":1710003600,"queries":[{"kind":"query","ref_id":"ES","datasource":{"cate":"elasticsearch","id":987654322},"result_type":"logs","query":{"index_type":"index","index":"logs-*","date_field":"@timestamp","limit":10,"filter_language":"kql","filter":"message: *timeout*"}}]}`)
+	body := []byte(`{"from":1710000000,"to":1710003600,"queries":[{"kind":"query","ref_id":"ES","datasource":{"cate":"elasticsearch","id":987654322},"result_type":"logs","query":{"index_type":"index","index":"logs-*","date_field":"@timestamp","limit":10,"filter_language":"kql","filter":"message: timeout*"}}]}`)
 	recorder := httptest.NewRecorder()
 	request := httptest.NewRequest(http.MethodPost, "/api/n9e/v2/query-batch", bytes.NewReader(body))
 	request.Header.Set("Content-Type", "application/json")
@@ -114,9 +114,10 @@ func TestQueryBatchV2ElasticsearchKQLEndToEnd(t *testing.T) {
 	if len(filters) != 2 {
 		t.Fatalf("ES filters = %#v", filters)
 	}
-	wildcard := filters[1].(map[string]interface{})["wildcard"].(map[string]interface{})["message"].(map[string]interface{})
-	if wildcard["value"] != "*timeout*" {
-		t.Fatalf("KQL was not compiled to wildcard DSL: %#v", receivedQuery)
+	should := filters[1].(map[string]interface{})["bool"].(map[string]interface{})["should"].([]interface{})
+	queryString := should[0].(map[string]interface{})["query_string"].(map[string]interface{})
+	if queryString["query"] != "timeout*" {
+		t.Fatalf("KQL was not compiled to frontend-compatible query_string DSL: %#v", receivedQuery)
 	}
 }
 
@@ -559,6 +560,54 @@ func TestQueryBatchV2ExpressionValidationDoesNotExecute(t *testing.T) {
 	}
 	if results[2].Error == nil || results[2].Error.Code != "EXPRESSION_INVALID" {
 		t.Fatalf("invalid syntax result = %#v", results[2])
+	}
+}
+
+func TestQueryBatchV2ExpressionRuntimeError(t *testing.T) {
+	scalar := float64(2)
+	values := map[string]queryBatchV2Value{
+		"A": {
+			ResultType: resultTypeTimeSeries,
+			Series: []QueryBatchV2Series{{
+				Labels:  map[string]string{},
+				Samples: []QueryBatchV2Sample{{Timestamp: 10, Value: 4}},
+			}},
+		},
+		"S": {ResultType: resultTypeTimeSeries, Scalar: &scalar},
+	}
+	req := QueryBatchV2Request{To: 20, Queries: []QueryBatchV2Query{
+		{Kind: queryKindDatasource, RefID: "A"},
+		{Kind: queryKindDatasource, RefID: "S"},
+		{Kind: queryKindExpression, RefID: "B", Expression: "nosuchfunc($A)"},
+		{Kind: queryKindExpression, RefID: "C", Expression: "nosuchfunc($S)"},
+	}}
+	results := []QueryBatchV2Result{
+		queryBatchV2Success("A", values["A"]),
+		queryBatchV2Success("S", values["S"]),
+		{}, {},
+	}
+
+	queryBatchV2Executor{}.evaluateExpressions(req, results, values)
+	for _, index := range []int{2, 3} {
+		if results[index].Error == nil || results[index].Error.Code != "EXPRESSION_EVALUATION_ERROR" {
+			t.Fatalf("runtime error result[%d] = %#v", index, results[index])
+		}
+	}
+}
+
+func TestQueryBatchV2ExpressionRuntimeErrorWithEmptySeries(t *testing.T) {
+	values := map[string]queryBatchV2Value{
+		"A": {ResultType: resultTypeTimeSeries, Series: []QueryBatchV2Series{}},
+	}
+	req := QueryBatchV2Request{Queries: []QueryBatchV2Query{
+		{Kind: queryKindDatasource, RefID: "A"},
+		{Kind: queryKindExpression, RefID: "B", Expression: "nosuchfunc($A)"},
+	}}
+	results := []QueryBatchV2Result{queryBatchV2Success("A", values["A"]), {}}
+
+	queryBatchV2Executor{}.evaluateExpressions(req, results, values)
+	if results[1].Error == nil || results[1].Error.Code != "EXPRESSION_EVALUATION_ERROR" {
+		t.Fatalf("empty-series runtime error result = %#v", results[1])
 	}
 }
 

--- a/datasource/commons/eslike/eslike.go
+++ b/datasource/commons/eslike/eslike.go
@@ -37,6 +37,8 @@ type Query struct {
 	Index          string     `json:"index" mapstructure:"index"`
 	IndexPatternId int64      `json:"index_pattern" mapstructure:"index_pattern"`
 	Filter         string     `json:"filter" mapstructure:"filter"`
+	FilterLanguage string     `json:"filter_language" mapstructure:"filter_language"`
+	KQLOptions     KQLOptions `json:"kql_options" mapstructure:"kql_options"`
 	Offset         int64      `json:"offset" mapstructure:"offset"`
 	MetricAggr     MetricAggr `json:"value" mapstructure:"value"`
 	GroupBy        []GroupBy  `json:"group_by" mapstructure:"group_by"`
@@ -416,7 +418,10 @@ func QueryData(ctx context.Context, queryParam interface{}, cliTimeout int64, ve
 	field := param.MetricAggr.Field
 	groupBys := param.GroupBy
 
-	queryString := GetQueryString(param.Filter, q)
+	queryString, err := GetFilterQuery(param, q)
+	if err != nil {
+		return nil, err
+	}
 
 	var aggr elastic.Aggregation
 	switch param.MetricAggr.Func {
@@ -704,7 +709,10 @@ func QueryLog(ctx context.Context, queryParam interface{}, timeout int64, versio
 	q.Lt(time.Unix(end, 0).UnixMilli())
 	q.Format("epoch_millis")
 
-	queryString := GetQueryString(param.Filter, q)
+	queryString, err := GetFilterQuery(param, q)
+	if err != nil {
+		return nil, 0, err
+	}
 
 	if param.Limit <= 0 {
 		param.Limit = 10

--- a/datasource/commons/eslike/kql.go
+++ b/datasource/commons/eslike/kql.go
@@ -1,0 +1,413 @@
+package eslike
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"github.com/olivere/elastic/v7"
+)
+
+const kqlMaxNestingDepth = 64
+
+// KQLOptions configures the KQL compiler. KQL is compiled to Query DSL so it
+// also works with the ES 7.10+ clusters supported by this datasource.
+type KQLOptions struct {
+	DefaultField    string `json:"default_field" mapstructure:"default_field"`
+	CaseInsensitive bool   `json:"case_insensitive" mapstructure:"case_insensitive"`
+	TimeZone        string `json:"time_zone" mapstructure:"time_zone"`
+	// dateField is supplied by the enclosing ES query. KQL has no mapping in
+	// this layer, so this is the only field for which applying time_zone is
+	// unambiguously safe (numeric ranges must not receive it).
+	dateField string
+}
+
+// GetFilterQuery preserves the legacy Lucene path and compiles an explicitly
+// requested KQL filter into standard Elasticsearch Query DSL.
+func GetFilterQuery(param *Query, timeRange *elastic.RangeQuery) (elastic.Query, error) {
+	if strings.EqualFold(param.FilterLanguage, "kql") {
+		if strings.TrimSpace(param.Filter) == "" {
+			return nil, fmt.Errorf("filter is required when filter_language is kql")
+		}
+		options := param.KQLOptions
+		options.dateField = param.DateField
+		compiled, err := CompileKQL(param.Filter, options)
+		if err != nil {
+			return nil, err
+		}
+		rangeSource, err := timeRange.Source()
+		if err != nil {
+			return nil, err
+		}
+		filters := []interface{}{rangeSource}
+		if compiled != nil {
+			filters = append(filters, compiled)
+		}
+		body, err := json.Marshal(map[string]interface{}{"bool": map[string]interface{}{"filter": filters}})
+		if err != nil {
+			return nil, err
+		}
+		return elastic.NewRawStringQuery(string(body)), nil
+	}
+	if param.FilterLanguage != "" && !strings.EqualFold(param.FilterLanguage, "lucene") {
+		return nil, fmt.Errorf("unsupported filter_language: %s", param.FilterLanguage)
+	}
+	return GetQueryString(param.Filter, timeRange), nil
+}
+
+// CompileKQL supports the filter-oriented KQL subset used by log search:
+// boolean operators, parentheses, field matching, existence, wildcards and
+// range comparisons. It intentionally rejects Lucene-only operators.
+func CompileKQL(input string, options KQLOptions) (map[string]interface{}, error) {
+	if strings.TrimSpace(input) == "" {
+		return nil, nil
+	}
+	tokens, err := lexKQL(input)
+	if err != nil {
+		return nil, err
+	}
+	p := kqlParser{tokens: tokens, options: options}
+	query, err := p.parseOr(options.DefaultField)
+	if err != nil {
+		return nil, err
+	}
+	if p.peek().kind != kqlEOF {
+		return nil, fmt.Errorf("invalid KQL near %q", p.peek().value)
+	}
+	return query, nil
+}
+
+type kqlTokenKind uint8
+
+const (
+	kqlEOF kqlTokenKind = iota
+	kqlWord
+	kqlString
+	kqlLParen
+	kqlRParen
+	kqlColon
+	kqlGT
+	kqlGTE
+	kqlLT
+	kqlLTE
+)
+
+type kqlToken struct {
+	kind  kqlTokenKind
+	value string
+}
+
+func lexKQL(input string) ([]kqlToken, error) {
+	tokens := make([]kqlToken, 0)
+	runes := []rune(input)
+	for i := 0; i < len(runes); {
+		if unicode.IsSpace(runes[i]) {
+			i++
+			continue
+		}
+		switch runes[i] {
+		case '(':
+			tokens = append(tokens, kqlToken{kind: kqlLParen, value: "("})
+			i++
+		case ')':
+			tokens = append(tokens, kqlToken{kind: kqlRParen, value: ")"})
+			i++
+		case ':':
+			tokens = append(tokens, kqlToken{kind: kqlColon, value: ":"})
+			i++
+		case '>', '<':
+			kind := kqlGT
+			if runes[i] == '<' {
+				kind = kqlLT
+			}
+			value := string(runes[i])
+			i++
+			if i < len(runes) && runes[i] == '=' {
+				if kind == kqlGT {
+					kind = kqlGTE
+				} else {
+					kind = kqlLTE
+				}
+				value += "="
+				i++
+			}
+			tokens = append(tokens, kqlToken{kind: kind, value: value})
+		case '"':
+			start := i
+			i++
+			var b strings.Builder
+			closed := false
+			for i < len(runes) {
+				if runes[i] == '\\' && i+1 < len(runes) {
+					i++
+					b.WriteRune(runes[i])
+					i++
+					continue
+				}
+				if runes[i] == '"' {
+					i++
+					closed = true
+					break
+				}
+				b.WriteRune(runes[i])
+				i++
+			}
+			if !closed {
+				return nil, fmt.Errorf("unterminated quoted string at position %d", start)
+			}
+			tokens = append(tokens, kqlToken{kind: kqlString, value: b.String()})
+		default:
+			start := i
+			for i < len(runes) && !unicode.IsSpace(runes[i]) && !strings.ContainsRune("():><\"", runes[i]) {
+				i++
+			}
+			if start == i {
+				return nil, fmt.Errorf("invalid character at position %d", start)
+			}
+			tokens = append(tokens, kqlToken{kind: kqlWord, value: string(runes[start:i])})
+		}
+	}
+	return append(tokens, kqlToken{kind: kqlEOF}), nil
+}
+
+type kqlParser struct {
+	tokens  []kqlToken
+	pos     int
+	depth   int
+	options KQLOptions
+}
+
+func (p *kqlParser) peek() kqlToken { return p.tokens[p.pos] }
+func (p *kqlParser) take() kqlToken {
+	t := p.peek()
+	if p.pos < len(p.tokens)-1 {
+		p.pos++
+	}
+	return t
+}
+func (p *kqlParser) keyword(word string) bool {
+	t := p.peek()
+	return t.kind == kqlWord && strings.EqualFold(t.value, word)
+}
+
+func (p *kqlParser) enterNesting() error {
+	if p.depth >= kqlMaxNestingDepth {
+		return fmt.Errorf("KQL nesting exceeds maximum depth %d", kqlMaxNestingDepth)
+	}
+	p.depth++
+	return nil
+}
+
+func (p *kqlParser) leaveNesting() {
+	p.depth--
+}
+
+func (p *kqlParser) parseOr(defaultField string) (map[string]interface{}, error) {
+	left, err := p.parseAnd(defaultField)
+	if err != nil {
+		return nil, err
+	}
+	values := []interface{}{left}
+	for p.keyword("OR") {
+		p.take()
+		right, err := p.parseAnd(defaultField)
+		if err != nil {
+			return nil, err
+		}
+		values = append(values, right)
+	}
+	if len(values) == 1 {
+		return left, nil
+	}
+	return map[string]interface{}{"bool": map[string]interface{}{"should": values, "minimum_should_match": 1}}, nil
+}
+
+func (p *kqlParser) parseAnd(defaultField string) (map[string]interface{}, error) {
+	left, err := p.parseUnary(defaultField)
+	if err != nil {
+		return nil, err
+	}
+	values := []interface{}{left}
+	for {
+		if p.keyword("AND") {
+			p.take()
+		} else if !p.startsImplicitAnd() {
+			break
+		}
+		right, err := p.parseUnary(defaultField)
+		if err != nil {
+			return nil, err
+		}
+		values = append(values, right)
+	}
+	if len(values) == 1 {
+		return left, nil
+	}
+	return map[string]interface{}{"bool": map[string]interface{}{"filter": values}}, nil
+}
+
+func (p *kqlParser) startsImplicitAnd() bool {
+	switch p.peek().kind {
+	case kqlWord:
+		return !p.keyword("OR") && !p.keyword("AND")
+	case kqlString, kqlLParen:
+		return true
+	default:
+		return false
+	}
+}
+
+func (p *kqlParser) parseUnary(defaultField string) (map[string]interface{}, error) {
+	if p.keyword("NOT") {
+		p.take()
+		if err := p.enterNesting(); err != nil {
+			return nil, err
+		}
+		defer p.leaveNesting()
+		q, err := p.parseUnary(defaultField)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]interface{}{"bool": map[string]interface{}{"must_not": []interface{}{q}}}, nil
+	}
+	return p.parsePrimary(defaultField)
+}
+
+func (p *kqlParser) parsePrimary(defaultField string) (map[string]interface{}, error) {
+	if p.peek().kind == kqlLParen {
+		p.take()
+		if err := p.enterNesting(); err != nil {
+			return nil, err
+		}
+		defer p.leaveNesting()
+		q, err := p.parseOr(defaultField)
+		if err != nil {
+			return nil, err
+		}
+		if p.take().kind != kqlRParen {
+			return nil, fmt.Errorf("missing closing parenthesis")
+		}
+		return q, nil
+	}
+	t := p.take()
+	if t.kind != kqlWord && t.kind != kqlString {
+		return nil, fmt.Errorf("expected KQL term near %q", t.value)
+	}
+	if p.peek().kind == kqlColon {
+		p.take()
+		return p.parseFieldValue(t.value)
+	}
+	if p.peek().kind == kqlGT || p.peek().kind == kqlGTE || p.peek().kind == kqlLT || p.peek().kind == kqlLTE {
+		op := p.take()
+		value := p.take()
+		if value.kind != kqlWord && value.kind != kqlString {
+			return nil, fmt.Errorf("range value is required")
+		}
+		return kqlRange(t.value, op.kind, value.value, value.kind == kqlString, p.options), nil
+	}
+	if defaultField != "" {
+		return kqlValue(defaultField, t.value, t.kind == kqlString, p.options), nil
+	}
+	return map[string]interface{}{"simple_query_string": map[string]interface{}{"query": t.value, "default_operator": "and"}}, nil
+}
+
+func (p *kqlParser) parseFieldValue(field string) (map[string]interface{}, error) {
+	if p.peek().kind == kqlLParen {
+		p.take()
+		if err := p.enterNesting(); err != nil {
+			return nil, err
+		}
+		defer p.leaveNesting()
+		q, err := p.parseOr(field)
+		if err != nil {
+			return nil, err
+		}
+		if p.take().kind != kqlRParen {
+			return nil, fmt.Errorf("missing closing parenthesis")
+		}
+		return q, nil
+	}
+	t := p.take()
+	if t.kind == kqlWord && t.value == "*" {
+		return map[string]interface{}{"exists": map[string]interface{}{"field": field}}, nil
+	}
+	if t.kind != kqlWord && t.kind != kqlString {
+		return nil, fmt.Errorf("value is required for field %s", field)
+	}
+	// KQL users commonly type an unquoted multi-word value. Keep consuming
+	// value words until a boolean operator, a grouping boundary, or the start
+	// of a new field clause. This compiles to a full-text match below instead
+	// of producing a dangling token / INVALID_QUERY response.
+	values := []string{t.value}
+	for t.kind == kqlWord && p.canConsumeFieldValueWord() {
+		values = append(values, p.take().value)
+	}
+	value := strings.Join(values, " ")
+	if t.kind == kqlWord && strings.Contains(value, "/") {
+		return nil, fmt.Errorf("unquoted / is not supported in KQL values")
+	}
+	return kqlValue(field, value, t.kind == kqlString, p.options), nil
+}
+
+func (p *kqlParser) canConsumeFieldValueWord() bool {
+	return p.peek().kind == kqlWord &&
+		!p.keyword("AND") &&
+		!p.keyword("OR") &&
+		!p.keyword("NOT") &&
+		!p.nextStartsFieldClause()
+}
+
+func (p *kqlParser) nextStartsFieldClause() bool {
+	return p.pos+1 < len(p.tokens) && (p.tokens[p.pos+1].kind == kqlColon ||
+		p.tokens[p.pos+1].kind == kqlGT || p.tokens[p.pos+1].kind == kqlGTE ||
+		p.tokens[p.pos+1].kind == kqlLT || p.tokens[p.pos+1].kind == kqlLTE)
+}
+
+func kqlValue(field, value string, quoted bool, options KQLOptions) map[string]interface{} {
+	if quoted {
+		return map[string]interface{}{"match_phrase": map[string]interface{}{field: value}}
+	}
+	if strings.Contains(value, "*") {
+		body := map[string]interface{}{"value": value, "case_insensitive": options.CaseInsensitive}
+		if strings.HasSuffix(value, "*") && !strings.Contains(value[:len(value)-1], "*") {
+			body["value"] = strings.TrimSuffix(value, "*")
+			return map[string]interface{}{"prefix": map[string]interface{}{field: body}}
+		}
+		return map[string]interface{}{"wildcard": map[string]interface{}{field: body}}
+	}
+	// Without a mapping, term is incorrect for analyzed text fields. match also
+	// works for keyword and numeric fields and gives the expected full-text KQL
+	// behaviour. case_insensitive is intentionally only emitted for wildcard /
+	// prefix, the ES query types that actually support it.
+	return map[string]interface{}{"match": map[string]interface{}{field: map[string]interface{}{"query": value, "operator": "and"}}}
+}
+
+func kqlRange(field string, op kqlTokenKind, value string, quoted bool, options KQLOptions) map[string]interface{} {
+	var key string
+	switch op {
+	case kqlGT:
+		key = "gt"
+	case kqlGTE:
+		key = "gte"
+	case kqlLT:
+		key = "lt"
+	case kqlLTE:
+		key = "lte"
+	}
+	rangeValue := interface{}(value)
+	if !quoted {
+		if integer, err := strconv.ParseInt(value, 10, 64); err == nil {
+			rangeValue = integer
+		} else if number, err := strconv.ParseFloat(value, 64); err == nil && !math.IsNaN(number) && !math.IsInf(number, 0) {
+			rangeValue = number
+		}
+	}
+	body := map[string]interface{}{key: rangeValue}
+	if options.TimeZone != "" && field == options.dateField {
+		body["time_zone"] = options.TimeZone
+	}
+	return map[string]interface{}{"range": map[string]interface{}{field: body}}
+}

--- a/datasource/commons/eslike/kql.go
+++ b/datasource/commons/eslike/kql.go
@@ -3,30 +3,33 @@ package eslike
 import (
 	"encoding/json"
 	"fmt"
-	"math"
-	"strconv"
 	"strings"
 	"unicode"
 
 	"github.com/olivere/elastic/v7"
 )
 
-const kqlMaxNestingDepth = 64
+const (
+	kqlMaxNestingDepth = 64
+	// Same sentinel the frontend grammar uses to carry an unescaped '*' through
+	// a literal's text. A value that literally contains this substring would be
+	// turned back into a wildcard, which is why it stays this unlikely.
+	kqlWildcardMarker = "@kuery-wildcard@"
+)
 
-// KQLOptions configures the KQL compiler. KQL is compiled to Query DSL so it
-// also works with the ES 7.10+ clusters supported by this datasource.
+// KQLOptions configures server-specific additions around the frontend KQL
+// grammar. CompileKQL itself follows buildESQueryFromKuery's default mode: it
+// does not inspect index mappings and disables leading wildcards.
 type KQLOptions struct {
+	// DefaultField and CaseInsensitive are accepted for request compatibility
+	// and ignored: the frontend grammar always searches all fields for a bare
+	// term, and its no-mapping branch emits no case_insensitive option.
 	DefaultField    string `json:"default_field" mapstructure:"default_field"`
 	CaseInsensitive bool   `json:"case_insensitive" mapstructure:"case_insensitive"`
 	TimeZone        string `json:"time_zone" mapstructure:"time_zone"`
-	// dateField is supplied by the enclosing ES query. KQL has no mapping in
-	// this layer, so this is the only field for which applying time_zone is
-	// unambiguously safe (numeric ranges must not receive it).
-	dateField string
+	dateField       string
 }
 
-// GetFilterQuery preserves the legacy Lucene path and compiles an explicitly
-// requested KQL filter into standard Elasticsearch Query DSL.
 func GetFilterQuery(param *Query, timeRange *elastic.RangeQuery) (elastic.Query, error) {
 	if strings.EqualFold(param.FilterLanguage, "kql") {
 		if strings.TrimSpace(param.Filter) == "" {
@@ -42,11 +45,9 @@ func GetFilterQuery(param *Query, timeRange *elastic.RangeQuery) (elastic.Query,
 		if err != nil {
 			return nil, err
 		}
-		filters := []interface{}{rangeSource}
-		if compiled != nil {
-			filters = append(filters, compiled)
-		}
-		body, err := json.Marshal(map[string]interface{}{"bool": map[string]interface{}{"filter": filters}})
+		body, err := json.Marshal(map[string]interface{}{"bool": map[string]interface{}{
+			"filter": []interface{}{rangeSource, compiled},
+		}})
 		if err != nil {
 			return nil, err
 		}
@@ -58,36 +59,50 @@ func GetFilterQuery(param *Query, timeRange *elastic.RangeQuery) (elastic.Query,
 	return GetQueryString(param.Filter, timeRange), nil
 }
 
-// CompileKQL supports the filter-oriented KQL subset used by log search:
-// boolean operators, parentheses, field matching, existence, wildcards and
-// range comparisons. It intentionally rejects Lucene-only operators.
+// CompileKQL is a Go implementation of the grammar and no-index-pattern DSL
+// conversion used by buildESQueryFromKuery in the web client.
 func CompileKQL(input string, options KQLOptions) (map[string]interface{}, error) {
-	if strings.TrimSpace(input) == "" {
-		return nil, nil
+	p := kqlParser{input: []rune(input), options: options}
+	if err := p.next(); err != nil {
+		return nil, err
 	}
-	tokens, err := lexKQL(input)
+	node, err := p.parseExpression("")
 	if err != nil {
 		return nil, err
 	}
-	p := kqlParser{tokens: tokens, options: options}
-	query, err := p.parseOr(options.DefaultField)
-	if err != nil {
+	if p.token.kind != kqlEOF {
+		return nil, p.errorf("invalid KQL near %q", kqlDisplayText(p.token.text))
+	}
+	if err := kqlValidateLeadingWildcards(node); err != nil {
 		return nil, err
 	}
-	if p.peek().kind != kqlEOF {
-		return nil, fmt.Errorf("invalid KQL near %q", p.peek().value)
+	return kqlToDSL(node, "", options), nil
+}
+
+// kqlValidateLeadingWildcards mirrors where the frontend raises the error: in
+// the "is" conversion only. Field names and range values keep their leading
+// wildcards, and whether Elasticsearch accepts them depends on the field type.
+func kqlValidateLeadingWildcards(node *kqlNode) error {
+	if node.kind == "is" && node.value != nil && node.value.wildcard && kqlHasLeadingWildcard(node.value) {
+		return fmt.Errorf("Leading wildcards are disabled.")
 	}
-	return query, nil
+	for _, child := range node.children {
+		if err := kqlValidateLeadingWildcards(child); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 type kqlTokenKind uint8
 
 const (
 	kqlEOF kqlTokenKind = iota
-	kqlWord
-	kqlString
+	kqlAtom
 	kqlLParen
 	kqlRParen
+	kqlLBrace
+	kqlRBrace
 	kqlColon
 	kqlGT
 	kqlGTE
@@ -96,318 +111,562 @@ const (
 )
 
 type kqlToken struct {
-	kind  kqlTokenKind
-	value string
+	kind        kqlTokenKind
+	text        string
+	value       interface{}
+	quoted      bool
+	wildcard    bool
+	spaceBefore bool
+	position    int
 }
 
-func lexKQL(input string) ([]kqlToken, error) {
-	tokens := make([]kqlToken, 0)
-	runes := []rune(input)
-	for i := 0; i < len(runes); {
-		if unicode.IsSpace(runes[i]) {
-			i++
-			continue
-		}
-		switch runes[i] {
-		case '(':
-			tokens = append(tokens, kqlToken{kind: kqlLParen, value: "("})
-			i++
-		case ')':
-			tokens = append(tokens, kqlToken{kind: kqlRParen, value: ")"})
-			i++
-		case ':':
-			tokens = append(tokens, kqlToken{kind: kqlColon, value: ":"})
-			i++
-		case '>', '<':
-			kind := kqlGT
-			if runes[i] == '<' {
-				kind = kqlLT
-			}
-			value := string(runes[i])
-			i++
-			if i < len(runes) && runes[i] == '=' {
-				if kind == kqlGT {
-					kind = kqlGTE
-				} else {
-					kind = kqlLTE
-				}
-				value += "="
-				i++
-			}
-			tokens = append(tokens, kqlToken{kind: kind, value: value})
-		case '"':
-			start := i
-			i++
-			var b strings.Builder
-			closed := false
-			for i < len(runes) {
-				if runes[i] == '\\' && i+1 < len(runes) {
-					i++
-					b.WriteRune(runes[i])
-					i++
-					continue
-				}
-				if runes[i] == '"' {
-					i++
-					closed = true
-					break
-				}
-				b.WriteRune(runes[i])
-				i++
-			}
-			if !closed {
-				return nil, fmt.Errorf("unterminated quoted string at position %d", start)
-			}
-			tokens = append(tokens, kqlToken{kind: kqlString, value: b.String()})
-		default:
-			start := i
-			for i < len(runes) && !unicode.IsSpace(runes[i]) && !strings.ContainsRune("():><\"", runes[i]) {
-				i++
-			}
-			if start == i {
-				return nil, fmt.Errorf("invalid character at position %d", start)
-			}
-			tokens = append(tokens, kqlToken{kind: kqlWord, value: string(runes[start:i])})
-		}
-	}
-	return append(tokens, kqlToken{kind: kqlEOF}), nil
+type kqlNode struct {
+	kind     string
+	field    *kqlToken
+	value    *kqlToken
+	op       kqlTokenKind
+	children []*kqlNode
 }
 
 type kqlParser struct {
-	tokens  []kqlToken
+	input   []rune
 	pos     int
+	token   kqlToken
 	depth   int
 	options KQLOptions
 }
 
-func (p *kqlParser) peek() kqlToken { return p.tokens[p.pos] }
-func (p *kqlParser) take() kqlToken {
-	t := p.peek()
-	if p.pos < len(p.tokens)-1 {
-		p.pos++
-	}
-	return t
-}
-func (p *kqlParser) keyword(word string) bool {
-	t := p.peek()
-	return t.kind == kqlWord && strings.EqualFold(t.value, word)
+func (p *kqlParser) errorf(format string, args ...interface{}) error {
+	return fmt.Errorf(format+" at position %d", append(args, p.token.position)...)
 }
 
-func (p *kqlParser) enterNesting() error {
+// kqlDisplayText restores the wildcard marker so that error messages quote the
+// filter as the user wrote it.
+func kqlDisplayText(text string) string {
+	return strings.ReplaceAll(text, kqlWildcardMarker, "*")
+}
+
+func (p *kqlParser) next() error {
+	space := false
+	for p.pos < len(p.input) && unicode.IsSpace(p.input[p.pos]) {
+		space = true
+		p.pos++
+	}
+	position := p.pos
+	if p.pos == len(p.input) {
+		p.token = kqlToken{kind: kqlEOF, spaceBefore: space, position: position}
+		return nil
+	}
+	r := p.input[p.pos]
+	p.pos++
+	kind := kqlAtom
+	switch r {
+	case '(':
+		kind = kqlLParen
+	case ')':
+		kind = kqlRParen
+	case '{':
+		kind = kqlLBrace
+	case '}':
+		kind = kqlRBrace
+	case ':':
+		kind = kqlColon
+	case '>':
+		kind = kqlGT
+		if p.pos < len(p.input) && p.input[p.pos] == '=' {
+			p.pos++
+			kind = kqlGTE
+		}
+	case '<':
+		kind = kqlLT
+		if p.pos < len(p.input) && p.input[p.pos] == '=' {
+			p.pos++
+			kind = kqlLTE
+		}
+	case '"':
+		value, err := p.readQuoted(position)
+		if err != nil {
+			return err
+		}
+		p.token = kqlToken{kind: kqlAtom, text: value, value: value, quoted: true, spaceBefore: space, position: position}
+		return nil
+	default:
+		p.pos--
+		value, wildcard, err := p.readAtom(position)
+		if err != nil {
+			return err
+		}
+		p.token = kqlToken{kind: kqlAtom, text: value, value: kqlLiteralValue(value, wildcard), wildcard: wildcard, spaceBefore: space, position: position}
+		return nil
+	}
+	p.token = kqlToken{kind: kind, text: string(p.input[position:p.pos]), spaceBefore: space, position: position}
+	return nil
+}
+
+func (p *kqlParser) readQuoted(start int) (string, error) {
+	var b strings.Builder
+	for p.pos < len(p.input) {
+		r := p.input[p.pos]
+		p.pos++
+		if r == '"' {
+			return b.String(), nil
+		}
+		if r == '\\' {
+			escaped, err := p.readEscape(start)
+			if err != nil {
+				return "", err
+			}
+			b.WriteRune(escaped)
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return "", fmt.Errorf("unterminated quoted string at position %d", start)
+}
+
+func (p *kqlParser) readAtom(start int) (string, bool, error) {
+	var b strings.Builder
+	wildcard := false
+	for p.pos < len(p.input) {
+		r := p.input[p.pos]
+		if unicode.IsSpace(r) || strings.ContainsRune("():><\"{}", r) {
+			break
+		}
+		p.pos++
+		if r == '\\' {
+			escaped, err := p.readEscape(start)
+			if err != nil {
+				return "", false, err
+			}
+			b.WriteRune(escaped)
+			continue
+		}
+		if r == '*' {
+			wildcard = true
+			b.WriteString(kqlWildcardMarker)
+			continue
+		}
+		b.WriteRune(r)
+	}
+	if b.Len() == 0 {
+		return "", false, fmt.Errorf("invalid character at position %d", start)
+	}
+	return b.String(), wildcard, nil
+}
+
+func (p *kqlParser) readEscape(start int) (rune, error) {
+	if p.pos >= len(p.input) {
+		return 0, fmt.Errorf("unterminated escape at position %d", start)
+	}
+	r := p.input[p.pos]
+	p.pos++
+	switch r {
+	case 't':
+		return '\t', nil
+	case 'r':
+		return '\r', nil
+	case 'n':
+		return '\n', nil
+	case 'u':
+		if p.pos+4 > len(p.input) {
+			return 0, fmt.Errorf("invalid unicode escape at position %d", start)
+		}
+		var value rune
+		for _, hex := range p.input[p.pos : p.pos+4] {
+			value <<= 4
+			switch {
+			case hex >= '0' && hex <= '9':
+				value += hex - '0'
+			case hex >= 'a' && hex <= 'f':
+				value += hex - 'a' + 10
+			case hex >= 'A' && hex <= 'F':
+				value += hex - 'A' + 10
+			default:
+				return 0, fmt.Errorf("invalid unicode escape at position %d", start)
+			}
+		}
+		p.pos += 4
+		return value, nil
+	default:
+		return r, nil
+	}
+}
+
+// kqlLiteralValue keeps numbers as strings, as the frontend grammar does: only
+// true / false / null become typed literals. Elasticsearch parses the string
+// according to the field type, including epoch milliseconds on date fields.
+func kqlLiteralValue(value string, wildcard bool) interface{} {
+	if wildcard {
+		return value
+	}
+	switch value {
+	case "true":
+		return true
+	case "false":
+		return false
+	case "null":
+		return nil
+	default:
+		return value
+	}
+}
+
+func (p *kqlParser) enter() error {
 	if p.depth >= kqlMaxNestingDepth {
-		return fmt.Errorf("KQL nesting exceeds maximum depth %d", kqlMaxNestingDepth)
+		return p.errorf("KQL nesting exceeds maximum depth %d", kqlMaxNestingDepth)
 	}
 	p.depth++
 	return nil
 }
-
-func (p *kqlParser) leaveNesting() {
-	p.depth--
+func (p *kqlParser) leave()      { p.depth-- }
+func (p *kqlParser) take() error { return p.next() }
+func (p *kqlParser) keyword(word string) bool {
+	return p.token.kind == kqlAtom && !p.token.quoted && !p.token.wildcard && strings.EqualFold(p.token.text, word)
 }
 
-func (p *kqlParser) parseOr(defaultField string) (map[string]interface{}, error) {
+func (p *kqlParser) parseExpression(defaultField string) (*kqlNode, error) {
+	return p.parseOr(defaultField)
+}
+func (p *kqlParser) parseOr(defaultField string) (*kqlNode, error) {
 	left, err := p.parseAnd(defaultField)
 	if err != nil {
 		return nil, err
 	}
-	values := []interface{}{left}
+	children := []*kqlNode{left}
 	for p.keyword("OR") {
-		p.take()
+		if err := p.take(); err != nil {
+			return nil, err
+		}
 		right, err := p.parseAnd(defaultField)
 		if err != nil {
 			return nil, err
 		}
-		values = append(values, right)
+		children = append(children, right)
 	}
-	if len(values) == 1 {
+	if len(children) == 1 {
 		return left, nil
 	}
-	return map[string]interface{}{"bool": map[string]interface{}{"should": values, "minimum_should_match": 1}}, nil
+	return &kqlNode{kind: "or", children: children}, nil
 }
-
-func (p *kqlParser) parseAnd(defaultField string) (map[string]interface{}, error) {
+func (p *kqlParser) parseAnd(defaultField string) (*kqlNode, error) {
 	left, err := p.parseUnary(defaultField)
 	if err != nil {
 		return nil, err
 	}
-	values := []interface{}{left}
-	for {
-		if p.keyword("AND") {
-			p.take()
-		} else if !p.startsImplicitAnd() {
-			break
+	children := []*kqlNode{left}
+	for p.keyword("AND") {
+		if err := p.take(); err != nil {
+			return nil, err
 		}
 		right, err := p.parseUnary(defaultField)
 		if err != nil {
 			return nil, err
 		}
-		values = append(values, right)
+		children = append(children, right)
 	}
-	if len(values) == 1 {
+	if len(children) == 1 {
 		return left, nil
 	}
-	return map[string]interface{}{"bool": map[string]interface{}{"filter": values}}, nil
+	return &kqlNode{kind: "and", children: children}, nil
 }
-
-func (p *kqlParser) startsImplicitAnd() bool {
-	switch p.peek().kind {
-	case kqlWord:
-		return !p.keyword("OR") && !p.keyword("AND")
-	case kqlString, kqlLParen:
-		return true
-	default:
-		return false
-	}
-}
-
-func (p *kqlParser) parseUnary(defaultField string) (map[string]interface{}, error) {
+func (p *kqlParser) parseUnary(defaultField string) (*kqlNode, error) {
 	if p.keyword("NOT") {
-		p.take()
-		if err := p.enterNesting(); err != nil {
+		if err := p.take(); err != nil {
 			return nil, err
 		}
-		defer p.leaveNesting()
-		q, err := p.parseUnary(defaultField)
+		if err := p.enter(); err != nil {
+			return nil, err
+		}
+		defer p.leave()
+		child, err := p.parseUnary(defaultField)
 		if err != nil {
 			return nil, err
 		}
-		return map[string]interface{}{"bool": map[string]interface{}{"must_not": []interface{}{q}}}, nil
+		return &kqlNode{kind: "not", children: []*kqlNode{child}}, nil
 	}
 	return p.parsePrimary(defaultField)
 }
-
-func (p *kqlParser) parsePrimary(defaultField string) (map[string]interface{}, error) {
-	if p.peek().kind == kqlLParen {
-		p.take()
-		if err := p.enterNesting(); err != nil {
+func (p *kqlParser) parsePrimary(defaultField string) (*kqlNode, error) {
+	if p.token.kind == kqlLParen {
+		if err := p.take(); err != nil {
 			return nil, err
 		}
-		defer p.leaveNesting()
-		q, err := p.parseOr(defaultField)
+		if err := p.enter(); err != nil {
+			return nil, err
+		}
+		defer p.leave()
+		node, err := p.parseExpression(defaultField)
 		if err != nil {
 			return nil, err
 		}
-		if p.take().kind != kqlRParen {
-			return nil, fmt.Errorf("missing closing parenthesis")
+		if p.token.kind != kqlRParen {
+			return nil, p.errorf("missing closing parenthesis")
 		}
-		return q, nil
-	}
-	t := p.take()
-	if t.kind != kqlWord && t.kind != kqlString {
-		return nil, fmt.Errorf("expected KQL term near %q", t.value)
-	}
-	if p.peek().kind == kqlColon {
-		p.take()
-		return p.parseFieldValue(t.value)
-	}
-	if p.peek().kind == kqlGT || p.peek().kind == kqlGTE || p.peek().kind == kqlLT || p.peek().kind == kqlLTE {
-		op := p.take()
-		value := p.take()
-		if value.kind != kqlWord && value.kind != kqlString {
-			return nil, fmt.Errorf("range value is required")
+		if err := p.take(); err != nil {
+			return nil, err
 		}
-		return kqlRange(t.value, op.kind, value.value, value.kind == kqlString, p.options), nil
+		return node, nil
 	}
+	if p.token.kind != kqlAtom {
+		return nil, p.errorf("expected KQL term near %q", kqlDisplayText(p.token.text))
+	}
+	first := p.token
+	if err := p.take(); err != nil {
+		return nil, err
+	}
+	// Parentheses following a field parse values in the field's context. Unlike
+	// a top-level group, they cannot introduce another field clause.
 	if defaultField != "" {
-		return kqlValue(defaultField, t.value, t.kind == kqlString, p.options), nil
-	}
-	return map[string]interface{}{"simple_query_string": map[string]interface{}{"query": t.value, "default_operator": "and"}}, nil
-}
-
-func (p *kqlParser) parseFieldValue(field string) (map[string]interface{}, error) {
-	if p.peek().kind == kqlLParen {
-		p.take()
-		if err := p.enterNesting(); err != nil {
-			return nil, err
-		}
-		defer p.leaveNesting()
-		q, err := p.parseOr(field)
+		value, err := p.parseLiteralTail(first)
 		if err != nil {
 			return nil, err
 		}
-		if p.take().kind != kqlRParen {
-			return nil, fmt.Errorf("missing closing parenthesis")
+		field := kqlToken{
+			kind:     kqlAtom,
+			text:     defaultField,
+			value:    defaultField,
+			wildcard: strings.Contains(defaultField, kqlWildcardMarker),
 		}
-		return q, nil
+		return &kqlNode{kind: "is", field: &field, value: value}, nil
 	}
-	t := p.take()
-	if t.kind == kqlWord && t.value == "*" {
-		return map[string]interface{}{"exists": map[string]interface{}{"field": field}}, nil
-	}
-	if t.kind != kqlWord && t.kind != kqlString {
-		return nil, fmt.Errorf("value is required for field %s", field)
-	}
-	// KQL users commonly type an unquoted multi-word value. Keep consuming
-	// value words until a boolean operator, a grouping boundary, or the start
-	// of a new field clause. This compiles to a full-text match below instead
-	// of producing a dangling token / INVALID_QUERY response.
-	values := []string{t.value}
-	for t.kind == kqlWord && p.canConsumeFieldValueWord() {
-		values = append(values, p.take().value)
-	}
-	value := strings.Join(values, " ")
-	if t.kind == kqlWord && strings.Contains(value, "/") {
-		return nil, fmt.Errorf("unquoted / is not supported in KQL values")
-	}
-	return kqlValue(field, value, t.kind == kqlString, p.options), nil
-}
-
-func (p *kqlParser) canConsumeFieldValueWord() bool {
-	return p.peek().kind == kqlWord &&
-		!p.keyword("AND") &&
-		!p.keyword("OR") &&
-		!p.keyword("NOT") &&
-		!p.nextStartsFieldClause()
-}
-
-func (p *kqlParser) nextStartsFieldClause() bool {
-	return p.pos+1 < len(p.tokens) && (p.tokens[p.pos+1].kind == kqlColon ||
-		p.tokens[p.pos+1].kind == kqlGT || p.tokens[p.pos+1].kind == kqlGTE ||
-		p.tokens[p.pos+1].kind == kqlLT || p.tokens[p.pos+1].kind == kqlLTE)
-}
-
-func kqlValue(field, value string, quoted bool, options KQLOptions) map[string]interface{} {
-	if quoted {
-		return map[string]interface{}{"match_phrase": map[string]interface{}{field: value}}
-	}
-	if strings.Contains(value, "*") {
-		body := map[string]interface{}{"value": value, "case_insensitive": options.CaseInsensitive}
-		if strings.HasSuffix(value, "*") && !strings.Contains(value[:len(value)-1], "*") {
-			body["value"] = strings.TrimSuffix(value, "*")
-			return map[string]interface{}{"prefix": map[string]interface{}{field: body}}
+	if p.token.kind == kqlColon {
+		if err := p.take(); err != nil {
+			return nil, err
 		}
-		return map[string]interface{}{"wildcard": map[string]interface{}{field: body}}
+		if p.token.kind == kqlLBrace {
+			if err := p.take(); err != nil {
+				return nil, err
+			}
+			if err := p.enter(); err != nil {
+				return nil, err
+			}
+			defer p.leave()
+			child, err := p.parseExpression("")
+			if err != nil {
+				return nil, err
+			}
+			if p.token.kind != kqlRBrace {
+				return nil, p.errorf("missing closing nested scope")
+			}
+			if err := p.take(); err != nil {
+				return nil, err
+			}
+			return &kqlNode{kind: "nested", field: &first, children: []*kqlNode{child}}, nil
+		}
+		return p.parseFieldValue(first)
 	}
-	// Without a mapping, term is incorrect for analyzed text fields. match also
-	// works for keyword and numeric fields and gives the expected full-text KQL
-	// behaviour. case_insensitive is intentionally only emitted for wildcard /
-	// prefix, the ES query types that actually support it.
-	return map[string]interface{}{"match": map[string]interface{}{field: map[string]interface{}{"query": value, "operator": "and"}}}
+	if kqlRangeKey(p.token.kind) != "" {
+		op := p.token.kind
+		if err := p.take(); err != nil {
+			return nil, err
+		}
+		value, err := p.parseLiteral()
+		if err != nil {
+			return nil, err
+		}
+		return &kqlNode{kind: "range", field: &first, value: value, op: op}, nil
+	}
+	value, err := p.parseLiteralTail(first)
+	if err != nil {
+		return nil, err
+	}
+	return &kqlNode{kind: "is", value: value}, nil
 }
 
-func kqlRange(field string, op kqlTokenKind, value string, quoted bool, options KQLOptions) map[string]interface{} {
-	var key string
-	switch op {
+func (p *kqlParser) parseFieldValue(field kqlToken) (*kqlNode, error) {
+	if p.token.kind == kqlLParen {
+		if err := p.take(); err != nil {
+			return nil, err
+		}
+		if err := p.enter(); err != nil {
+			return nil, err
+		}
+		defer p.leave()
+		node, err := p.parseExpression(field.text)
+		if err != nil {
+			return nil, err
+		}
+		if p.token.kind != kqlRParen {
+			return nil, p.errorf("missing closing parenthesis")
+		}
+		if err := p.take(); err != nil {
+			return nil, err
+		}
+		return node, nil
+	}
+	value, err := p.parseLiteral()
+	if err != nil {
+		return nil, err
+	}
+	return &kqlNode{kind: "is", field: &field, value: value}, nil
+}
+
+func (p *kqlParser) parseLiteral() (*kqlToken, error) {
+	if p.token.kind != kqlAtom {
+		return nil, p.errorf("value is required")
+	}
+	first := p.token
+	if err := p.take(); err != nil {
+		return nil, err
+	}
+	return p.parseLiteralTail(first)
+}
+
+// parseLiteralTail collects an unquoted literal. The frontend grammar treats a
+// space as an ordinary literal character and a wildcard as one more character
+// of the same literal, so `foo bar*` is a single wildcard value rather than two
+// terms. Only a quoted string stands alone.
+func (p *kqlParser) parseLiteralTail(first kqlToken) (*kqlToken, error) {
+	if first.quoted {
+		return &first, nil
+	}
+	parts := []string{first.text}
+	wildcard := first.wildcard
+	for p.token.kind == kqlAtom && p.token.spaceBefore && !p.keyword("AND") && !p.keyword("OR") && !p.keyword("NOT") {
+		if p.token.quoted {
+			break
+		}
+		parts = append(parts, p.token.text)
+		wildcard = wildcard || p.token.wildcard
+		if err := p.take(); err != nil {
+			return nil, err
+		}
+	}
+	if len(parts) > 1 {
+		first.text = strings.Join(parts, " ")
+		first.wildcard = wildcard
+		first.value = kqlLiteralValue(first.text, wildcard)
+	}
+	return &first, nil
+}
+
+func kqlToDSL(node *kqlNode, nestedPath string, options KQLOptions) map[string]interface{} {
+	switch node.kind {
+	case "and":
+		values := make([]interface{}, 0, len(node.children))
+		for _, child := range node.children {
+			values = append(values, kqlToDSL(child, nestedPath, options))
+		}
+		return map[string]interface{}{"bool": map[string]interface{}{"filter": values}}
+	case "or":
+		values := make([]interface{}, 0, len(node.children))
+		for _, child := range node.children {
+			values = append(values, kqlToDSL(child, nestedPath, options))
+		}
+		return map[string]interface{}{"bool": map[string]interface{}{"should": values, "minimum_should_match": 1}}
+	case "not":
+		return map[string]interface{}{"bool": map[string]interface{}{"must_not": kqlToDSL(node.children[0], nestedPath, options)}}
+	case "nested":
+		path := kqlTokenString(node.field)
+		if nestedPath != "" {
+			path = nestedPath + "." + path
+		}
+		return map[string]interface{}{"nested": map[string]interface{}{"path": path, "query": kqlToDSL(node.children[0], path, options), "score_mode": "none"}}
+	case "range":
+		field := kqlFullField(node.field, nestedPath)
+		key := kqlRangeKey(node.op)
+		value := node.value.value
+		// The frontend parser represents unescaped '*' with an internal marker.
+		// Range conversion sends the wildcard text itself to Elasticsearch, rather
+		// than a query_string query, so restore the marker before emitting DSL.
+		if node.value.wildcard {
+			value = strings.ReplaceAll(node.value.text, kqlWildcardMarker, "*")
+		}
+		body := map[string]interface{}{key: value}
+		if options.TimeZone != "" && field == options.dateField {
+			body["time_zone"] = options.TimeZone
+		}
+		return kqlShould(map[string]interface{}{"range": map[string]interface{}{field: body}})
+	case "is":
+		return kqlIsDSL(node, nestedPath)
+	default:
+		return map[string]interface{}{"bool": map[string]interface{}{"filter": []interface{}{}}}
+	}
+}
+func kqlIsDSL(node *kqlNode, nestedPath string) map[string]interface{} {
+	value := node.value
+	if node.field != nil && node.field.wildcard && value.wildcard && kqlIsLoneWildcard(node.field) && kqlIsLoneWildcard(value) {
+		return map[string]interface{}{"match_all": map[string]interface{}{}}
+	}
+	if node.field == nil {
+		if value.wildcard {
+			return map[string]interface{}{"query_string": map[string]interface{}{"query": kqlQueryString(value.text)}}
+		}
+		typeName := "best_fields"
+		if value.quoted {
+			typeName = "phrase"
+		}
+		return map[string]interface{}{"multi_match": map[string]interface{}{"type": typeName, "query": value.value, "lenient": true}}
+	}
+	field := kqlFullField(node.field, nestedPath)
+	if value.wildcard && kqlIsLoneWildcard(value) {
+		return kqlShould(map[string]interface{}{"exists": map[string]interface{}{"field": field}})
+	}
+	var query map[string]interface{}
+	if value.wildcard {
+		query = map[string]interface{}{"query_string": map[string]interface{}{"fields": []string{field}, "query": kqlQueryString(value.text)}}
+	} else if value.quoted {
+		query = map[string]interface{}{"match_phrase": map[string]interface{}{field: value.value}}
+	} else {
+		query = map[string]interface{}{"match": map[string]interface{}{field: value.value}}
+	}
+	return kqlShould(query)
+}
+
+// kqlRangeKey maps a comparison token to its range key, and reports a
+// non-comparison token with an empty string.
+func kqlRangeKey(kind kqlTokenKind) string {
+	switch kind {
 	case kqlGT:
-		key = "gt"
+		return "gt"
 	case kqlGTE:
-		key = "gte"
+		return "gte"
 	case kqlLT:
-		key = "lt"
+		return "lt"
 	case kqlLTE:
-		key = "lte"
+		return "lte"
+	default:
+		return ""
 	}
-	rangeValue := interface{}(value)
-	if !quoted {
-		if integer, err := strconv.ParseInt(value, 10, 64); err == nil {
-			rangeValue = integer
-		} else if number, err := strconv.ParseFloat(value, 64); err == nil && !math.IsNaN(number) && !math.IsInf(number, 0) {
-			rangeValue = number
-		}
+}
+func kqlShould(query map[string]interface{}) map[string]interface{} {
+	return map[string]interface{}{"bool": map[string]interface{}{"should": []interface{}{query}, "minimum_should_match": 1}}
+}
+func kqlTokenString(token *kqlToken) string {
+	if token == nil || token.value == nil {
+		return "null"
 	}
-	body := map[string]interface{}{key: rangeValue}
-	if options.TimeZone != "" && field == options.dateField {
-		body["time_zone"] = options.TimeZone
+	if !token.wildcard {
+		return token.text
 	}
-	return map[string]interface{}{"range": map[string]interface{}{field: body}}
+	return strings.ReplaceAll(token.text, kqlWildcardMarker, "*")
+}
+func kqlFullField(token *kqlToken, nestedPath string) string {
+	field := kqlTokenString(token)
+	if nestedPath != "" {
+		return nestedPath + "." + field
+	}
+	return field
+}
+func kqlIsLoneWildcard(token *kqlToken) bool {
+	return token != nil && token.wildcard && token.text == kqlWildcardMarker
+}
+func kqlHasLeadingWildcard(token *kqlToken) bool {
+	return token != nil && token.wildcard && strings.HasPrefix(token.text, kqlWildcardMarker) && !kqlIsLoneWildcard(token)
+}
+
+// kqlLuceneEscaper escapes the same character class as the frontend's
+// escapeQueryString before the text is handed to query_string.
+var kqlLuceneEscaper = strings.NewReplacer(
+	"\\", "\\\\", "+", "\\+", "-", "\\-", "=", "\\=", "&", "\\&", "|", "\\|",
+	">", "\\>", "<", "\\<", "!", "\\!", "(", "\\(", ")", "\\)", "{", "\\{",
+	"}", "\\}", "[", "\\[", "]", "\\]", "^", "\\^", "\"", "\\\"", "~", "\\~",
+	"*", "\\*", "?", "\\?", ":", "\\:", "/", "\\/")
+
+func kqlQueryString(value string) string {
+	parts := strings.Split(value, kqlWildcardMarker)
+	for i := range parts {
+		parts[i] = kqlLuceneEscaper.Replace(parts[i])
+	}
+	return strings.Join(parts, "*")
 }

--- a/datasource/commons/eslike/kql_test.go
+++ b/datasource/commons/eslike/kql_test.go
@@ -2,96 +2,177 @@ package eslike
 
 import (
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/olivere/elastic/v7"
 )
 
-func TestCompileKQL(t *testing.T) {
-	query, err := CompileKQL(`service.name: api AND log.level: "ERROR" AND http.response.status_code >= 500`, KQLOptions{})
-	if err != nil {
-		t.Fatal(err)
+func TestCompileKQLFrontendCompatibility(t *testing.T) {
+	cases := []struct {
+		filter string
+		want   map[string]interface{}
+	}{
+		{`message: (timeout error)`, should(map[string]interface{}{"match": map[string]interface{}{"message": "timeout error"}})},
+		{`message: "timeout error"`, should(map[string]interface{}{"match_phrase": map[string]interface{}{"message": "timeout error"}})},
+		{`message: foo~2`, should(map[string]interface{}{"match": map[string]interface{}{"message": "foo~2"}})},
+		{`message: /timeout.*/`, should(map[string]interface{}{"query_string": map[string]interface{}{"fields": []string{"message"}, "query": `\/timeout.*\/`}})},
+		{`field.*: logs`, should(map[string]interface{}{"match": map[string]interface{}{"field.*": "logs"}})},
+		{`bytes.* >= 1024`, should(map[string]interface{}{"range": map[string]interface{}{"bytes.*": map[string]interface{}{"gte": "1024"}}})},
+		{`bytes >= *`, should(map[string]interface{}{"range": map[string]interface{}{"bytes": map[string]interface{}{"gte": "*"}}})},
+		{`bytes >= foo*`, should(map[string]interface{}{"range": map[string]interface{}{"bytes": map[string]interface{}{"gte": "foo*"}}})},
+		{`bytes >= *foo`, should(map[string]interface{}{"range": map[string]interface{}{"bytes": map[string]interface{}{"gte": "*foo"}}})},
+		{`trace.id: *`, should(map[string]interface{}{"exists": map[string]interface{}{"field": "trace.id"}})},
+		{`*: (*)`, map[string]interface{}{"match_all": map[string]interface{}{}}},
+		{`field: true`, should(map[string]interface{}{"match": map[string]interface{}{"field": true}})},
+		{`field: null`, should(map[string]interface{}{"match": map[string]interface{}{"field": nil}})},
+		{`field: \u4e2d`, should(map[string]interface{}{"match": map[string]interface{}{"field": "中"}})},
+		{`foo bar`, map[string]interface{}{"multi_match": map[string]interface{}{"type": "best_fields", "query": "foo bar", "lenient": true}}},
+		{`*: *`, map[string]interface{}{"match_all": map[string]interface{}{}}},
+		{`user:{ first: "Alice" AND last: "White" }`, map[string]interface{}{"nested": map[string]interface{}{
+			"path": "user", "score_mode": "none", "query": map[string]interface{}{"bool": map[string]interface{}{"filter": []interface{}{
+				should(map[string]interface{}{"match_phrase": map[string]interface{}{"user.first": "Alice"}}),
+				should(map[string]interface{}{"match_phrase": map[string]interface{}{"user.last": "White"}}),
+			}}},
+		}}},
+		{`a: 1 OR b: 2`, map[string]interface{}{"bool": map[string]interface{}{"should": []interface{}{
+			should(map[string]interface{}{"match": map[string]interface{}{"a": "1"}}),
+			should(map[string]interface{}{"match": map[string]interface{}{"b": "2"}}),
+		}, "minimum_should_match": 1}}},
 	}
-	boolQuery := query["bool"].(map[string]interface{})
-	filters := boolQuery["filter"].([]interface{})
-	if len(filters) != 3 {
-		t.Fatalf("filter count = %d, want 3", len(filters))
-	}
-
-	exists, err := CompileKQL(`trace.id: *`, KQLOptions{})
-	if err != nil || exists["exists"].(map[string]interface{})["field"] != "trace.id" {
-		t.Fatalf("exists query = %#v, err = %v", exists, err)
-	}
-
-	wildcard, err := CompileKQL(`service: api*`, KQLOptions{CaseInsensitive: true})
-	if err != nil {
-		t.Fatal(err)
-	}
-	prefix := wildcard["prefix"].(map[string]interface{})["service"].(map[string]interface{})
-	if prefix["value"] != "api" || prefix["case_insensitive"] != true {
-		t.Fatalf("prefix query = %#v", prefix)
-	}
-}
-
-func TestCompileKQLTextWildcardAndDefaultField(t *testing.T) {
-	text, err := CompileKQL(`message: timeout error`, KQLOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	match := text["match"].(map[string]interface{})["message"].(map[string]interface{})
-	if match["query"] != "timeout error" || match["operator"] != "and" {
-		t.Fatalf("text match = %#v", match)
-	}
-
-	wildcard, err := CompileKQL(`message: *timeout*`, KQLOptions{CaseInsensitive: true})
-	if err != nil {
-		t.Fatal(err)
-	}
-	body := wildcard["wildcard"].(map[string]interface{})["message"].(map[string]interface{})
-	if body["value"] != "*timeout*" || body["case_insensitive"] != true {
-		t.Fatalf("wildcard query = %#v", body)
-	}
-
-	defaultField, err := CompileKQL(`timeout`, KQLOptions{DefaultField: "message"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, ok := defaultField["match"].(map[string]interface{})["message"]; !ok {
-		t.Fatalf("default field query = %#v", defaultField)
+	for _, tc := range cases {
+		got, err := CompileKQL(tc.filter, KQLOptions{})
+		if err != nil {
+			t.Fatalf("%q: %v", tc.filter, err)
+		}
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("%q:\n got: %#v\nwant: %#v", tc.filter, got, tc.want)
+		}
 	}
 }
 
-func TestCompileKQLQuotedWildcardIsLiteralPhrase(t *testing.T) {
-	for _, value := range []string{"foo*", "*"} {
-		query, err := CompileKQL(`message: "`+value+`"`, KQLOptions{})
+func TestCompileKQLLeadingWildcardsAndSyntax(t *testing.T) {
+	for _, filter := range []string{`message: *timeout`, `*timeout`, `message: **`} {
+		if _, err := CompileKQL(filter, KQLOptions{}); err == nil || !strings.Contains(err.Error(), "Leading wildcards") {
+			t.Errorf("%q error = %v, want leading wildcard error", filter, err)
+		}
+	}
+	for _, filter := range []string{`message: *`, `*: *`, `field.*: logs`, `message: foo^2`, `message: [one TO two]`} {
+		if _, err := CompileKQL(filter, KQLOptions{}); err != nil {
+			t.Errorf("%q rejected: %v", filter, err)
+		}
+	}
+	for _, filter := range []string{`status: 200 level: ERROR`, `message: foo NOT bar`, `message: "unterminated`, `a: (b: 1)`} {
+		if _, err := CompileKQL(filter, KQLOptions{}); err == nil {
+			t.Errorf("%q accepted", filter)
+		}
+	}
+}
+
+func TestCompileKQLFieldLeadingWildcardMatchesFrontendDefault(t *testing.T) {
+	for _, filter := range []string{`*: foo`, `*timeout: foo`} {
+		if _, err := CompileKQL(filter, KQLOptions{}); err != nil {
+			t.Errorf("%q rejected: %v", filter, err)
+		}
+	}
+}
+
+func TestCompileKQLWildcardMarkerLiteralFieldDoesNotBecomeWildcard(t *testing.T) {
+	query, err := CompileKQL(`@kuery-wildcard@: foo`, KQLOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	match := query["bool"].(map[string]interface{})["should"].([]interface{})[0].(map[string]interface{})["match"].(map[string]interface{})
+	if match[kqlWildcardMarker] != "foo" {
+		t.Fatalf("marker field was changed to a wildcard: %#v", match)
+	}
+}
+
+// This matrix follows Elastic's documented KQL forms and the frontend
+// buildESQueryFromKuery grammar used as this compiler's compatibility target.
+// The cases are kept grouped by grammar production so adding one feature does
+// not silently narrow another production's accepted syntax.
+func TestCompileKQLSyntaxCoverage(t *testing.T) {
+	accepted := map[string][]string{
+		"exists and match": {
+			`http.request.method: *`, `http.request.method: GET`, `null pointer`,
+			`message: null pointer`, `message: "null pointer"`, `enabled: true`,
+			`enabled: false`, `field: null`,
+		},
+		"escaping and literals": {
+			`http.request.referrer: https\://example.com`, `message: foo\*`,
+			`message: "a (quoted): value*"`, `message: \u4e2d`,
+			`message: \t`, `message: \r`, `message: \n`,
+		},
+		"range": {
+			`bytes > 10000`, `bytes >= 10000`, `bytes < 20000`, `bytes <= 20000`,
+			`@timestamp < now-2w`, `ip >= 10.0.0.1`, `bytes >= foo*`,
+			`datastream.* >= logs`,
+		},
+		"wildcards": {
+			`http.response.status_code: 4*`, `message: foo*bar`, `field: *`,
+			`datastream.*: logs`, `*: foo`, `*timeout: foo`, `*:*`,
+		},
+		"boolean and grouping": {
+			`NOT http.request.method: GET`, `a: 1 AND b: 2`, `a: 1 or b: 2`,
+			`(a: 1 AND b: 2) OR (a: 3 AND b: 4)`,
+			`http.request.method: (GET OR POST OR DELETE)`,
+			`message: (timeout error)`, `message: (timeout AND error)`,
+			`message: (NOT timeout)`,
+		},
+		"nested": {
+			`user:{ first: "Alice" AND last: "White" }`,
+			`user.names:{ first: "Alice" AND last: "White" }`,
+			`user:{ names:{ first: Alice AND last: White } }`,
+		},
+	}
+	for group, filters := range accepted {
+		for _, filter := range filters {
+			if _, err := CompileKQL(filter, KQLOptions{}); err != nil {
+				t.Errorf("%s: %q rejected: %v", group, filter, err)
+			}
+		}
+	}
+
+	rejected := []string{
+		`message: *timeout`, `*timeout`, `message: **`, // leading value wildcards
+		`status: 200 level: ERROR`, // no implicit AND in frontend grammar
+		`message: foo NOT bar`,     // NOT is an operator, not a value word
+		`message: "unterminated`, `a: (b: 1)`, `a: 1 AND`,
+		`user:{ first: Alice`, `a: (b OR c`,
+	}
+	for _, filter := range rejected {
+		if _, err := CompileKQL(filter, KQLOptions{}); err == nil {
+			t.Errorf("%q accepted", filter)
+		}
+	}
+}
+
+func TestCompileKQLRangeOperatorsAndEscapesDSL(t *testing.T) {
+	for _, tc := range []struct {
+		filter, operator, value string
+	}{
+		{`bytes > 1`, "gt", "1"}, {`bytes >= 1`, "gte", "1"},
+		{`bytes < 1`, "lt", "1"}, {`bytes <= 1`, "lte", "1"},
+	} {
+		query, err := CompileKQL(tc.filter, KQLOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
-		phrase, ok := query["match_phrase"].(map[string]interface{})
-		if !ok || phrase["message"] != value {
-			t.Fatalf("quoted wildcard %q query = %#v", value, query)
+		body := query["bool"].(map[string]interface{})["should"].([]interface{})[0].(map[string]interface{})["range"].(map[string]interface{})["bytes"].(map[string]interface{})
+		if len(body) != 1 || body[tc.operator] != tc.value {
+			t.Errorf("%q range = %#v", tc.filter, body)
 		}
 	}
-}
 
-func TestCompileKQLRejectsSlashInAnyUnquotedValueWord(t *testing.T) {
-	if _, err := CompileKQL(`message: timeout /foo`, KQLOptions{}); err == nil {
-		t.Fatal("expected slash in a later unquoted value word to fail")
-	}
-	if _, err := CompileKQL(`message: "timeout /foo"`, KQLOptions{}); err != nil {
-		t.Fatalf("quoted slash should be accepted: %v", err)
-	}
-}
-
-func TestCompileKQLHandlesUnicodeInput(t *testing.T) {
-	query, err := CompileKQL("message:\u3000服务 超时", KQLOptions{})
+	query, err := CompileKQL(`http.request.referrer: https\://example.com`, KQLOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	match := query["match"].(map[string]interface{})["message"].(map[string]interface{})
-	if match["query"] != "服务 超时" {
-		t.Fatalf("unicode match = %#v", match)
+	match := query["bool"].(map[string]interface{})["should"].([]interface{})[0].(map[string]interface{})["match"].(map[string]interface{})
+	if match["http.request.referrer"] != "https://example.com" {
+		t.Fatalf("escaped URL match = %#v", match)
 	}
 }
 
@@ -111,137 +192,8 @@ func TestGetFilterQueryKQLIncludesTimeRange(t *testing.T) {
 	}
 }
 
-func TestGetFilterQueryKQLRejectsEmptyFilter(t *testing.T) {
-	_, err := GetFilterQuery(&Query{FilterLanguage: "kql", Filter: "  "}, elastic.NewRangeQuery("@timestamp"))
-	if err == nil {
-		t.Fatal("expected empty KQL filter to fail")
-	}
-}
-
-func TestCompileKQLTimeZoneOnlyForDateField(t *testing.T) {
-	options := KQLOptions{TimeZone: "+08:00", dateField: "@timestamp"}
-	numeric, err := CompileKQL(`bytes >= 1024`, options)
-	if err != nil {
-		t.Fatal(err)
-	}
-	numericRange := numeric["range"].(map[string]interface{})["bytes"].(map[string]interface{})
-	if _, ok := numericRange["time_zone"]; ok {
-		t.Fatalf("numeric range must not contain time_zone: %#v", numericRange)
-	}
-
-	date, err := CompileKQL(`@timestamp >= "2026-07-29T00:00:00"`, options)
-	if err != nil {
-		t.Fatal(err)
-	}
-	dateRange := date["range"].(map[string]interface{})["@timestamp"].(map[string]interface{})
-	if dateRange["time_zone"] != "+08:00" {
-		t.Fatalf("date range = %#v", dateRange)
-	}
-}
-
-func TestCompileKQLRangePreservesNumericType(t *testing.T) {
-	query, err := CompileKQL(`bytes >= 1024`, KQLOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	body := query["range"].(map[string]interface{})["bytes"].(map[string]interface{})
-	if value, ok := body["gte"].(int64); !ok || value != 1024 {
-		t.Fatalf("integer range value = %#v (%T)", body["gte"], body["gte"])
-	}
-
-	query, err = CompileKQL(`ratio < 1.5`, KQLOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	body = query["range"].(map[string]interface{})["ratio"].(map[string]interface{})
-	if value, ok := body["lt"].(float64); !ok || value != 1.5 {
-		t.Fatalf("float range value = %#v (%T)", body["lt"], body["lt"])
-	}
-
-	query, err = CompileKQL(`@timestamp >= "1700000000"`, KQLOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	body = query["range"].(map[string]interface{})["@timestamp"].(map[string]interface{})
-	if value, ok := body["gte"].(string); !ok || value != "1700000000" {
-		t.Fatalf("quoted numeric range value = %#v (%T)", body["gte"], body["gte"])
-	}
-
-	query, err = CompileKQL(`@timestamp >= 1700000000`,
-		KQLOptions{TimeZone: "+08:00", dateField: "@timestamp"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	body = query["range"].(map[string]interface{})["@timestamp"].(map[string]interface{})
-	if _, ok := body["gte"].(int64); !ok || body["time_zone"] != "+08:00" {
-		t.Fatalf("numeric date range = %#v", body)
-	}
-}
-
-func TestCompileKQLReportsLexerErrors(t *testing.T) {
-	_, err := CompileKQL(`message: "unterminated`, KQLOptions{})
-	if err == nil || !strings.Contains(err.Error(), "unterminated quoted string") {
-		t.Fatalf("lexer error = %v", err)
-	}
-}
-
-func TestCompileKQLRejectsExcessiveNesting(t *testing.T) {
-	input := strings.Repeat("(", kqlMaxNestingDepth+1) + "a: 1" +
-		strings.Repeat(")", kqlMaxNestingDepth+1)
-	_, err := CompileKQL(input, KQLOptions{})
-	if err == nil || !strings.Contains(err.Error(), "maximum depth") {
-		t.Fatalf("nesting error = %v", err)
-	}
-
-	input = strings.Repeat("NOT ", kqlMaxNestingDepth+1) + "a: 1"
-	if _, err := CompileKQL(input, KQLOptions{}); err == nil {
-		t.Fatal("expected excessive unary nesting to fail")
-	}
-}
-
-func TestCompileKQLBooleanComposition(t *testing.T) {
-	orQuery, err := CompileKQL(`a: 1 OR b: 2 OR c: 3`, KQLOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	orBody := orQuery["bool"].(map[string]interface{})
-	if orBody["minimum_should_match"] != 1 || len(orBody["should"].([]interface{})) != 3 {
-		t.Fatalf("OR query = %#v", orQuery)
-	}
-
-	if _, err := CompileKQL(`NOT NOT a: 1`, KQLOptions{}); err != nil {
-		t.Fatalf("double NOT rejected: %v", err)
-	}
-	if _, err := CompileKQL(`(a: 1 OR (b: 2 AND c: 3))`, KQLOptions{}); err != nil {
-		t.Fatalf("nested boolean expression rejected: %v", err)
-	}
-}
-
-func TestCompileKQLImplicitAnd(t *testing.T) {
-	query, err := CompileKQL(`status: 200 level: ERROR service: api`, KQLOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	filters := query["bool"].(map[string]interface{})["filter"].([]interface{})
-	if len(filters) != 3 {
-		t.Fatalf("implicit AND filters = %#v", filters)
-	}
-
-	query, err = CompileKQL(`status: 200 NOT level: DEBUG`, KQLOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	filters = query["bool"].(map[string]interface{})["filter"].([]interface{})
-	if len(filters) != 2 {
-		t.Fatalf("implicit AND NOT filters = %#v", filters)
-	}
-	if _, ok := filters[1].(map[string]interface{})["bool"]; !ok {
-		t.Fatalf("implicit NOT query = %#v", filters[1])
-	}
-}
-
 func TestGetFilterQueryLuceneCompatibility(t *testing.T) {
-	for _, language := range []string{"", "lucene"} {
+	for _, language := range []string{"", "lucene", "LUCENE"} {
 		query, err := GetFilterQuery(&Query{FilterLanguage: language, Filter: `level:ERROR`},
 			elastic.NewRangeQuery("@timestamp").Gte(1000).Lt(2000))
 		if err != nil {
@@ -251,6 +203,9 @@ func TestGetFilterQueryLuceneCompatibility(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		if _, ok := source.(map[string]interface{})["bool"].(map[string]interface{})["filter"]; !ok {
+			t.Fatalf("language %q legacy query changed: %#v", language, source)
+		}
 		encoded, err := json.Marshal(source)
 		if err != nil {
 			t.Fatal(err)
@@ -259,10 +214,108 @@ func TestGetFilterQueryLuceneCompatibility(t *testing.T) {
 			t.Fatalf("language %q no longer uses Lucene query_string: %s", language, encoded)
 		}
 	}
+
+	if _, err := GetFilterQuery(&Query{FilterLanguage: "sql", Filter: `level:ERROR`},
+		elastic.NewRangeQuery("@timestamp")); err == nil {
+		t.Fatal("expected an unsupported filter_language to fail")
+	}
 }
 
-func TestCompileKQLRejectsLuceneOnlySyntax(t *testing.T) {
-	if _, err := CompileKQL(`message:/timeout.*/`, KQLOptions{}); err == nil {
-		t.Fatal("expected regexp syntax to be rejected")
+func TestGetFilterQueryKQLRejectsEmptyFilter(t *testing.T) {
+	for _, filter := range []string{"", "  "} {
+		if _, err := GetFilterQuery(&Query{FilterLanguage: "kql", Filter: filter},
+			elastic.NewRangeQuery("@timestamp")); err == nil {
+			t.Errorf("expected empty KQL filter %q to fail", filter)
+		}
 	}
+}
+
+func TestCompileKQLTimeZoneOnlyForDateField(t *testing.T) {
+	options := KQLOptions{TimeZone: "+08:00", dateField: "@timestamp"}
+	numeric, err := CompileKQL(`bytes >= 1024`, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := kqlRangeBody(t, numeric, "bytes")["time_zone"]; ok {
+		t.Fatalf("numeric range must not carry time_zone: %#v", numeric)
+	}
+
+	date, err := CompileKQL(`@timestamp >= "2026-07-29T00:00:00"`, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if body := kqlRangeBody(t, date, "@timestamp"); body["time_zone"] != "+08:00" {
+		t.Fatalf("date range = %#v", body)
+	}
+
+	withoutZone, err := CompileKQL(`@timestamp >= "2026-07-29T00:00:00"`, KQLOptions{dateField: "@timestamp"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := kqlRangeBody(t, withoutZone, "@timestamp")["time_zone"]; ok {
+		t.Fatalf("range must not carry time_zone when none was requested: %#v", withoutZone)
+	}
+}
+
+func TestCompileKQLNestingDepthLimit(t *testing.T) {
+	deep := map[string]string{
+		"parentheses": strings.Repeat("(", kqlMaxNestingDepth+1) + "a: 1" + strings.Repeat(")", kqlMaxNestingDepth+1),
+		"not":         strings.Repeat("NOT ", kqlMaxNestingDepth+1) + "a: 1",
+		"nested":      strings.Repeat("a:{ ", kqlMaxNestingDepth+1) + "b: 1" + strings.Repeat(" }", kqlMaxNestingDepth+1),
+	}
+	for name, filter := range deep {
+		if _, err := CompileKQL(filter, KQLOptions{}); err == nil || !strings.Contains(err.Error(), "maximum depth") {
+			t.Errorf("%s nesting error = %v, want maximum depth error", name, err)
+		}
+	}
+
+	shallow := strings.Repeat("(", kqlMaxNestingDepth-1) + "a: 1" + strings.Repeat(")", kqlMaxNestingDepth-1)
+	if _, err := CompileKQL(shallow, KQLOptions{}); err != nil {
+		t.Fatalf("nesting below the limit rejected: %v", err)
+	}
+}
+
+func TestCompileKQLMultiWordWildcardValue(t *testing.T) {
+	for _, tc := range []struct{ filter, query string }{
+		{`message: foo bar*`, "foo bar*"},
+		{`message: foo* bar`, "foo* bar"},
+	} {
+		query, err := CompileKQL(tc.filter, KQLOptions{})
+		if err != nil {
+			t.Fatalf("%q: %v", tc.filter, err)
+		}
+		want := should(map[string]interface{}{"query_string": map[string]interface{}{
+			"fields": []string{"message"}, "query": tc.query}})
+		if !reflect.DeepEqual(query, want) {
+			t.Errorf("%q:\n got: %#v\nwant: %#v", tc.filter, query, want)
+		}
+	}
+
+	if _, err := CompileKQL(`message: * foo`, KQLOptions{}); err == nil ||
+		!strings.Contains(err.Error(), "Leading wildcards") {
+		t.Errorf("leading wildcard in a multi-word value = %v", err)
+	}
+}
+
+func TestCompileKQLErrorsQuoteTheOriginalText(t *testing.T) {
+	_, err := CompileKQL(`message: "foo" bar*`, KQLOptions{})
+	if err == nil {
+		t.Fatal("expected a value after a quoted string to fail")
+	}
+	if strings.Contains(err.Error(), kqlWildcardMarker) {
+		t.Fatalf("error leaks the internal wildcard marker: %v", err)
+	}
+	if !strings.Contains(err.Error(), `"bar*"`) {
+		t.Fatalf("error does not quote the original text: %v", err)
+	}
+}
+
+func kqlRangeBody(t *testing.T, query map[string]interface{}, field string) map[string]interface{} {
+	t.Helper()
+	should := query["bool"].(map[string]interface{})["should"].([]interface{})
+	return should[0].(map[string]interface{})["range"].(map[string]interface{})[field].(map[string]interface{})
+}
+
+func should(query map[string]interface{}) map[string]interface{} {
+	return map[string]interface{}{"bool": map[string]interface{}{"should": []interface{}{query}, "minimum_should_match": 1}}
 }

--- a/datasource/commons/eslike/kql_test.go
+++ b/datasource/commons/eslike/kql_test.go
@@ -1,0 +1,268 @@
+package eslike
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/olivere/elastic/v7"
+)
+
+func TestCompileKQL(t *testing.T) {
+	query, err := CompileKQL(`service.name: api AND log.level: "ERROR" AND http.response.status_code >= 500`, KQLOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	boolQuery := query["bool"].(map[string]interface{})
+	filters := boolQuery["filter"].([]interface{})
+	if len(filters) != 3 {
+		t.Fatalf("filter count = %d, want 3", len(filters))
+	}
+
+	exists, err := CompileKQL(`trace.id: *`, KQLOptions{})
+	if err != nil || exists["exists"].(map[string]interface{})["field"] != "trace.id" {
+		t.Fatalf("exists query = %#v, err = %v", exists, err)
+	}
+
+	wildcard, err := CompileKQL(`service: api*`, KQLOptions{CaseInsensitive: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	prefix := wildcard["prefix"].(map[string]interface{})["service"].(map[string]interface{})
+	if prefix["value"] != "api" || prefix["case_insensitive"] != true {
+		t.Fatalf("prefix query = %#v", prefix)
+	}
+}
+
+func TestCompileKQLTextWildcardAndDefaultField(t *testing.T) {
+	text, err := CompileKQL(`message: timeout error`, KQLOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	match := text["match"].(map[string]interface{})["message"].(map[string]interface{})
+	if match["query"] != "timeout error" || match["operator"] != "and" {
+		t.Fatalf("text match = %#v", match)
+	}
+
+	wildcard, err := CompileKQL(`message: *timeout*`, KQLOptions{CaseInsensitive: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := wildcard["wildcard"].(map[string]interface{})["message"].(map[string]interface{})
+	if body["value"] != "*timeout*" || body["case_insensitive"] != true {
+		t.Fatalf("wildcard query = %#v", body)
+	}
+
+	defaultField, err := CompileKQL(`timeout`, KQLOptions{DefaultField: "message"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := defaultField["match"].(map[string]interface{})["message"]; !ok {
+		t.Fatalf("default field query = %#v", defaultField)
+	}
+}
+
+func TestCompileKQLQuotedWildcardIsLiteralPhrase(t *testing.T) {
+	for _, value := range []string{"foo*", "*"} {
+		query, err := CompileKQL(`message: "`+value+`"`, KQLOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		phrase, ok := query["match_phrase"].(map[string]interface{})
+		if !ok || phrase["message"] != value {
+			t.Fatalf("quoted wildcard %q query = %#v", value, query)
+		}
+	}
+}
+
+func TestCompileKQLRejectsSlashInAnyUnquotedValueWord(t *testing.T) {
+	if _, err := CompileKQL(`message: timeout /foo`, KQLOptions{}); err == nil {
+		t.Fatal("expected slash in a later unquoted value word to fail")
+	}
+	if _, err := CompileKQL(`message: "timeout /foo"`, KQLOptions{}); err != nil {
+		t.Fatalf("quoted slash should be accepted: %v", err)
+	}
+}
+
+func TestCompileKQLHandlesUnicodeInput(t *testing.T) {
+	query, err := CompileKQL("message:\u3000服务 超时", KQLOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	match := query["match"].(map[string]interface{})["message"].(map[string]interface{})
+	if match["query"] != "服务 超时" {
+		t.Fatalf("unicode match = %#v", match)
+	}
+}
+
+func TestGetFilterQueryKQLIncludesTimeRange(t *testing.T) {
+	q := elastic.NewRangeQuery("@timestamp").Gte(1000).Lt(2000).Format("epoch_millis")
+	query, err := GetFilterQuery(&Query{FilterLanguage: "kql", Filter: `level: ERROR`}, q)
+	if err != nil {
+		t.Fatal(err)
+	}
+	source, err := query.Source()
+	if err != nil {
+		t.Fatal(err)
+	}
+	filters := source.(map[string]interface{})["bool"].(map[string]interface{})["filter"].([]interface{})
+	if len(filters) != 2 {
+		t.Fatalf("filter count = %d, want 2", len(filters))
+	}
+}
+
+func TestGetFilterQueryKQLRejectsEmptyFilter(t *testing.T) {
+	_, err := GetFilterQuery(&Query{FilterLanguage: "kql", Filter: "  "}, elastic.NewRangeQuery("@timestamp"))
+	if err == nil {
+		t.Fatal("expected empty KQL filter to fail")
+	}
+}
+
+func TestCompileKQLTimeZoneOnlyForDateField(t *testing.T) {
+	options := KQLOptions{TimeZone: "+08:00", dateField: "@timestamp"}
+	numeric, err := CompileKQL(`bytes >= 1024`, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	numericRange := numeric["range"].(map[string]interface{})["bytes"].(map[string]interface{})
+	if _, ok := numericRange["time_zone"]; ok {
+		t.Fatalf("numeric range must not contain time_zone: %#v", numericRange)
+	}
+
+	date, err := CompileKQL(`@timestamp >= "2026-07-29T00:00:00"`, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dateRange := date["range"].(map[string]interface{})["@timestamp"].(map[string]interface{})
+	if dateRange["time_zone"] != "+08:00" {
+		t.Fatalf("date range = %#v", dateRange)
+	}
+}
+
+func TestCompileKQLRangePreservesNumericType(t *testing.T) {
+	query, err := CompileKQL(`bytes >= 1024`, KQLOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := query["range"].(map[string]interface{})["bytes"].(map[string]interface{})
+	if value, ok := body["gte"].(int64); !ok || value != 1024 {
+		t.Fatalf("integer range value = %#v (%T)", body["gte"], body["gte"])
+	}
+
+	query, err = CompileKQL(`ratio < 1.5`, KQLOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body = query["range"].(map[string]interface{})["ratio"].(map[string]interface{})
+	if value, ok := body["lt"].(float64); !ok || value != 1.5 {
+		t.Fatalf("float range value = %#v (%T)", body["lt"], body["lt"])
+	}
+
+	query, err = CompileKQL(`@timestamp >= "1700000000"`, KQLOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body = query["range"].(map[string]interface{})["@timestamp"].(map[string]interface{})
+	if value, ok := body["gte"].(string); !ok || value != "1700000000" {
+		t.Fatalf("quoted numeric range value = %#v (%T)", body["gte"], body["gte"])
+	}
+
+	query, err = CompileKQL(`@timestamp >= 1700000000`,
+		KQLOptions{TimeZone: "+08:00", dateField: "@timestamp"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body = query["range"].(map[string]interface{})["@timestamp"].(map[string]interface{})
+	if _, ok := body["gte"].(int64); !ok || body["time_zone"] != "+08:00" {
+		t.Fatalf("numeric date range = %#v", body)
+	}
+}
+
+func TestCompileKQLReportsLexerErrors(t *testing.T) {
+	_, err := CompileKQL(`message: "unterminated`, KQLOptions{})
+	if err == nil || !strings.Contains(err.Error(), "unterminated quoted string") {
+		t.Fatalf("lexer error = %v", err)
+	}
+}
+
+func TestCompileKQLRejectsExcessiveNesting(t *testing.T) {
+	input := strings.Repeat("(", kqlMaxNestingDepth+1) + "a: 1" +
+		strings.Repeat(")", kqlMaxNestingDepth+1)
+	_, err := CompileKQL(input, KQLOptions{})
+	if err == nil || !strings.Contains(err.Error(), "maximum depth") {
+		t.Fatalf("nesting error = %v", err)
+	}
+
+	input = strings.Repeat("NOT ", kqlMaxNestingDepth+1) + "a: 1"
+	if _, err := CompileKQL(input, KQLOptions{}); err == nil {
+		t.Fatal("expected excessive unary nesting to fail")
+	}
+}
+
+func TestCompileKQLBooleanComposition(t *testing.T) {
+	orQuery, err := CompileKQL(`a: 1 OR b: 2 OR c: 3`, KQLOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	orBody := orQuery["bool"].(map[string]interface{})
+	if orBody["minimum_should_match"] != 1 || len(orBody["should"].([]interface{})) != 3 {
+		t.Fatalf("OR query = %#v", orQuery)
+	}
+
+	if _, err := CompileKQL(`NOT NOT a: 1`, KQLOptions{}); err != nil {
+		t.Fatalf("double NOT rejected: %v", err)
+	}
+	if _, err := CompileKQL(`(a: 1 OR (b: 2 AND c: 3))`, KQLOptions{}); err != nil {
+		t.Fatalf("nested boolean expression rejected: %v", err)
+	}
+}
+
+func TestCompileKQLImplicitAnd(t *testing.T) {
+	query, err := CompileKQL(`status: 200 level: ERROR service: api`, KQLOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	filters := query["bool"].(map[string]interface{})["filter"].([]interface{})
+	if len(filters) != 3 {
+		t.Fatalf("implicit AND filters = %#v", filters)
+	}
+
+	query, err = CompileKQL(`status: 200 NOT level: DEBUG`, KQLOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	filters = query["bool"].(map[string]interface{})["filter"].([]interface{})
+	if len(filters) != 2 {
+		t.Fatalf("implicit AND NOT filters = %#v", filters)
+	}
+	if _, ok := filters[1].(map[string]interface{})["bool"]; !ok {
+		t.Fatalf("implicit NOT query = %#v", filters[1])
+	}
+}
+
+func TestGetFilterQueryLuceneCompatibility(t *testing.T) {
+	for _, language := range []string{"", "lucene"} {
+		query, err := GetFilterQuery(&Query{FilterLanguage: language, Filter: `level:ERROR`},
+			elastic.NewRangeQuery("@timestamp").Gte(1000).Lt(2000))
+		if err != nil {
+			t.Fatal(err)
+		}
+		source, err := query.Source()
+		if err != nil {
+			t.Fatal(err)
+		}
+		encoded, err := json.Marshal(source)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(encoded), "query_string") {
+			t.Fatalf("language %q no longer uses Lucene query_string: %s", language, encoded)
+		}
+	}
+}
+
+func TestCompileKQLRejectsLuceneOnlySyntax(t *testing.T) {
+	if _, err := CompileKQL(`message:/timeout.*/`, KQLOptions{}); err == nil {
+		t.Fatal("expected regexp syntax to be rejected")
+	}
+}

--- a/doc/api/query-batch-v2-kql.md
+++ b/doc/api/query-batch-v2-kql.md
@@ -1,0 +1,112 @@
+# Elasticsearch KQL 查询支持
+
+> 状态：已实现第一阶段 KQL 支持。
+>
+> 本文仅说明 V2 批量查询中 Elasticsearch 的 KQL 扩展；通用 V2 请求、响应与错误码见
+> [`query-batch-v2.md`](./query-batch-v2.md)。
+
+## 使用方式
+
+在 `datasource.cate = "elasticsearch"` 的 query 对象中传入：
+
+```json
+{
+  "filter_language": "kql",
+  "filter": "service.name: api AND log.level: \"ERROR\" AND http.response.status_code >= 500",
+  "kql_options": {
+    "case_insensitive": false,
+    "time_zone": "Asia/Shanghai"
+  }
+}
+```
+
+新增字段：
+
+| 字段 | 类型 | 必填 | 说明 |
+| --- | --- | --- | --- |
+| `filter_language` | string | 否 | 传 `kql` 启用 KQL；未传或 `lucene` 保持旧的 Lucene 行为 |
+| `filter` | string | `filter_language=kql` 时是 | KQL 表达式 |
+| `kql_options.default_field` | string | 否 | 未指定字段的裸词默认查询字段 |
+| `kql_options.case_insensitive` | boolean | 否 | `wildcard` / `prefix` 是否忽略大小写，默认 `false` |
+| `kql_options.time_zone` | string | 否 | 仅对本请求 `date_field` 的范围条件生效；用于日期文字解释时区，如 `Asia/Shanghai` 或 `+08:00` |
+
+顶层 V2 的 `from/to` 仍是权威时间范围；KQL 中的时间条件会与其共同作为 filter 生效。
+
+## 编译方式
+
+KQL 不会直接传给 Lucene `query_string`。后端将 KQL 解析为 AST，再编译为标准
+Elasticsearch Query DSL，最后与 V2 时间范围合并至 `bool.filter`。
+
+这样可避免 KQL 与 Lucene 在范围比较、字段存在、转义和布尔语义上的差异。项目支持 ES
+7.10 及以上版本，因此不能把仅较新 ES 才提供的原生 `kql` Query DSL 作为通用依赖。
+
+## 已支持语法
+
+| KQL | 生成的 DSL | 示例 |
+| --- | --- | --- |
+| 字段匹配 | `match`（`operator: and`） | `status: 200`、`message: timeout error` |
+| 精确短语 | `match_phrase` | `message: "timeout error"` |
+| 字段存在 | `exists` | `trace.id: *` |
+| 后缀通配 | `prefix` | `service: api*` |
+| 其他 `*` 通配 | `wildcard` | `message: *timeout*` |
+| 范围比较 | `range` | `bytes >= 1024`、`@timestamp < now-2d` |
+| 布尔运算 | `bool` | `a: 1 AND b: 2`、`a: 1 b: 2`、`NOT status: 200` |
+| 括号与同字段多值 | `bool.should` | `status: (200 OR 201)` |
+
+`AND`、`OR`、`NOT` 不区分大小写。相邻的字段条件按隐式 `AND` 处理，例如
+`status: 200 level: ERROR` 等价于 `status: 200 AND level: ERROR`。可使用括号明确优先级。
+双引号内的 `*` 是普通字符，例如 `message: "foo*"` 会按短语匹配，不会生成通配查询。
+字段后的多个未加引号词会合并为一个 `match` 查询，例如 `message: timeout error`；
+如需表达多个候选值，应写成 `status: (200 OR 201)`。
+当前编译器不读取 Elasticsearch mapping，因此不会像 Kibana 一样根据 `text` / `keyword`
+字段类型切换查询类型；未加引号且不含通配符的值统一生成 `match`。
+
+## 当前限制
+
+以下语法目前会返回单项 `INVALID_QUERY`，不会降级为 Lucene：
+
+- nested 作用域，例如 `user:{ first: Alice AND last: White }`；
+- 字段名通配符，例如 `datastream.*: logs`；
+- 括号内未使用布尔操作符的多词值，例如 `message: (timeout error)`；请改成
+  `message: timeout error`，或显式写成 `message: (timeout AND error)`；
+- Lucene regexp、fuzzy、proximity、boost 等非 KQL 语法；
+- 未加引号的 `/` 字符。URL 等值请使用引号，例如
+  `http.request.referrer: "https://example.com"`。
+
+前导 `*` 通配可能造成全索引扫描，前端应在输入时给出性能提示。
+KQL 的括号和连续 `NOT` 嵌套最多 64 层。
+
+## 示例
+
+```json
+{
+  "from": 1784971200,
+  "to": 1784974800,
+  "queries": [
+    {
+      "kind": "query",
+      "ref_id": "ES_LOGS",
+      "datasource": {"cate": "elasticsearch", "id": 7},
+      "result_type": "logs",
+      "query": {
+        "index_type": "index",
+        "index": "logs-*",
+        "date_field": "@timestamp",
+        "limit": 100,
+        "ascending": false,
+        "filter_language": "kql",
+        "filter": "service.name: api AND log.level: ERROR AND http.response.status_code >= 500",
+        "kql_options": {"time_zone": "Asia/Shanghai"}
+      }
+    }
+  ]
+}
+```
+
+KQL 查询成功后的日志记录遵循 V2 通用响应；Elasticsearch/OpenSearch 命中的 `_source` 会直接成为
+`records[].fields`，不会返回 `_id`、`_index` 或 `sort`。
+
+## 参考
+
+- [Elastic：KQL 语法](https://www.elastic.co/docs/reference/query-languages/kql)
+- [Elastic：Lucene query_string 语法](https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-query-string-query)

--- a/doc/api/query-batch-v2-kql.md
+++ b/doc/api/query-batch-v2-kql.md
@@ -1,6 +1,6 @@
 # Elasticsearch KQL 查询支持
 
-> 状态：已实现第一阶段 KQL 支持。
+> 状态：与前端 `buildESQueryFromKuery` 的默认转换行为对齐。
 >
 > 本文仅说明 V2 批量查询中 Elasticsearch 的 KQL 扩展；通用 V2 请求、响应与错误码见
 > [`query-batch-v2.md`](./query-batch-v2.md)。
@@ -26,8 +26,8 @@
 | --- | --- | --- | --- |
 | `filter_language` | string | 否 | 传 `kql` 启用 KQL；未传或 `lucene` 保持旧的 Lucene 行为 |
 | `filter` | string | `filter_language=kql` 时是 | KQL 表达式 |
-| `kql_options.default_field` | string | 否 | 未指定字段的裸词默认查询字段 |
-| `kql_options.case_insensitive` | boolean | 否 | `wildcard` / `prefix` 是否忽略大小写，默认 `false` |
+| `kql_options.default_field` | string | 否 | **已忽略**，仅为请求兼容保留；裸词按前端行为查询全字段 |
+| `kql_options.case_insensitive` | boolean | 否 | **已忽略**，仅为请求兼容保留；值通配生成 `query_string`，大小写行为由字段的分析器决定 |
 | `kql_options.time_zone` | string | 否 | 仅对本请求 `date_field` 的范围条件生效；用于日期文字解释时区，如 `Asia/Shanghai` 或 `+08:00` |
 
 顶层 V2 的 `from/to` 仍是权威时间范围；KQL 中的时间条件会与其共同作为 filter 生效。
@@ -44,36 +44,39 @@ Elasticsearch Query DSL，最后与 V2 时间范围合并至 `bool.filter`。
 
 | KQL | 生成的 DSL | 示例 |
 | --- | --- | --- |
-| 字段匹配 | `match`（`operator: and`） | `status: 200`、`message: timeout error` |
+| 字段匹配 | `match` | `status: 200`、`message: timeout error` |
 | 精确短语 | `match_phrase` | `message: "timeout error"` |
 | 字段存在 | `exists` | `trace.id: *` |
-| 后缀通配 | `prefix` | `service: api*` |
-| 其他 `*` 通配 | `wildcard` | `message: *timeout*` |
+| 值通配 | `query_string` | `service: api*` |
+| 字段名通配 | 与前端默认模式相同的字段名 DSL | `datastream.*: logs` |
 | 范围比较 | `range` | `bytes >= 1024`、`@timestamp < now-2d` |
-| 布尔运算 | `bool` | `a: 1 AND b: 2`、`a: 1 b: 2`、`NOT status: 200` |
+| 布尔运算 | `bool` | `a: 1 AND b: 2`、`NOT status: 200` |
 | 括号与同字段多值 | `bool.should` | `status: (200 OR 201)` |
+| nested 作用域 | `nested` | `user:{ first: Alice AND last: White }` |
+| 全量匹配 | `match_all` | `*:*` |
 
-`AND`、`OR`、`NOT` 不区分大小写。相邻的字段条件按隐式 `AND` 处理，例如
-`status: 200 level: ERROR` 等价于 `status: 200 AND level: ERROR`。可使用括号明确优先级。
-双引号内的 `*` 是普通字符，例如 `message: "foo*"` 会按短语匹配，不会生成通配查询。
-字段后的多个未加引号词会合并为一个 `match` 查询，例如 `message: timeout error`；
-如需表达多个候选值，应写成 `status: (200 OR 201)`。
-当前编译器不读取 Elasticsearch mapping，因此不会像 Kibana 一样根据 `text` / `keyword`
-字段类型切换查询类型；未加引号且不含通配符的值统一生成 `match`。
+`AND`、`OR`、`NOT` 不区分大小写，但字段条件之间必须显式使用 `AND` 或 `OR`。
+可使用括号明确优先级；字段后的括号可以容纳多词值，例如
+`message: (timeout error)`。未加引号的多词值中的空格是值的一部分，其中可以带通配符，
+例如 `message: foo bar*` 会整体作为一个通配值下发。双引号内的 `*` 是普通字符，
+例如 `message: "foo*"` 会按短语匹配。未加引号的 `/`、`~`、`^`、`[]` 是普通值内容；
+支持反斜杠转义与 `\t`、`\r`、`\n`、`\uXXXX`。
+
+当前编译器不读取 Elasticsearch mapping，因而严格复现前端默认转换器的无 mapping 分支，
+不会按 `text` / `keyword` 字段类型切换查询类型。
+
+未加引号的值除 `true` / `false` / `null` 外一律按字符串下发，与前端文法一致，
+例如 `bytes >= 1024` 生成 `{"gte": "1024"}`；数值与日期（含 epoch 毫秒）字段由
+Elasticsearch 按 mapping 解析。
+
+字段名通配符（包括 `*: value` 与 `*prefix: value`）会按前端默认转换器原样传入 DSL，
+不会受值通配的前导 `*` 限制。范围值中的通配符同样会原样传递给 `range`；这可能因字段类型
+而被 Elasticsearch 拒绝或得到非预期结果，建议仅在确有兼容需求时使用。
 
 ## 当前限制
 
-以下语法目前会返回单项 `INVALID_QUERY`，不会降级为 Lucene：
-
-- nested 作用域，例如 `user:{ first: Alice AND last: White }`；
-- 字段名通配符，例如 `datastream.*: logs`；
-- 括号内未使用布尔操作符的多词值，例如 `message: (timeout error)`；请改成
-  `message: timeout error`，或显式写成 `message: (timeout AND error)`；
-- Lucene regexp、fuzzy、proximity、boost 等非 KQL 语法；
-- 未加引号的 `/` 字符。URL 等值请使用引号，例如
-  `http.request.referrer: "https://example.com"`。
-
-前导 `*` 通配可能造成全索引扫描，前端应在输入时给出性能提示。
+非单独 `*` 的前导通配默认返回 `INVALID_QUERY`，例如 `message: *timeout` 和 `*timeout`。
+这与前端导出函数的 `allowLeadingWildcards=false` 默认值一致；`field: *` 与 `*:*` 不受此限制。
 KQL 的括号和连续 `NOT` 嵌套最多 64 层。
 
 ## 示例

--- a/doc/api/query-batch-v2.md
+++ b/doc/api/query-batch-v2.md
@@ -1,0 +1,165 @@
+# V2 通用多数据源批量查询接口
+
+Elasticsearch KQL 的支持范围与参数协议见
+[`query-batch-v2-kql.md`](./query-batch-v2-kql.md)。
+
+## Endpoint
+
+```http
+POST /api/n9e/v2/query-batch
+Content-Type: application/json
+```
+
+商业版使用相同协议和接口名，路径为：
+
+```http
+POST /api/n9e-plus/v2/query-batch
+```
+
+接口支持在一次请求中查询多个数据源，并使用表达式组合时序结果。除 Prometheus 的专用
+查询分支外，V2 会按请求中的 `datasource.cate` 和 `datasource.id` 从已初始化的数据源缓存
+取得插件并执行。因此，新注册并完成初始化的数据源不需要额外维护 V2 类型列表；具体查询
+参数及 `logs` / `time_series` 能力仍由对应数据源插件决定。
+
+权限行为与现有查询接口一致：关闭 `AnonymousAccess.PromQuerier` 时，每个数据源查询都会
+执行 `CheckDsPerm`；开启该匿名查询开关时，请求不执行数据源权限检查。该开关是全局查询
+访问策略，不只影响 Prometheus 数据源。
+
+## 请求
+
+```json
+{
+  "from": 1784851200,
+  "to": 1784854800,
+  "queries": [
+    {
+      "kind": "query",
+      "ref_id": "A",
+      "datasource": { "cate": "prometheus", "id": 1 },
+      "result_type": "time_series",
+      "query": {
+        "expr": "rate(http_requests_total[5m])",
+        "instant": false,
+        "step": 15
+      }
+    },
+    {
+      "kind": "query",
+      "ref_id": "B",
+      "datasource": { "cate": "iotdb", "id": 8 },
+      "result_type": "time_series",
+      "query": {
+        "sql": "SELECT time, value, host FROM service_qps",
+        "keys": {
+          "valueKey": "value",
+          "labelKey": "host",
+          "timeKey": "time"
+        }
+      }
+    },
+    {
+      "kind": "expression",
+      "ref_id": "C",
+      "expression": "$A / $B * 100"
+    }
+  ]
+}
+```
+
+约束：
+
+- `to` 必须大于等于 `from`。
+- 顶层 `from/to` 只接受 Unix 时间戳秒，不接受 Unix 毫秒。
+- 单次请求最多包含 100 个 query（包括数据源查询和表达式）。
+- `ref_id` 必须在请求内唯一、区分大小写，并符合
+  `[A-Za-z][A-Za-z0-9_]*`。
+- `kind=query` 时必须提供真实的 `datasource.id`、`result_type` 和对象类型的
+  `query`。`query` 使用对应 Nightingale datasource adapter 的原生结构。
+- `result_type` 只能是 `time_series` 或 `logs`。
+- `kind=expression` 时使用 `$A` 形式引用普通查询或其他表达式；日志不能参与表达式。
+- 表达式匹配会忽略 `__name__`。同一个 Ref 内如果存在多条除 `__name__` 外标签完全
+  相同的序列，它们会落入同一分组，仅最后一条序列参与计算。
+- 单次表达式最多处理 10000 个标签分组和 50000 个时间点，超出时返回
+  `EXPRESSION_LIMIT_EXCEEDED`，避免单个批量请求长期占用 CPU。
+- 当前时序表达式会在每个匹配时间点调用一次表达式解析与计算；较大的时间范围、较小的
+  step 或接近 50000 点上限的请求会增加 CPU 开销。调用方应优先缩小时间范围或增大
+  step。
+- 表达式依赖链最多 64 层，超出时返回 `EXPRESSION_DEPTH_EXCEEDED`。
+- 请求级 `from/to` 是权威时间范围，会覆盖 adapter query 中已有的时间字段。
+
+## 响应
+
+接口使用 Nightingale 通用响应信封。合法的批量请求返回 HTTP 200；单项失败不会中断
+其他查询，结果顺序与请求一致。
+
+```json
+{
+  "dat": {
+    "results": [
+      {
+        "ref_id": "A",
+        "status": "success",
+        "result_type": "time_series",
+        "series": [
+          {
+            "labels": { "instance": "api-1" },
+            "samples": [[1784851200, 12.5]]
+          }
+        ]
+      },
+      {
+        "ref_id": "B",
+        "status": "error",
+        "error": {
+          "code": "DATASOURCE_TIMEOUT",
+          "message": "query timed out",
+          "retryable": true
+        }
+      },
+      {
+        "ref_id": "C",
+        "status": "skipped",
+        "error": {
+          "code": "DEPENDENCY_FAILED",
+          "message": "one or more expression dependencies failed",
+          "retryable": true,
+          "dependency_ref_ids": ["B"]
+        }
+      }
+    ]
+  },
+  "err": "",
+  "request_id": "..."
+}
+```
+
+时序返回 `labels` 和 `[timestamp, value]`。V2 不对 datasource adapter 返回的 sample
+时间戳做二次单位换算：顶层 `from/to` 固定使用 Unix 秒；如果某数据源通过其原生查询参数
+使用毫秒格式，该数据源返回的 sample 也可能是毫秒。当前 V2 请求侧只允许 Unix 秒，因此
+不会由 V2 把毫秒参数传入 adapter。表达式只匹配数值完全相同的时间戳。
+
+日志返回 `records: [{"fields": {...}}]`。空结果是 `success` 状态的空数组。
+
+表达式沿用现有批量查询的数学运算语义：忽略 `__name__` 后标签完全相同的序列相互
+匹配，只计算相同时间戳，标量可广播到序列。表达式按依赖拓扑执行；未知引用、日志
+引用和循环依赖分别返回稳定错误，基础查询失败时下游表达式返回 `skipped`。
+
+## 错误码
+
+| code                       | 说明                   |
+| -------------------------- | ---------------------- |
+| `FORBIDDEN`                | 没有数据源或子资源权限 |
+| `DATASOURCE_NOT_FOUND`     | 数据源不存在或未初始化 |
+| `INVALID_QUERY`            | 数据源查询参数不合法   |
+| `DATASOURCE_TIMEOUT`       | 查询超时或被取消       |
+| `DATASOURCE_ERROR`         | 数据源执行失败         |
+| `EXPRESSION_INVALID`       | 表达式语法不合法       |
+| `EXPRESSION_LIMIT_EXCEEDED` | 表达式分组或点数超限  |
+| `EXPRESSION_DEPTH_EXCEEDED` | 表达式依赖层数超限    |
+| `EXPRESSION_EVALUATION_ERROR` | 表达式运行时求值失败 |
+| `DEPENDENCY_NOT_FOUND`     | 表达式引用未知 RefID   |
+| `DEPENDENCY_TYPE_MISMATCH` | 表达式引用日志结果     |
+| `DEPENDENCY_CYCLE`         | 表达式形成循环依赖     |
+| `DEPENDENCY_FAILED`        | 上游依赖执行失败       |
+
+JSON 结构、时间范围、RefID 或枚举值不合法属于整体请求错误，返回 HTTP 400。


### PR DESCRIPTION
- Add POST /api/n9e/v2/query-batch endpoint that queries multiple datasources in one request and combines time-series results via expressions; reuses initialized datasource plugin cache so newly registered sources need no extra allowlist
- Register route with anonymous-access-aware auth (mirrors existing query-range-batch / query-instant-batch permission behavior)
- Add KQL filter language for Elasticsearch: parse KQL to AST and compile to standard ES Query DSL merged with the v2 time range, instead of passing KQL through Lucene query_string
- Extend eslike.Query with filter_language / kql_options fields and route both QueryData and QueryLog through the new GetFilterQuery, keeping Lucene as the default when filter_language is unset
- Add docs for the v2 batch query protocol and the KQL extension, plus unit tests for the router and KQL parser

**What type of PR is this?**

**What this PR does / why we need it**:
<!--
"Nice to have" "You need it" is not a good reason. :)
-->

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or "Fixes (paste link of issue)"
-->
Fixes #
 
**Special notes for your reviewer**: