### PR TITLE
fix: llm openai url normalize support non /v1 suffix providers (#3339)

### DIFF
--- a/aiagent/llm/openai.go
+++ b/aiagent/llm/openai.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 
 	"github.com/toolkits/pkg/logger"
@@ -37,16 +38,18 @@ func NewOpenAI(cfg *Config, client *http.Client) (*OpenAI, error) {
 	}, nil
 }
 
+// versionSuffixRe 匹配版本号结尾的 base URL path，如 /v1、/api/v3、/api/paas/v4。
+var versionSuffixRe = regexp.MustCompile(`(?i)/v\d+$`)
+
 // NormalizeOpenAIURL 归一化 OpenAI 兼容端点：
-// 用户常见填法包括 `https://host/v1` 或 `https://host/compatible-mode/v1`，
-// 这里自动补 `/chat/completions`，避免漏路径时返回 404。
+// 用户常见填法是版本号结尾的 base URL（如 `https://host/v1`、智谱的 `/api/paas/v4`、
+// 方舟的 `/api/v3`），对这类 URL 自动补 `/chat/completions`，避免漏路径时返回 404。
+// 其余形态视为完整端点原样透传——存量配置里可能是不带标准路径的自定义网关地址，
+// 不能改写；后缀判断基于 parse 后的 path，避免带 query 的完整端点被重复拼路径。
 // 对于已知需要 /v1/chat/completions 路径的提供商（如 DeepSeek），
 // 当用户只填写了根域名时自动补全完整路径。
 func NormalizeOpenAIURL(rawURL string) string {
 	u := strings.TrimRight(rawURL, "/")
-	if strings.HasSuffix(u, "/chat/completions") {
-		return u
-	}
 	// DeepSeek 使用标准 OpenAI 兼容路径，用户填写根域名时自动补全
 	if u == "https://api.deepseek.com" || u == "http://api.deepseek.com" {
 		return u + "/v1/chat/completions"
@@ -54,9 +57,13 @@ func NormalizeOpenAIURL(rawURL string) string {
 
 	parsed, err := url.Parse(u)
 	if err != nil {
-		return rawURL
+		return u
 	}
-	parsed.Path += "/chat/completions"
+	path := strings.TrimRight(parsed.Path, "/")
+	if strings.HasSuffix(path, "/chat/completions") || !versionSuffixRe.MatchString(path) {
+		return u
+	}
+	parsed.Path = path + "/chat/completions"
 	return parsed.String()
 }
 

--- a/aiagent/llm/openai.go
+++ b/aiagent/llm/openai.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/toolkits/pkg/logger"
@@ -46,14 +47,17 @@ func NormalizeOpenAIURL(rawURL string) string {
 	if strings.HasSuffix(u, "/chat/completions") {
 		return u
 	}
-	if strings.HasSuffix(u, "/v1") {
-		return u + "/chat/completions"
-	}
 	// DeepSeek 使用标准 OpenAI 兼容路径，用户填写根域名时自动补全
 	if u == "https://api.deepseek.com" || u == "http://api.deepseek.com" {
 		return u + "/v1/chat/completions"
 	}
-	return u
+
+	parsed, err := url.Parse(u)
+	if err != nil {
+		return rawURL
+	}
+	parsed.Path += "/chat/completions"
+	return parsed.String()
 }
 
 func (o *OpenAI) Name() string {

--- a/aiagent/llm/openai_test.go
+++ b/aiagent/llm/openai_test.go
@@ -9,6 +9,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // runOpenAIStream 把一段 SSE 文本灌进 streamResponse，收齐所有 chunk。
@@ -575,5 +577,37 @@ func TestGenerate_DoesNotRetryUnrelated400(t *testing.T) {
 	}
 	if calls != 1 {
 		t.Errorf("unrelated 400 must not be retried, got %d upstream calls", calls)
+	}
+}
+
+func TestNormalizeOpenAIURL(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		// 标准OpenAI/Ollama场景
+		{name: "ollama v1", input: "http://127.0.0.1:11434/v1", expected: "http://127.0.0.1:11434/v1/chat/completions"},
+		{name: "openai official v1", input: "https://api.openai.com/v1", expected: "https://api.openai.com/v1/chat/completions"},
+
+		// DeepSeek 场景
+		{name: "deepseek bare domain special rule", input: "https://api.deepseek.com", expected: "https://api.deepseek.com/v1/chat/completions"},
+		{name: "deepseek v1 base", input: "https://api.deepseek.com/v1", expected: "https://api.deepseek.com/v1/chat/completions"},
+		{name: "deepseek full url already", input: "https://api.deepseek.com/v1/chat/completions", expected: "https://api.deepseek.com/v1/chat/completions"},
+
+		// 本次修复：国内厂商
+		{name: "zhipu glm v4 base", input: "https://open.bigmodel.cn/api/paas/v4", expected: "https://open.bigmodel.cn/api/paas/v4/chat/completions"},
+		{name: "volc ark v3 base", input: "https://ark.cn-beijing.volces.com/api/v3", expected: "https://ark.cn-beijing.volces.com/api/v3/chat/completions"},
+
+		// 边界场景放最后
+		{name: "trailing slash trim", input: "https://open.bigmodel.cn/api/paas/v4/", expected: "https://open.bigmodel.cn/api/paas/v4/chat/completions"},
+		{name: "already full endpoint", input: "https://demo.test.com/chat/completions", expected: "https://demo.test.com/chat/completions"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			out := NormalizeOpenAIURL(c.input)
+			assert.Equal(t, c.expected, out)
+		})
 	}
 }

