### PR TITLE
fix: move primaryKey into gorm tag for InitBoardBusiGroup

### DIFF
--- a/pkg/ormx/database_init.go
+++ b/pkg/ormx/database_init.go
@@ -870,8 +870,8 @@ func (InitPostgresAlertHisEvent) TableName() string {
 }
 
 type InitBoardBusiGroup struct {
-	BusiGroupID int64 `primaryKey;gorm:"not null;default:0;comment:busi group id"`
-	BoardID     int64 `primaryKey;gorm:"not null;default:0;comment:board id"`
+	BusiGroupID int64 `gorm:"primaryKey;not null;default:0;comment:busi group id"`
+	BoardID     int64 `gorm:"primaryKey;not null;default:0;comment:board id"`
 }
 
 func (InitBoardBusiGroup) TableName() string {


### PR DESCRIPTION
The primaryKey annotation was placed outside the gorm struct tag, causing GORM to not recognize the composite primary key. On some MariaDB 10.5 instances this can cause AutoMigrate to skip the board_busigroup table creation, leading to "Error 1146: Table 'docs_session.board_busigroup' doesn't exist" at runtime.

Tested: n9e v9.1.0 on MariaDB 10.5.22.

**What type of PR is this?**

**What this PR does / why we need it**:
<!--
"Nice to have" "You need it" is not a good reason. :)
-->

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or "Fixes (paste link of issue)"
-->
Fixes #
 
**Special notes for your reviewer**: