### PR TITLE
docs: fix broken star history chart links

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Then Nightingale is not suitable. It is recommended that you choose on-call prod
 
 ## 🌟 Stargazers over time
 
-[![Stargazers over time](https://api.star-history.com/svg?repos=ccfos/nightingale&type=Date)](https://star-history.com/#ccfos/nightingale&Date)
+[![Stargazers over time](https://star-history.dera.page/svg?repos=ccfos/nightingale&type=Date)](https://star-history.dera.page/#ccfos/nightingale&Date)
 
 ## 🔥 Users
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -156,7 +156,7 @@
 - 因为夜莺有个业务组的概念，机器可以归属不同的业务组，有时在仪表盘里只想查看当前所属业务组的机器，所以夜莺的仪表盘可以和业务组联动
 
 ## 广受关注
-[![Stargazers over time](https://api.star-history.com/svg?repos=ccfos/nightingale&type=Date)](https://star-history.com/#ccfos/nightingale&Date)
+[![Stargazers over time](https://star-history.dera.page/svg?repos=ccfos/nightingale&type=Date)](https://star-history.dera.page/#ccfos/nightingale&Date)
 
 ## 感谢众多企业的信赖
 


### PR DESCRIPTION
The star history chart in both README.md and README_zh.md is currently broken because the underlying GitHub stargazer API is restricted. Point the chart image and its wrapping link to star-history.dera.page, the new home of the service that uses an alternative data source which requires no API token, so the chart renders correctly again.