--- a/aiagent/llm/openai_test.go
+++ b/aiagent/llm/openai_test.go
@@ -602,6 +602,15 @@ func TestNormalizeOpenAIURL(t *testing.T) {
 		// 边界场景放最后
 		{name: "trailing slash trim", input: "https://open.bigmodel.cn/api/paas/v4/", expected: "https://open.bigmodel.cn/api/paas/v4/chat/completions"},
 		{name: "already full endpoint", input: "https://demo.test.com/chat/completions", expected: "https://demo.test.com/chat/completions"},
+
+		// 带 query 的完整端点（如 Azure 的 api-version）必须原样透传，不能重复拼路径
+		{name: "full endpoint with query passes through", input: "https://res.openai.azure.com/openai/deployments/gpt4/chat/completions?api-version=2024-02-01", expected: "https://res.openai.azure.com/openai/deployments/gpt4/chat/completions?api-version=2024-02-01"},
+		// 非版本号结尾的自定义网关端点原样透传，保证存量配置不被改写
+		{name: "custom gateway endpoint passes through", input: "https://gw.example.com/llm/proxy", expected: "https://gw.example.com/llm/proxy"},
+		// query 参数在补路径后保留
+		{name: "v1 base with query keeps query", input: "https://host.example.com/v1?key=abc", expected: "https://host.example.com/v1/chat/completions?key=abc"},
+		{name: "v1 trailing slash before query", input: "https://host.example.com/v1/?key=abc", expected: "https://host.example.com/v1/chat/completions?key=abc"},
+		{name: "azure v1 endpoint with query", input: "https://res.openai.azure.com/openai/v1?api-version=preview", expected: "https://res.openai.azure.com/openai/v1/chat/completions?api-version=preview"},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
**What type of PR is this?**
bug

**What this PR does / why we need it**:
The original NormalizeOpenAIURL function only automatically appends `/chat/completions` for URLs ending with `/v1`.
Some mainstream service providers including Zhipu GLM v4 and Volc Ark v3 adopt base URLs without the `/v1` suffix.
When users fill in these base URLs, the final request lacks the chat completion path and returns HTTP 404.

This patch removes hard-coded `/v1` suffix check, uses url.Parse to safely append `/chat/completions` for all base URLs.
The special case for DeepSeek root domain `https://api.deepseek.com` is preserved to keep backward compatibility.
If the input URL already contains `/chat/completions`, return it directly to avoid duplicate path segments.

**Which issue(s) this PR fixes**:
Fixes #3339
 
**Special notes for your reviewer**:
1. Keep DeepSeek root domain special logic unchanged to avoid breaking existing configurations.
2. Adopt url.Parse for path concatenation to handle slash edge cases properly.
3. Add corresponding unit test cases for Zhipu GLM and Volc Ark.
4. **No i18n-related files are modified in this PR. Please let maintainers update i18n files uniformly.**  The related code is in `pkg/i18nx/var.go` line `218`.