### PR TITLE
fix: allow large victorialogs log entries

### DIFF
--- a/datasource/victorialogs/victorialogs.go
+++ b/datasource/victorialogs/victorialogs.go
@@ -117,6 +117,9 @@ func (vl *VictoriaLogs) Validate(ctx context.Context) error {
 	if vl.MaxQueryRows == 0 {
 		vl.MaxQueryRows = 1000
 	}
+	if vl.MaxLogEntrySize <= 0 {
+		vl.MaxLogEntrySize = victorialogs.DefaultMaxLogEntrySize
+	}
 
 	return nil
 }
@@ -134,6 +137,7 @@ func (vl *VictoriaLogs) Equal(other datasource.Datasource) bool {
 		vl.VictorialogsTls.SkipTlsVerify == o.VictorialogsTls.SkipTlsVerify &&
 		vl.Timeout == o.Timeout &&
 		vl.MaxQueryRows == o.MaxQueryRows &&
+		vl.MaxLogEntrySize == o.MaxLogEntrySize &&
 		vl.EnableWrite == o.EnableWrite &&
 		reflect.DeepEqual(vl.Headers, o.Headers) &&
 		reflect.DeepEqual(vl.WriteAddrs, o.WriteAddrs)

--- a/datasource/victorialogs/victorialogs_test.go
+++ b/datasource/victorialogs/victorialogs_test.go
@@ -86,6 +86,24 @@ func TestResolveLogTimeDesc(t *testing.T) {
 	}
 }
 
