### PR TITLE
feat: add assistant chat rename endpoint

### DIFF
--- a/center/router/router.go
+++ b/center/router/router.go
@@ -706,6 +706,7 @@ func (rt *Router) Config(r *gin.Engine) {
 		// AI Assistant Chat
 		pages.POST("/assistant/chat/new", rt.auth(), rt.user(), rt.assistantChatNew)
 		pages.GET("/assistant/chat/history", rt.auth(), rt.user(), rt.assistantChatHistory)
+		pages.POST("/assistant/chat/rename", rt.auth(), rt.user(), rt.assistantChatRename)
 		pages.DELETE("/assistant/chat/:chatId", rt.auth(), rt.user(), rt.assistantChatDel)
 
 		// AI Assistant Message
@@ -943,6 +944,7 @@ func (rt *Router) Config(r *gin.Engine) {
 			// AI Assistant (for external service, reuses frontend handlers via serviceUser middleware)
 			service.POST("/assistant/chat/new", rt.serviceUser(), rt.assistantChatNew)
 			service.GET("/assistant/chat/history", rt.serviceUser(), rt.assistantChatHistory)
+			service.POST("/assistant/chat/rename", rt.serviceUser(), rt.assistantChatRename)
 			service.DELETE("/assistant/chat/:chatId", rt.serviceUser(), rt.assistantChatDel)
 			service.POST("/assistant/message/new", rt.serviceUser(), rt.assistantMessageNew)
 			service.POST("/assistant/message/detail", rt.serviceUser(), rt.assistantMessageDetail)

--- a/center/router/router_ai_assistant.go
+++ b/center/router/router_ai_assistant.go
@@ -103,6 +103,32 @@ func (rt *Router) assistantChatHistory(c *gin.Context) {
 	ginx.NewRender(c).Data(chats, nil)
 }
 
+func (rt *Router) assistantChatRename(c *gin.Context) {
+	var req struct {
+		ChatID string `json:"chat_id"`
+		Title  string `json:"title"`
+	}
+	ginx.BindJSON(c, &req)
+
+	if req.ChatID == "" {
+		ginx.Bomb(http.StatusBadRequest, "chat_id is required")
+		return
+	}
+	if strings.TrimSpace(req.Title) == "" {
+		ginx.Bomb(http.StatusBadRequest, "title is required")
+		return
+	}
+
+	me := c.MustGet("user").(*models.User)
+	chat, err := models.AssistantChatCheckOwner(rt.Ctx, req.ChatID, me.Id)
+	ginx.Dangerous(err)
+
+	chat.Title = req.Title
+	chat.IsRenamed = true
+	ginx.Dangerous(models.AssistantChatSet(rt.Ctx, *chat))
+	ginx.NewRender(c).Data(chat, nil)
+}
+
 func (rt *Router) assistantChatDel(c *gin.Context) {
 	chatID := c.Param("chatId")
 	me := c.MustGet("user").(*models.User)

--- a/center/router/router_ai_assistant_internal.go
+++ b/center/router/router_ai_assistant_internal.go
@@ -171,7 +171,7 @@ func (rt *Router) StartAssistantMessage(userID int64, chat *models.AssistantChat
 		return nil, 0, err
 	}
 
-	if seqID == 1 {
+	if seqID == 1 && !chat.IsRenamed {
 		title := query.Content
 		if runes := []rune(title); len(runes) > 50 {
 			title = string(runes[:50]) + "..."

--- a/center/router/router_ai_assistant_rename_test.go
+++ b/center/router/router_ai_assistant_rename_test.go
@@ -1,0 +1,134 @@
+package router
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ccfos/nightingale/v6/models"
+	"github.com/ccfos/nightingale/v6/pkg/ctx"
+	"github.com/toolkits/pkg/errorx"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	"github.com/gin-gonic/gin"
+)
+
+func setupAssistantChatRenameTest(t *testing.T) (*Router, *ctx.Context) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&models.AssistantChatRow{}); err != nil {
+		t.Fatalf("migrate assistant chat: %v", err)
+	}
+	c := &ctx.Context{DB: db}
+	return &Router{Ctx: c}, c
+}
+
+func callAssistantChatRename(rt *Router, userID int64, body string) (*httptest.ResponseRecorder, any) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/n9e/assistant/chat/rename", bytes.NewBufferString(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Set("user", &models.User{Id: userID})
+
+	var recovered any
+	func() {
+		defer func() { recovered = recover() }()
+		rt.assistantChatRename(c)
+	}()
+	return w, recovered
+}
+
+func TestAssistantChatRename(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rt, c := setupAssistantChatRenameTest(t)
+	chat := models.AssistantChat{
+		ChatID:     "chat-rename",
+		Title:      "New Chat",
+		LastUpdate: 1700000000,
+		UserID:     100,
+		IsNew:      true,
+	}
+	if err := models.AssistantChatSet(c, chat); err != nil {
+		t.Fatalf("seed chat: %v", err)
+	}
+
+	w, recovered := callAssistantChatRename(rt, chat.UserID, `{"chat_id":"chat-rename","title":"生产环境告警排查"}`)
+	if recovered != nil {
+		t.Fatalf("rename panicked: %v", recovered)
+	}
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var response struct {
+		Dat models.AssistantChat `json:"dat"`
+		Err string               `json:"err"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Err != "" || response.Dat.Title != "生产环境告警排查" || !response.Dat.IsRenamed {
+		t.Fatalf("unexpected response: %+v", response)
+	}
+
+	stored, err := models.AssistantChatGet(c, chat.ChatID)
+	if err != nil {
+		t.Fatalf("load renamed chat: %v", err)
+	}
+	if stored.Title != response.Dat.Title || !stored.IsRenamed {
+		t.Fatalf("rename was not persisted: %+v", stored)
+	}
+	if stored.LastUpdate != chat.LastUpdate {
+		t.Fatalf("last_update changed from %d to %d", chat.LastUpdate, stored.LastUpdate)
+	}
+}
+
+func TestAssistantChatRenameRejectsInvalidOrForeignChat(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rt, c := setupAssistantChatRenameTest(t)
+	chat := models.AssistantChat{ChatID: "chat-owned", Title: "Original", UserID: 100}
+	if err := models.AssistantChatSet(c, chat); err != nil {
+		t.Fatalf("seed chat: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name     string
+		user     int64
+		body     string
+		want     string
+		wantCode int
+	}{
+		{name: "blank title", user: 100, body: `{"chat_id":"chat-owned","title":"  "}`, want: "title is required", wantCode: http.StatusBadRequest},
+		{name: "missing chat id", user: 100, body: `{"title":"renamed"}`, want: "chat_id is required", wantCode: http.StatusBadRequest},
+		{name: "foreign chat", user: 101, body: `{"chat_id":"chat-owned","title":"renamed"}`, want: "forbidden", wantCode: http.StatusOK},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, recovered := callAssistantChatRename(rt, tc.user, tc.body)
+			pageErr, ok := recovered.(errorx.PageError)
+			if !ok {
+				t.Fatalf("panic = %#v, want errorx.PageError", recovered)
+			}
+			if pageErr.Code != tc.wantCode {
+				t.Fatalf("status = %d, want %d", pageErr.Code, tc.wantCode)
+			}
+			if pageErr.Message != tc.want {
+				t.Fatalf("message = %q, want %q", pageErr.Message, tc.want)
+			}
+		})
+	}
+
+	stored, err := models.AssistantChatGet(c, chat.ChatID)
+	if err != nil {
+		t.Fatalf("load chat: %v", err)
+	}
+	if stored.Title != chat.Title || stored.IsRenamed {
+		t.Fatalf("invalid rename modified chat: %+v", stored)
+	}
+}

--- a/doc/api/ai-assistant-chat.md
+++ b/doc/api/ai-assistant-chat.md
@@ -1,0 +1,66 @@
+# AI 助手会话接口
+
+本文说明 Nightingale AI 助手会话相关接口。
+
+所有成功响应均使用 Nightingale 标准 JSON 信封：
+
+```json
+{
+  "dat": {},
+  "err": "",
+  "request_id": "..."
+}
+```
+
+## 重命名会话
+
+```text
+POST /api/n9e/assistant/chat/rename
+```
+
+需要登录。调用者只能重命名自己创建的会话。
+
+### 请求体
+
+| 字段 | 类型 | 必填 | 说明 |
+| --- | --- | --- | --- |
+| `chat_id` | string | 是 | 要重命名的会话 ID |
+| `title` | string | 是 | 新标题；不能是空字符串或仅由空白字符组成 |
+
+```json
+{
+  "chat_id": "ad4075b8-ea4e-43d5-954c-71bb951874ca",
+  "title": "生产环境告警排查"
+}
+```
+
+### 响应
+
+成功时，`dat` 是更新后的会话对象：
+
+```json
+{
+  "dat": {
+    "chat_id": "ad4075b8-ea4e-43d5-954c-71bb951874ca",
+    "title": "生产环境告警排查",
+    "last_update": 1730000000,
+    "page_from": {
+      "page": "dashboards"
+    },
+    "user_id": 1,
+    "is_new": false,
+    "is_renamed": true
+  },
+  "err": "",
+  "request_id": "..."
+}
+```
+
+`is_renamed` 表示标题已被用户手动设置。若在发送首条消息前改名，服务端不会再使用首条消息内容自动覆盖该标题。改名本身不会修改 `last_update`，因此不会影响历史会话列表的排序。
+
+### 错误
+
+| HTTP 状态码 | 场景 |
+| --- | --- |
+| 400 | `chat_id` 缺失，或 `title` 为空/仅空白字符 |
+| 200 | 会话不存在或不属于当前用户；按 n9e 通用错误格式在 `err` 中返回错误信息 |

--- a/models/ai_assistant.go
+++ b/models/ai_assistant.go
@@ -9,6 +9,9 @@ type AssistantChat struct {
 	PageFrom   AssistantPageInfo `json:"page_from"`
 	UserID     int64             `json:"user_id"`
 	IsNew      bool              `json:"is_new"`
+	// IsRenamed prevents the first message from replacing a title explicitly
+	// chosen by the user before the message is sent.
+	IsRenamed bool `json:"is_renamed"`
 }
 
 type AssistantPageType string


### PR DESCRIPTION
**What type of PR is this?**

Feature / Enhancement

**What this PR does / why we need it**:

Adds an AI assistant chat rename endpoint:

```text
POST /api/n9e/assistant/chat/rename
```

The endpoint validates the chat owner and non-empty title, persists the renamed title, and returns the updated chat using the standard n9e response envelope.

It also adds an `is_renamed` flag so a user-provided title is preserved when the first message is sent, instead of being replaced by the automatic title derived from that message.

Includes API documentation and tests for successful rename, validation failures, ownership checks, persistence, and chat-history ordering behavior.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

- No database migration is required because chat records are persisted as serialized data.
- The message-history API response format remains unchanged.