### PR TITLE
fix(ai): preserve empty Claude thinking blocks during tool continuation

### DIFF
--- a/aiagent/llm/claude.go
+++ b/aiagent/llm/claude.go
@@ -95,7 +95,7 @@ type claudeContentBlock struct {
 
 	// 扩展思考块（type=thinking / redacted_thinking）。开启 thinking 后工具
 	// 续轮必须把这些块带签名回填进 assistant 消息（native 下放开 thinking 的前提）。
-	Thinking  string `json:"thinking,omitempty"`
+	Thinking  string `json:"thinking"`
 	Signature string `json:"signature,omitempty"`
 	Data      string `json:"data,omitempty"`
 }

--- a/aiagent/llm/claude.go
+++ b/aiagent/llm/claude.go
@@ -95,9 +95,20 @@ type claudeContentBlock struct {
 
 	// 扩展思考块（type=thinking / redacted_thinking）。开启 thinking 后工具
 	// 续轮必须把这些块带签名回填进 assistant 消息（native 下放开 thinking 的前提）。
-	Thinking  string `json:"thinking"`
+	Thinking  string `json:"thinking,omitempty"`
 	Signature string `json:"signature,omitempty"`
 	Data      string `json:"data,omitempty"`
+}
+
+func (b claudeContentBlock) MarshalJSON() ([]byte, error) {
+	type alias claudeContentBlock
+	if b.Type != "thinking" {
+		return json.Marshal(alias(b))
+	}
+	return json.Marshal(struct {
+		alias
+		Thinking string `json:"thinking"`
+	}{alias: alias(b), Thinking: b.Thinking})
 }
 
 type claudeTool struct {

--- a/aiagent/llm/claude_test.go
+++ b/aiagent/llm/claude_test.go
@@ -63,3 +63,24 @@ func TestClaudeRequest_MarshalNoExtraBody(t *testing.T) {
 		t.Errorf("baseline marshal broke: %s", data)
 	}
 }
+
+// TestClaudeContentBlock_EmptyThinkingKept 空 thinking + signature 回放时
+// 不能被 omitempty 丢掉，否则 Anthropic 续轮 400（#3327）。
+func TestClaudeContentBlock_EmptyThinkingKept(t *testing.T) {
+	block := claudeContentBlock{
+		Type:      "thinking",
+		Thinking:  "",
+		Signature: "sig",
+	}
+	data, err := json.Marshal(block)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	s := string(data)
+	if !strings.Contains(s, `"thinking":""`) {
+		t.Errorf("empty thinking dropped from replay payload: %s", s)
+	}
+	if !strings.Contains(s, `"signature":"sig"`) {
+		t.Errorf("signature missing: %s", s)
+	}
+}

--- a/aiagent/llm/claude_test.go
+++ b/aiagent/llm/claude_test.go
@@ -2,6 +2,7 @@ package llm
 
 import (
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -86,15 +87,31 @@ func TestClaudeContentBlock_EmptyThinkingKept(t *testing.T) {
 }
 
 func TestClaudeContentBlock_ThinkingOmittedFromOtherTypes(t *testing.T) {
-	blocks := []claudeContentBlock{
-		{Type: "text", Text: "hello"},
-		{Type: "tool_use", ID: "call-1", Name: "lookup", Input: map[string]any{}},
-		{Type: "tool_result", ToolUseID: "call-1", Content: "done"},
+	tests := []struct {
+		block claudeContentBlock
+		want  map[string]any
+	}{
+		{
+			block: claudeContentBlock{Type: "text", Text: "hello"},
+			want:  map[string]any{"type": "text", "text": "hello"},
+		},
+		{
+			block: claudeContentBlock{Type: "tool_use", ID: "call-1", Name: "lookup", Input: map[string]any{}},
+			want:  map[string]any{"type": "tool_use", "id": "call-1", "name": "lookup", "input": map[string]any{}},
+		},
+		{
+			block: claudeContentBlock{Type: "tool_result", ToolUseID: "call-1", Content: "done"},
+			want:  map[string]any{"type": "tool_result", "tool_use_id": "call-1", "content": "done"},
+		},
+		{
+			block: claudeContentBlock{Type: "redacted_thinking", Data: "encrypted"},
+			want:  map[string]any{"type": "redacted_thinking", "data": "encrypted"},
+		},
 	}
 
-	for _, block := range blocks {
-		t.Run(block.Type, func(t *testing.T) {
-			data, err := json.Marshal(block)
+	for _, test := range tests {
+		t.Run(test.block.Type, func(t *testing.T) {
+			data, err := json.Marshal(test.block)
 			if err != nil {
 				t.Fatalf("marshal failed: %v", err)
 			}
@@ -102,8 +119,8 @@ func TestClaudeContentBlock_ThinkingOmittedFromOtherTypes(t *testing.T) {
 			if err := json.Unmarshal(data, &payload); err != nil {
 				t.Fatalf("unmarshal back failed: %v", err)
 			}
-			if _, exists := payload["thinking"]; exists {
-				t.Errorf("thinking leaked into %s block: %s", block.Type, data)
+			if !reflect.DeepEqual(payload, test.want) {
+				t.Errorf("payload = %#v, want %#v", payload, test.want)
 			}
 		})
 	}

--- a/aiagent/llm/claude_test.go
+++ b/aiagent/llm/claude_test.go
@@ -17,7 +17,7 @@ func TestClaudeRequest_MarshalExtraBody(t *testing.T) {
 		},
 		extraBody: map[string]any{
 			"thinking": map[string]any{"type": "disabled"},
-			"model":    "evil-override",      // 必须被显式字段挡掉
+			"model":    "evil-override", // 必须被显式字段挡掉
 			"foo":      "bar",
 		},
 	}
@@ -82,5 +82,29 @@ func TestClaudeContentBlock_EmptyThinkingKept(t *testing.T) {
 	}
 	if !strings.Contains(s, `"signature":"sig"`) {
 		t.Errorf("signature missing: %s", s)
+	}
+}
+
+func TestClaudeContentBlock_ThinkingOmittedFromOtherTypes(t *testing.T) {
+	blocks := []claudeContentBlock{
+		{Type: "text", Text: "hello"},
+		{Type: "tool_use", ID: "call-1", Name: "lookup", Input: map[string]any{}},
+		{Type: "tool_result", ToolUseID: "call-1", Content: "done"},
+	}
+
+	for _, block := range blocks {
+		t.Run(block.Type, func(t *testing.T) {
+			data, err := json.Marshal(block)
+			if err != nil {
+				t.Fatalf("marshal failed: %v", err)
+			}
+			var payload map[string]any
+			if err := json.Unmarshal(data, &payload); err != nil {
+				t.Fatalf("unmarshal back failed: %v", err)
+			}
+			if _, exists := payload["thinking"]; exists {
+				t.Errorf("thinking leaked into %s block: %s", block.Type, data)
+			}
+		})
 	}
 }


### PR DESCRIPTION
fixes #3327

claude thinking block with empty text gets omitempty dropped.
tool-continue then 400 because thinking is required.

keep the field even when empty. test covers marshal.