### PR TITLE
fix: accept UI array-form headers in webhook callback processor

### DIFF
--- a/alert/pipeline/processor/aisummary/ai_summary_test.go
+++ b/alert/pipeline/processor/aisummary/ai_summary_test.go
@@ -134,7 +134,7 @@ func TestAISummaryConfig_Process(t *testing.T) {
 			URL:           srv.URL,
 			Timeout:       30000,
 			SkipSSLVerify: true,
-			Headers: map[string]string{
+			Headers: callback.HTTPHeaders{
 				"Content-Type": "application/json",
 			},
 		},

--- a/alert/pipeline/processor/callback/callback.go
+++ b/alert/pipeline/processor/callback/callback.go
@@ -1,6 +1,7 @@
 package callback
 
 import (
+	"bytes"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
@@ -17,17 +18,56 @@ import (
 	"github.com/toolkits/pkg/logger"
 )
 
+// HTTPHeaders accepts both {"X-Token":"v"} and the UI form [{"key":"X-Token","value":"v"}].
+type HTTPHeaders map[string]string
+
+func (h *HTTPHeaders) UnmarshalJSON(data []byte) error {
+	data = bytes.TrimSpace(data)
+	if len(data) == 0 || string(data) == "null" {
+		return nil
+	}
+
+	switch data[0] {
+	case '{':
+		var asMap map[string]string
+		if err := json.Unmarshal(data, &asMap); err != nil {
+			return err
+		}
+		*h = asMap
+		return nil
+	case '[':
+		var pairs []struct {
+			Key   string `json:"key"`
+			Value string `json:"value"`
+		}
+		if err := json.Unmarshal(data, &pairs); err != nil {
+			return err
+		}
+		out := make(HTTPHeaders, len(pairs))
+		for _, p := range pairs {
+			if p.Key == "" {
+				continue
+			}
+			out[p.Key] = p.Value
+		}
+		*h = out
+		return nil
+	default:
+		return fmt.Errorf("header: expected object or array")
+	}
+}
+
 type HTTPConfig struct {
-	URL           string            `json:"url"`
-	Method        string            `json:"method,omitempty"`
-	Body          string            `json:"body,omitempty"`
-	Headers       map[string]string `json:"header"`
-	AuthUsername  string            `json:"auth_username"`
-	AuthPassword  string            `json:"auth_password"`
-	Timeout       int               `json:"timeout"` // 单位:ms
-	SkipSSLVerify bool              `json:"skip_ssl_verify"`
-	Proxy         string            `json:"proxy"`
-	Client        *http.Client      `json:"-"`
+	URL           string       `json:"url"`
+	Method        string       `json:"method,omitempty"`
+	Body          string       `json:"body,omitempty"`
+	Headers       HTTPHeaders  `json:"header"`
+	AuthUsername  string       `json:"auth_username"`
+	AuthPassword  string       `json:"auth_password"`
+	Timeout       int          `json:"timeout"` // 单位:ms
+	SkipSSLVerify bool         `json:"skip_ssl_verify"`
+	Proxy         string       `json:"proxy"`
+	Client        *http.Client `json:"-"`
 }
 
 // RelabelConfig

--- a/alert/pipeline/processor/callback/callback_test.go
+++ b/alert/pipeline/processor/callback/callback_test.go
@@ -1,0 +1,57 @@
+package callback
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCallbackConfig_Init_headers(t *testing.T) {
+	tests := []struct {
+		name     string
+		settings map[string]any
+		want     map[string]string
+	}{
+		{
+			name: "map headers",
+			settings: map[string]any{
+				"url":    "https://example.com/webhook",
+				"header": map[string]string{"X-Hook-Token": "xxx"},
+			},
+			want: map[string]string{"X-Hook-Token": "xxx"},
+		},
+		{
+			name: "array headers from ui",
+			settings: map[string]any{
+				"url": "https://example.com/webhook",
+				"header": []map[string]string{
+					{"key": "X-Hook-Token", "value": "xxx"},
+					{"key": "X-Request-Id", "value": "abc"},
+				},
+			},
+			want: map[string]string{
+				"X-Hook-Token": "xxx",
+				"X-Request-Id": "abc",
+			},
+		},
+		{
+			name: "empty array headers",
+			settings: map[string]any{
+				"url":    "https://example.com/webhook",
+				"header": []map[string]string{},
+			},
+			want: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, err := (&CallbackConfig{}).Init(tt.settings)
+			require.NoError(t, err)
+			got, ok := p.(*CallbackConfig)
+			require.True(t, ok)
+			assert.Equal(t, tt.want, map[string]string(got.Headers))
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

fix

**What this PR does / why we need it**:

Workflow webhook nodes persist custom headers as `[{"key":"...","value":"..."}]`. `CallbackConfig.HTTPConfig.header` only accepted `map[string]string`, so `Init` failed with `cannot unmarshal array` and the processor never loaded.

Accept both the object form and the UI key/value array.

**Which issue(s) this PR fixes**:

Fixes #3313

**Special notes for your reviewer**:

RED on current main: `TestCallbackConfig_Init_headers/array_headers_from_ui` reproduced `cannot unmarshal array into Go struct field .header of type map[string]string`.

GREEN: `go test ./alert/pipeline/processor/callback/ ./alert/pipeline/processor/aisummary/ -count=1`

Made with [Cursor](https://cursor.com)