### PR TITLE
fix: align alert conversion test with CronPattern scheduling

### DIFF
--- a/models/prom_alert_rule_test.go
+++ b/models/prom_alert_rule_test.go
@@ -22,9 +22,9 @@ func TestConvertAlert(t *testing.T) {
 	}
 	t.Logf("jobMissing: %+v", jobMissing[0])
 	convJobMissing := models.ConvertAlert(jobMissing[0], "30s", []models.DatasourceQuery{}, 0)
-	if convJobMissing.PromEvalInterval != 30 {
-		t.Errorf("PromEvalInterval is expected to be 30, but got %d",
-			convJobMissing.PromEvalInterval)
+	if convJobMissing.CronPattern != "@every 30s" {
+		t.Errorf("CronPattern is expected to be @every 30s, but got %s",
+			convJobMissing.CronPattern)
 	}
 	if convJobMissing.PromForDuration != 60 {
 		t.Errorf("PromForDuration is expected to be 60, but got %d",
@@ -46,16 +46,16 @@ func TestConvertAlert(t *testing.T) {
 `), &ruleEvaluationSlow)
 	t.Logf("ruleEvaluationSlow: %+v", ruleEvaluationSlow[0])
 	convRuleEvaluationSlow := models.ConvertAlert(ruleEvaluationSlow[0], "1m", []models.DatasourceQuery{}, 0)
-	if convRuleEvaluationSlow.PromEvalInterval != 60 {
-		t.Errorf("PromEvalInterval is expected to be 60, but got %d",
-			convJobMissing.PromEvalInterval)
+	if convRuleEvaluationSlow.CronPattern != "@every 60s" {
+		t.Errorf("CronPattern is expected to be @every 60s, but got %s",
+			convRuleEvaluationSlow.CronPattern)
 	}
 	if convRuleEvaluationSlow.PromForDuration != 180 {
 		t.Errorf("PromForDuration is expected to be 180, but got %d",
-			convJobMissing.PromForDuration)
+			convRuleEvaluationSlow.PromForDuration)
 	}
 	if convRuleEvaluationSlow.Severity != 3 {
-		t.Errorf("Severity is expected to be 3, but got %d", convJobMissing.Severity)
+		t.Errorf("Severity is expected to be 3, but got %d", convRuleEvaluationSlow.Severity)
 	}
 
 	targetMissing := []models.PromRule{}
@@ -70,9 +70,9 @@ func TestConvertAlert(t *testing.T) {
 `), &targetMissing)
 	t.Logf("targetMissing: %+v", targetMissing[0])
 	convTargetMissing := models.ConvertAlert(targetMissing[0], "1h", []models.DatasourceQuery{}, 0)
-	if convTargetMissing.PromEvalInterval != 3600 {
-		t.Errorf("PromEvalInterval is expected to be 3600, but got %d",
-			convTargetMissing.PromEvalInterval)
+	if convTargetMissing.CronPattern != "@every 3600s" {
+		t.Errorf("CronPattern is expected to be @every 3600s, but got %s",
+			convTargetMissing.CronPattern)
 	}
 	if convTargetMissing.PromForDuration != 90 {
 		t.Errorf("PromForDuration is expected to be 90, but got %d",

--- a/models/prom_alert_rule_test.go
+++ b/models/prom_alert_rule_test.go
@@ -18,7 +18,7 @@ func TestConvertAlert(t *testing.T) {
       summary: Prometheus job missing (instance {{ $labels.instance }})
       description: "A Prometheus job has disappeared\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"`), &jobMissing)
 	if err != nil {
-		t.Errorf("Failed to Unmarshal, err: %s", err)
+		t.Fatalf("unmarshal PrometheusJobMissing: %v", err)
 	}
 	t.Logf("jobMissing: %+v", jobMissing[0])
 	convJobMissing := models.ConvertAlert(jobMissing[0], "30s", []models.DatasourceQuery{}, 0)
@@ -30,12 +30,12 @@ func TestConvertAlert(t *testing.T) {
 		t.Errorf("PromForDuration is expected to be 60, but got %d",
 			convJobMissing.PromForDuration)
 	}
-	if convJobMissing.Severity != 2 {
-		t.Errorf("Severity is expected to be 2, but got %d", convJobMissing.Severity)
+	if convJobMissing.Severity != models.SeverityWarning {
+		t.Errorf("Severity is expected to be %d, but got %d", models.SeverityWarning, convJobMissing.Severity)
 	}
 
 	ruleEvaluationSlow := []models.PromRule{}
-	yaml.Unmarshal([]byte(`  - alert: PrometheusRuleEvaluationSlow
+	if err := yaml.Unmarshal([]byte(`  - alert: PrometheusRuleEvaluationSlow
     expr: prometheus_rule_group_last_duration_seconds > prometheus_rule_group_interval_seconds
     for: 180s
     labels:
@@ -43,7 +43,9 @@ func TestConvertAlert(t *testing.T) {
     annotations:
       summary: Prometheus rule evaluation slow (instance {{ $labels.instance }})
       description: "Prometheus rule evaluation took more time than the scheduled interval. It indicates a slower storage backend access or too complex query.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
-`), &ruleEvaluationSlow)
+`), &ruleEvaluationSlow); err != nil {
+		t.Fatalf("unmarshal PrometheusRuleEvaluationSlow: %v", err)
+	}
 	t.Logf("ruleEvaluationSlow: %+v", ruleEvaluationSlow[0])
 	convRuleEvaluationSlow := models.ConvertAlert(ruleEvaluationSlow[0], "1m", []models.DatasourceQuery{}, 0)
 	if convRuleEvaluationSlow.CronPattern != "@every 60s" {
@@ -54,12 +56,12 @@ func TestConvertAlert(t *testing.T) {
 		t.Errorf("PromForDuration is expected to be 180, but got %d",
 			convRuleEvaluationSlow.PromForDuration)
 	}
-	if convRuleEvaluationSlow.Severity != 3 {
-		t.Errorf("Severity is expected to be 3, but got %d", convRuleEvaluationSlow.Severity)
+	if convRuleEvaluationSlow.Severity != models.SeverityNotice {
+		t.Errorf("Severity is expected to be %d, but got %d", models.SeverityNotice, convRuleEvaluationSlow.Severity)
 	}
 
 	targetMissing := []models.PromRule{}
-	yaml.Unmarshal([]byte(`  - alert: PrometheusTargetMissing
+	if err := yaml.Unmarshal([]byte(`  - alert: PrometheusTargetMissing
     expr: up == 0
     for: 1.5m
     labels:
@@ -67,7 +69,9 @@ func TestConvertAlert(t *testing.T) {
     annotations:
       summary: Prometheus target missing (instance {{ $labels.instance }})
       description: "A Prometheus target has disappeared. An exporter might be crashed.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
-`), &targetMissing)
+`), &targetMissing); err != nil {
+		t.Fatalf("unmarshal PrometheusTargetMissing: %v", err)
+	}
 	t.Logf("targetMissing: %+v", targetMissing[0])
 	convTargetMissing := models.ConvertAlert(targetMissing[0], "1h", []models.DatasourceQuery{}, 0)
 	if convTargetMissing.CronPattern != "@every 3600s" {
@@ -78,7 +82,7 @@ func TestConvertAlert(t *testing.T) {
 		t.Errorf("PromForDuration is expected to be 90, but got %d",
 			convTargetMissing.PromForDuration)
 	}
-	if convTargetMissing.Severity != 1 {
-		t.Errorf("Severity is expected to be 1, but got %d", convTargetMissing.Severity)
+	if convTargetMissing.Severity != models.SeverityEmergency {
+		t.Errorf("Severity is expected to be %d, but got %d", models.SeverityEmergency, convTargetMissing.Severity)
 	}
 }


### PR DESCRIPTION
ConvertAlert 已经把周期写到 CronPattern，测试还在看 PromEvalInterval，main 上必挂。
顺手把第二组断言从 convJobMissing 改回 convRuleEvaluationSlow。

Fixes #3321