+func TestVictoriaLogsValidateDefaultsMaxLogEntrySize(t *testing.T) {
+	vl := &VictoriaLogs{VictoriaLogs: vlkit.VictoriaLogs{VictorialogsAddr: "http://victorialogs.example"}}
+	if err := vl.Validate(context.Background()); err != nil {
+		t.Fatalf("Validate error: %v", err)
+	}
+	if vl.MaxLogEntrySize != vlkit.DefaultMaxLogEntrySize {
+		t.Fatalf("unexpected default max log entry size: got %d want %d", vl.MaxLogEntrySize, vlkit.DefaultMaxLogEntrySize)
+	}
+}
+
+func TestVictoriaLogsEqualIncludesMaxLogEntrySize(t *testing.T) {
+	left := &VictoriaLogs{VictoriaLogs: vlkit.VictoriaLogs{MaxLogEntrySize: 1024}}
+	right := &VictoriaLogs{VictoriaLogs: vlkit.VictoriaLogs{MaxLogEntrySize: 2048}}
+	if left.Equal(right) {
+		t.Fatal("datasources with different max log entry sizes must not be equal")
+	}
+}
+
 func TestQueryLogAddsSort(t *testing.T) {
 	var queryQuery string
 	var hitsQuery string

--- a/dskit/victorialogs/victorialogs.go
+++ b/dskit/victorialogs/victorialogs.go
@@ -16,6 +16,8 @@ import (
 	dskittypes "github.com/ccfos/nightingale/v6/dskit/types"
 )
 
+const DefaultMaxLogEntrySize = 1024 * 1024
+
 type VictoriaLogs struct {
 	VictorialogsAddr  string `json:"victorialogs.addr" mapstructure:"victorialogs.addr"`
 	VictorialogsBasic struct {
@@ -26,12 +28,13 @@ type VictoriaLogs struct {
 	VictorialogsTls struct {
 		SkipTlsVerify bool `json:"victorialogs.tls.skip_tls_verify" mapstructure:"victorialogs.tls.skip_tls_verify"`
 	} `json:"victorialogs.tls" mapstructure:"victorialogs.tls"`
-	Headers      map[string]string `json:"victorialogs.headers" mapstructure:"victorialogs.headers"`
-	Timeout      int64             `json:"victorialogs.timeout" mapstructure:"victorialogs.timeout"` // millis
-	ClusterName  string            `json:"victorialogs.cluster_name" mapstructure:"victorialogs.cluster_name"`
-	MaxQueryRows int               `json:"victorialogs.max_query_rows" mapstructure:"victorialogs.max_query_rows"`
-	EnableWrite  bool              `json:"victorialogs.enable_write" mapstructure:"victorialogs.enable_write"`
-	WriteAddrs   []string          `json:"victorialogs.write_addrs" mapstructure:"victorialogs.write_addrs"`
+	Headers         map[string]string `json:"victorialogs.headers" mapstructure:"victorialogs.headers"`
+	Timeout         int64             `json:"victorialogs.timeout" mapstructure:"victorialogs.timeout"` // millis
+	ClusterName     string            `json:"victorialogs.cluster_name" mapstructure:"victorialogs.cluster_name"`
+	MaxQueryRows    int               `json:"victorialogs.max_query_rows" mapstructure:"victorialogs.max_query_rows"`
+	MaxLogEntrySize int               `json:"victorialogs.max_log_entry_size" mapstructure:"victorialogs.max_log_entry_size"`
+	EnableWrite     bool              `json:"victorialogs.enable_write" mapstructure:"victorialogs.enable_write"`
+	WriteAddrs      []string          `json:"victorialogs.write_addrs" mapstructure:"victorialogs.write_addrs"`
 
 	HTTPClient *http.Client `json:"-" mapstructure:"-"`
 }
@@ -143,6 +146,11 @@ func (vl *VictoriaLogs) QueryWithOffset(ctx context.Context, query string, start
 	// VictoriaLogs returns NDJSON format (one JSON object per line)
 	var logs []LogEntry
 	scanner := bufio.NewScanner(strings.NewReader(string(body)))
+	maxLogEntrySize := vl.MaxLogEntrySize
+	if maxLogEntrySize <= 0 {
+		maxLogEntrySize = DefaultMaxLogEntrySize
+	}
+	scanner.Buffer(nil, maxLogEntrySize)
 	for scanner.Scan() {
 		line := scanner.Text()
 		if line == "" {

--- a/dskit/victorialogs/victorialogs_test.go
+++ b/dskit/victorialogs/victorialogs_test.go
@@ -2,6 +2,10 @@ package victorialogs
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -18,6 +22,27 @@ func TestVictoriaLogs_InitHTTPClient(t *testing.T) {
 	}
 	if v.HTTPClient == nil {
 		t.Fatal("HTTPClient should not be nil after initialization")
+	}
+}
+
+func TestVictoriaLogs_QueryAllowsLargeLogEntries(t *testing.T) {
+	largeMessage := strings.Repeat("x", 128*1024)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		fmt.Fprintf(w, `{"_msg":%q}`+"\n", largeMessage)
+	}))
+	defer server.Close()
+
+	vl := VictoriaLogs{VictorialogsAddr: server.URL, HTTPClient: server.Client()}
+	logs, err := vl.Query(context.Background(), "*", 0, 0, 1)
+	if err != nil {
+		t.Fatalf("Query failed for large log entry: %v", err)
+	}
+	if len(logs) != 1 {
+		t.Fatalf("got %d log entries, want 1", len(logs))
+	}
+	if got := logs[0]["_msg"]; got != largeMessage {
+		t.Fatalf("large log message was not preserved")
 	}
 }
 

--- a/dskit/victorialogs/victorialogs_unit_test.go
+++ b/dskit/victorialogs/victorialogs_unit_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -15,11 +16,28 @@ func newTestVictoriaLogs(serverURL string) *VictoriaLogs {
 		VictorialogsAddr: serverURL,
 		Headers:          make(map[string]string),
 		MaxQueryRows:     1000,
+		MaxLogEntrySize:  256 * 1024,
 	}
 	if err := vl.InitHTTPClient(); err != nil {
 		panic(err)
 	}
 	return vl
+}
+
+func TestVictoriaLogsQueryUsesConfiguredLogEntrySize(t *testing.T) {
+	largeMessage := strings.Repeat("x", 128*1024)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{"_msg":%q}`+"\n", largeMessage)
+	}))
+	defer server.Close()
+
+	logs, err := newTestVictoriaLogs(server.URL).Query(context.Background(), "*", 0, 0, 1)
+	if err != nil {
+		t.Fatalf("Query failed for configured log entry size: %v", err)
+	}
+	if len(logs) != 1 {
+		t.Fatalf("got %d log entries, want 1", len(logs))
+	}
 }
 
 func TestVictoriaLogs_QueryWithOffsetAddsOffset(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**
fix

**What this PR does / why we need it**:
Increase the `bufio.Scanner` limit used by the VictoriaLogs NDJSON response parser.

VictoriaLogs log entries containing long multiline Java stack traces can exceed Scanner's default 64 KiB token limit and fail with `bufio.Scanner: token too long`. This change allows log entries up to 1 MiB while preserving the existing line-by-line JSON parsing behavior.

**Which issue(s) this PR fixes**:
Fixes https://github.com/ccfos/nightingale/issues/3324
 
**Special notes for your reviewer**:
Added an `httptest` regression test that returns a 128 KiB log entry and verifies it is parsed successfully.

Verification:
- `go test ./dskit/victorialogs -run 'TestVictoriaLogs_(QueryAllowsLargeLogEntries|InitHTTPClient)' -v`
