### PR TITLE
fix: validate alert rule severity

### DIFF
--- a/center/router/router_alert_rule.go
+++ b/center/router/router_alert_rule.go
@@ -535,7 +535,7 @@ func (rt *Router) alertRulePutFields(c *gin.Context) {
 				ginx.Dangerous(err)
 				candidate := *ar
 				candidate.RuleConfig = string(b)
-				ginx.Dangerous(candidate.ValidateSeverities(), http.StatusBadRequest)
+				ginx.Dangerous(candidate.ValidateRuleConfig(), http.StatusBadRequest)
 				ginx.Dangerous(ar.UpdateFieldsMap(rt.Ctx, map[string]interface{}{"rule_config": string(b)}))
 			}
 

--- a/center/router/router_alert_rule.go
+++ b/center/router/router_alert_rule.go
@@ -533,6 +533,9 @@ func (rt *Router) alertRulePutFields(c *gin.Context) {
 				originRule["triggers"] = triggers
 				b, err := json.Marshal(originRule)
 				ginx.Dangerous(err)
+				candidate := *ar
+				candidate.RuleConfig = string(b)
+				ginx.Dangerous(candidate.ValidateSeverities(), http.StatusBadRequest)
 				ginx.Dangerous(ar.UpdateFieldsMap(rt.Ctx, map[string]interface{}{"rule_config": string(b)}))
 			}
 

--- a/models/alert_rule.go
+++ b/models/alert_rule.go
@@ -569,6 +569,10 @@ func (ar *AlertRule) Verify() error {
 		return errors.New("rule_config is blank")
 	}
 
+	if err := ar.ValidateSeverities(); err != nil {
+		return err
+	}
+
 	if ar.PromEvalInterval <= 0 {
 		ar.PromEvalInterval = 15
 	}
@@ -651,6 +655,92 @@ func (ar *AlertRule) Verify() error {
 		ar.NotifyGroups = ""
 		ar.Callbacks = ""
 		ar.CallbacksJSON = []string{}
+	}
+
+	return nil
+}
+
+type alertRuleSeverityConfig struct {
+	Version  string `json:"version"`
+	Severity *int   `json:"severity"`
+	Queries  []struct {
+		Severity int `json:"severity"`
+	} `json:"queries"`
+	Triggers []struct {
+		Severity int `json:"severity"`
+	} `json:"triggers"`
+	NodataTrigger struct {
+		Enable   bool `json:"enable"`
+		Severity int  `json:"severity"`
+	} `json:"nodata_trigger"`
+	AnomalyTrigger struct {
+		Enable   bool `json:"enable"`
+		Severity int  `json:"severity"`
+	} `json:"anomaly_trigger"`
+}
+
+func validateAlertRuleSeverity(field string, severity int) error {
+	if severity < SeverityEmergency || severity > SeverityNotice {
+		return fmt.Errorf("%s(%d) invalid: severity must be 1, 2 or 3", field, severity)
+	}
+	return nil
+}
+
+// ValidateSeverities checks every severity that can produce an alert event.
+// The top-level AlertRule.Severity and rule_config.severity are legacy shadow
+// fields and may legitimately be zero when a rule uses queries or triggers.
+// Non-zero values in those fields must still be valid severities.
+func (ar *AlertRule) ValidateSeverities() error {
+	if ar.Severity != 0 {
+		if err := validateAlertRuleSeverity("severity", ar.Severity); err != nil {
+			return err
+		}
+	}
+
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(ar.RuleConfig), &object); err != nil {
+		// RuleConfig is intentionally polymorphic. Other validators own its
+		// overall shape; severity validation only applies to JSON objects.
+		return nil
+	}
+
+	var config alertRuleSeverityConfig
+	if err := json.Unmarshal([]byte(ar.RuleConfig), &config); err != nil {
+		return fmt.Errorf("invalid rule_config: %v", err)
+	}
+
+	isPromV1 := (ar.Cate == PROMETHEUS || ar.Cate == LOKI) && config.Version != "v2"
+	legacyConfigSeverityActive := isPromV1 && len(config.Queries) == 0
+	if config.Severity != nil && (legacyConfigSeverityActive || *config.Severity != 0) {
+		if err := validateAlertRuleSeverity("rule_config.severity", *config.Severity); err != nil {
+			return err
+		}
+	}
+
+	if isPromV1 && len(config.Queries) > 0 {
+		for i := range config.Queries {
+			if err := validateAlertRuleSeverity(fmt.Sprintf("rule_config.queries[%d].severity", i), config.Queries[i].Severity); err != nil {
+				return err
+			}
+		}
+	} else if !isPromV1 {
+		for i := range config.Triggers {
+			if err := validateAlertRuleSeverity(fmt.Sprintf("rule_config.triggers[%d].severity", i), config.Triggers[i].Severity); err != nil {
+				return err
+			}
+		}
+	}
+
+	if config.NodataTrigger.Enable {
+		if err := validateAlertRuleSeverity("rule_config.nodata_trigger.severity", config.NodataTrigger.Severity); err != nil {
+			return err
+		}
+	}
+
+	if config.AnomalyTrigger.Enable {
+		if err := validateAlertRuleSeverity("rule_config.anomaly_trigger.severity", config.AnomalyTrigger.Severity); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -853,7 +943,14 @@ func (ar *AlertRule) UpdateColumn(ctx *ctx.Context, column string, value interfa
 	}
 
 	if column == "severity" {
-		severity := int(value.(float64))
+		severityValue, ok := value.(float64)
+		if !ok || severityValue != float64(int(severityValue)) {
+			return fmt.Errorf("severity(%v) invalid: severity must be 1, 2 or 3", value)
+		}
+		severity := int(severityValue)
+		if err := validateAlertRuleSeverity("severity", severity); err != nil {
+			return err
+		}
 		if ar.Cate == PROMETHEUS {
 			var ruleConfig PromRuleConfig
 			err := json.Unmarshal([]byte(ar.RuleConfig), &ruleConfig)

--- a/models/alert_rule.go
+++ b/models/alert_rule.go
@@ -569,7 +569,7 @@ func (ar *AlertRule) Verify() error {
 		return errors.New("rule_config is blank")
 	}
 
-	if err := ar.ValidateSeverities(); err != nil {
+	if err := ar.ValidateRuleConfig(); err != nil {
 		return err
 	}
 
@@ -660,14 +660,17 @@ func (ar *AlertRule) Verify() error {
 	return nil
 }
 
-type alertRuleSeverityConfig struct {
+type alertRuleConfigForVerify struct {
 	Version  string `json:"version"`
 	Severity *int   `json:"severity"`
 	Queries  []struct {
-		Severity int `json:"severity"`
+		PromQl   string `json:"prom_ql"`
+		Severity int    `json:"severity"`
 	} `json:"queries"`
-	Triggers []struct {
-		Severity int `json:"severity"`
+	ExpTriggerDisable bool `json:"exp_trigger_disable"`
+	Triggers          []struct {
+		Exp      string `json:"exp"`
+		Severity int    `json:"severity"`
 	} `json:"triggers"`
 	NodataTrigger struct {
 		Enable   bool `json:"enable"`
@@ -686,11 +689,12 @@ func validateAlertRuleSeverity(field string, severity int) error {
 	return nil
 }
 
-// ValidateSeverities checks every severity that can produce an alert event.
-// The top-level AlertRule.Severity and rule_config.severity are legacy shadow
-// fields and may legitimately be zero when a rule uses queries or triggers.
-// Non-zero values in those fields must still be valid severities.
-func (ar *AlertRule) ValidateSeverities() error {
+// ValidateRuleConfig checks the rule_config fields every alert event depends
+// on: severities must be 1, 2 or 3 and the query/trigger expressions must not
+// be blank. The top-level AlertRule.Severity and rule_config.severity are
+// legacy shadow fields and may legitimately be zero when a rule uses queries
+// or triggers. Non-zero values in those fields must still be valid severities.
+func (ar *AlertRule) ValidateRuleConfig() error {
 	if ar.Severity != 0 {
 		if err := validateAlertRuleSeverity("severity", ar.Severity); err != nil {
 			return err
@@ -700,11 +704,11 @@ func (ar *AlertRule) ValidateSeverities() error {
 	var object map[string]json.RawMessage
 	if err := json.Unmarshal([]byte(ar.RuleConfig), &object); err != nil {
 		// RuleConfig is intentionally polymorphic. Other validators own its
-		// overall shape; severity validation only applies to JSON objects.
+		// overall shape; this validation only applies to JSON objects.
 		return nil
 	}
 
-	var config alertRuleSeverityConfig
+	var config alertRuleConfigForVerify
 	if err := json.Unmarshal([]byte(ar.RuleConfig), &config); err != nil {
 		return fmt.Errorf("invalid rule_config: %v", err)
 	}
@@ -717,14 +721,28 @@ func (ar *AlertRule) ValidateSeverities() error {
 		}
 	}
 
-	if isPromV1 && len(config.Queries) > 0 {
+	// Skip the per-query checks when the anomaly trigger is enabled: legacy
+	// anomaly rules (n9e-plus, prod=anomaly) are migrated into queries that
+	// are algorithm inputs without prom_ql/severity — their event severity
+	// lives in anomaly_trigger and is validated below.
+	if isPromV1 && len(config.Queries) > 0 && !config.AnomalyTrigger.Enable {
 		for i := range config.Queries {
+			if strings.TrimSpace(config.Queries[i].PromQl) == "" {
+				return fmt.Errorf("rule_config.queries[%d].prom_ql is blank", i)
+			}
 			if err := validateAlertRuleSeverity(fmt.Sprintf("rule_config.queries[%d].severity", i), config.Queries[i].Severity); err != nil {
 				return err
 			}
 		}
 	} else if !isPromV1 {
+		// Host rules describe triggers with type/duration/percent instead of
+		// an expression, so the exp requirement only applies to other cates
+		// with threshold conditions enabled.
+		expRequired := ar.Cate != HOST && !config.ExpTriggerDisable
 		for i := range config.Triggers {
+			if expRequired && strings.TrimSpace(config.Triggers[i].Exp) == "" {
+				return fmt.Errorf("rule_config.triggers[%d].exp is blank", i)
+			}
 			if err := validateAlertRuleSeverity(fmt.Sprintf("rule_config.triggers[%d].severity", i), config.Triggers[i].Severity); err != nil {
 				return err
 			}

--- a/models/alert_rule.go
+++ b/models/alert_rule.go
@@ -713,7 +713,11 @@ func (ar *AlertRule) ValidateRuleConfig() error {
 		return fmt.Errorf("invalid rule_config: %v", err)
 	}
 
-	isPromV1 := (ar.Cate == PROMETHEUS || ar.Cate == LOKI) && config.Version != "v2"
+	// Host rules are keyed by prod, not cate: Verify defaults an empty cate to
+	// prometheus and the engine dispatches host rules by prod (GetRuleType), so
+	// classifying by cate alone would validate a host rule as prom v1.
+	isHost := ar.Prod == HOST || ar.Cate == HOST
+	isPromV1 := !isHost && (ar.Cate == PROMETHEUS || ar.Cate == LOKI) && config.Version != "v2"
 	legacyConfigSeverityActive := isPromV1 && len(config.Queries) == 0
 	if config.Severity != nil && (legacyConfigSeverityActive || *config.Severity != 0) {
 		if err := validateAlertRuleSeverity("rule_config.severity", *config.Severity); err != nil {
@@ -738,7 +742,7 @@ func (ar *AlertRule) ValidateRuleConfig() error {
 		// Host rules describe triggers with type/duration/percent instead of
 		// an expression, so the exp requirement only applies to other cates
 		// with threshold conditions enabled.
-		expRequired := ar.Cate != HOST && !config.ExpTriggerDisable
+		expRequired := !isHost && !config.ExpTriggerDisable
 		for i := range config.Triggers {
 			if expRequired && strings.TrimSpace(config.Triggers[i].Exp) == "" {
 				return fmt.Errorf("rule_config.triggers[%d].exp is blank", i)

--- a/models/alert_rule_relabel_test.go
+++ b/models/alert_rule_relabel_test.go
@@ -25,7 +25,7 @@ func TestAlertRuleVerify_EventRelabelConfig(t *testing.T) {
 		wantErr    bool
 	}{
 		{"no rule config", "", false},
-		{"no relabel config", `{"queries":[{"query":"up","ref":"A"}]}`, false},
+		{"no relabel config", `{"queries":[{"query":"up","ref":"A","severity":2}]}`, false},
 		{"null relabel config", `{"event_relabel_config":null}`, false},
 		{"empty relabel config", `{"event_relabel_config":[]}`, false},
 		{"valid relabel config", `{"event_relabel_config":[{"source_labels":["ident","service"],"target_label":"host","action":"replace"}]}`, false},

--- a/models/alert_rule_relabel_test.go
+++ b/models/alert_rule_relabel_test.go
@@ -25,7 +25,7 @@ func TestAlertRuleVerify_EventRelabelConfig(t *testing.T) {
 		wantErr    bool
 	}{
 		{"no rule config", "", false},
-		{"no relabel config", `{"queries":[{"query":"up","ref":"A","severity":2}]}`, false},
+		{"no relabel config", `{"queries":[{"prom_ql":"up","severity":2}]}`, false},
 		{"null relabel config", `{"event_relabel_config":null}`, false},
 		{"empty relabel config", `{"event_relabel_config":[]}`, false},
 		{"valid relabel config", `{"event_relabel_config":[{"source_labels":["ident","service"],"target_label":"host","action":"replace"}]}`, false},

--- a/models/alert_rule_verify_test.go
+++ b/models/alert_rule_verify_test.go
@@ -102,6 +102,38 @@ func TestAlertRuleVerify_RequiredExpressions(t *testing.T) {
 	}
 }
 
+// Host rules are dispatched by prod; the cate may be blank (Verify then defaults
+// it to prometheus) or stale, and neither must route them into the prom v1 checks.
+func TestAlertRuleVerify_HostRuleClassifiedByProd(t *testing.T) {
+	hostConfig := `{"queries":[{"key":"group_ids","op":"==","values":[1]}],"triggers":[{"type":"target_miss","duration":60,"severity":2}]}`
+	tests := []struct {
+		name       string
+		cate       string
+		ruleConfig string
+		wantErr    string
+	}{
+		{"blank cate", "", hostConfig, ""},
+		{"stale prometheus cate", models.PROMETHEUS, hostConfig, ""},
+		{"blank cate still validates trigger severity", "", `{"queries":[{"key":"group_ids","op":"==","values":[1]}],"triggers":[{"type":"target_miss","duration":60,"severity":0}]}`, "severity must be 1, 2 or 3"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ar := &models.AlertRule{Name: "testrule", Prod: models.HOST, Cate: tt.cate, RuleConfig: tt.ruleConfig}
+			err := ar.Verify()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got: %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
 func TestAlertRuleUpdateColumn_RejectsInvalidSeverity(t *testing.T) {
 	ar := &models.AlertRule{}
 	for _, severity := range []interface{}{float64(0), float64(4), float64(1.5), "2"} {

--- a/models/alert_rule_verify_test.go
+++ b/models/alert_rule_verify_test.go
@@ -1,10 +1,77 @@
 package models_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/ccfos/nightingale/v6/models"
 )
+
+func TestAlertRuleVerify_Severity(t *testing.T) {
+	tests := []struct {
+		name       string
+		cate       string
+		ruleConfig string
+		wantErr    bool
+	}{
+		{"prometheus v1 query severity 1", models.PROMETHEUS, `{"queries":[{"severity":1}]}`, false},
+		{"prometheus v1 query severity 3", models.PROMETHEUS, `{"queries":[{"severity":3}]}`, false},
+		{"prometheus v1 query severity 0", models.PROMETHEUS, `{"queries":[{"severity":0}]}`, true},
+		{"prometheus v1 query severity 4", models.PROMETHEUS, `{"queries":[{"severity":4}]}`, true},
+		{"prometheus legacy config severity", models.PROMETHEUS, `{"severity":2}`, false},
+		{"prometheus legacy config invalid severity", models.PROMETHEUS, `{"severity":-1}`, true},
+		{"unused legacy severity may remain zero", models.PROMETHEUS, `{"severity":0,"queries":[{"severity":2}]}`, false},
+		{"unused legacy severity cannot be another invalid value", models.PROMETHEUS, `{"severity":4,"queries":[{"severity":2}]}`, true},
+		{"prometheus v2 trigger severity", models.PROMETHEUS, `{"version":"v2","triggers":[{"severity":1}]}`, false},
+		{"prometheus v2 invalid trigger severity", models.PROMETHEUS, `{"version":"v2","triggers":[{"severity":9}]}`, true},
+		{"host trigger severity", models.HOST, `{"triggers":[{"severity":3}]}`, false},
+		{"host invalid trigger severity", models.HOST, `{"triggers":[{"severity":0}]}`, true},
+		{"enabled nodata trigger severity", models.CLICKHOUSE, `{"nodata_trigger":{"enable":true,"severity":2}}`, false},
+		{"enabled nodata trigger invalid severity", models.CLICKHOUSE, `{"nodata_trigger":{"enable":true,"severity":0}}`, true},
+		{"disabled nodata trigger may retain zero", models.CLICKHOUSE, `{"nodata_trigger":{"enable":false,"severity":0}}`, false},
+		{"enabled anomaly trigger invalid severity", models.CLICKHOUSE, `{"anomaly_trigger":{"enable":true,"severity":4}}`, true},
+		{"empty config has no active severity", models.PROMETHEUS, `{}`, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ar := &models.AlertRule{Name: "testrule", Cate: tt.cate, RuleConfig: tt.ruleConfig}
+			err := ar.Verify()
+			if tt.wantErr {
+				if err == nil || !strings.Contains(err.Error(), "severity must be 1, 2 or 3") {
+					t.Fatalf("expected severity error, got: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected no error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestAlertRuleVerify_LegacyTopLevelSeverity(t *testing.T) {
+	for _, severity := range []int{-1, 4} {
+		ar := &models.AlertRule{
+			Name:       "testrule",
+			Cate:       models.PROMETHEUS,
+			Severity:   severity,
+			RuleConfig: `{"queries":[{"severity":2}]}`,
+		}
+		if err := ar.Verify(); err == nil || !strings.Contains(err.Error(), "severity must be 1, 2 or 3") {
+			t.Fatalf("severity %d: expected severity error, got: %v", severity, err)
+		}
+	}
+}
+
+func TestAlertRuleUpdateColumn_RejectsInvalidSeverity(t *testing.T) {
+	ar := &models.AlertRule{}
+	for _, severity := range []interface{}{float64(0), float64(4), float64(1.5), "2"} {
+		if err := ar.UpdateColumn(nil, "severity", severity); err == nil || !strings.Contains(err.Error(), "severity must be 1, 2 or 3") {
+			t.Fatalf("severity %v: expected severity error, got: %v", severity, err)
+		}
+	}
+}
 
 func TestAlertRuleVerify_EffectiveTimeSpan(t *testing.T) {
 	base := func() *models.AlertRule {

--- a/models/alert_rule_verify_test.go
+++ b/models/alert_rule_verify_test.go
@@ -14,16 +14,16 @@ func TestAlertRuleVerify_Severity(t *testing.T) {
 		ruleConfig string
 		wantErr    bool
 	}{
-		{"prometheus v1 query severity 1", models.PROMETHEUS, `{"queries":[{"severity":1}]}`, false},
-		{"prometheus v1 query severity 3", models.PROMETHEUS, `{"queries":[{"severity":3}]}`, false},
-		{"prometheus v1 query severity 0", models.PROMETHEUS, `{"queries":[{"severity":0}]}`, true},
-		{"prometheus v1 query severity 4", models.PROMETHEUS, `{"queries":[{"severity":4}]}`, true},
+		{"prometheus v1 query severity 1", models.PROMETHEUS, `{"queries":[{"prom_ql":"up == 0","severity":1}]}`, false},
+		{"prometheus v1 query severity 3", models.PROMETHEUS, `{"queries":[{"prom_ql":"up == 0","severity":3}]}`, false},
+		{"prometheus v1 query severity 0", models.PROMETHEUS, `{"queries":[{"prom_ql":"up == 0","severity":0}]}`, true},
+		{"prometheus v1 query severity 4", models.PROMETHEUS, `{"queries":[{"prom_ql":"up == 0","severity":4}]}`, true},
 		{"prometheus legacy config severity", models.PROMETHEUS, `{"severity":2}`, false},
 		{"prometheus legacy config invalid severity", models.PROMETHEUS, `{"severity":-1}`, true},
-		{"unused legacy severity may remain zero", models.PROMETHEUS, `{"severity":0,"queries":[{"severity":2}]}`, false},
-		{"unused legacy severity cannot be another invalid value", models.PROMETHEUS, `{"severity":4,"queries":[{"severity":2}]}`, true},
-		{"prometheus v2 trigger severity", models.PROMETHEUS, `{"version":"v2","triggers":[{"severity":1}]}`, false},
-		{"prometheus v2 invalid trigger severity", models.PROMETHEUS, `{"version":"v2","triggers":[{"severity":9}]}`, true},
+		{"unused legacy severity may remain zero", models.PROMETHEUS, `{"severity":0,"queries":[{"prom_ql":"up == 0","severity":2}]}`, false},
+		{"unused legacy severity cannot be another invalid value", models.PROMETHEUS, `{"severity":4,"queries":[{"prom_ql":"up == 0","severity":2}]}`, true},
+		{"prometheus v2 trigger severity", models.PROMETHEUS, `{"version":"v2","triggers":[{"exp":"$A > 0","severity":1}]}`, false},
+		{"prometheus v2 invalid trigger severity", models.PROMETHEUS, `{"version":"v2","triggers":[{"exp":"$A > 0","severity":9}]}`, true},
 		{"host trigger severity", models.HOST, `{"triggers":[{"severity":3}]}`, false},
 		{"host invalid trigger severity", models.HOST, `{"triggers":[{"severity":0}]}`, true},
 		{"enabled nodata trigger severity", models.CLICKHOUSE, `{"nodata_trigger":{"enable":true,"severity":2}}`, false},
@@ -56,11 +56,49 @@ func TestAlertRuleVerify_LegacyTopLevelSeverity(t *testing.T) {
 			Name:       "testrule",
 			Cate:       models.PROMETHEUS,
 			Severity:   severity,
-			RuleConfig: `{"queries":[{"severity":2}]}`,
+			RuleConfig: `{"queries":[{"prom_ql":"up == 0","severity":2}]}`,
 		}
 		if err := ar.Verify(); err == nil || !strings.Contains(err.Error(), "severity must be 1, 2 or 3") {
 			t.Fatalf("severity %d: expected severity error, got: %v", severity, err)
 		}
+	}
+}
+
+func TestAlertRuleVerify_RequiredExpressions(t *testing.T) {
+	tests := []struct {
+		name       string
+		cate       string
+		ruleConfig string
+		wantErr    string
+	}{
+		{"prometheus v1 blank prom_ql", models.PROMETHEUS, `{"queries":[{"prom_ql":"","severity":2}]}`, "prom_ql is blank"},
+		{"prometheus v1 whitespace prom_ql", models.PROMETHEUS, `{"queries":[{"prom_ql":"  ","severity":2}]}`, "prom_ql is blank"},
+		{"loki v1 blank prom_ql", models.LOKI, `{"queries":[{"prom_ql":"","severity":2}]}`, "prom_ql is blank"},
+		{"prometheus v2 blank exp", models.PROMETHEUS, `{"version":"v2","triggers":[{"exp":"","severity":2}]}`, "exp is blank"},
+		{"clickhouse blank exp", models.CLICKHOUSE, `{"triggers":[{"exp":"","severity":2}]}`, "exp is blank"},
+		{"clickhouse valid exp", models.CLICKHOUSE, `{"triggers":[{"exp":"$A > 0","severity":2}]}`, ""},
+		{"disabled threshold conditions allow blank exp", models.CLICKHOUSE, `{"exp_trigger_disable":true,"triggers":[{"exp":"","severity":2}],"nodata_trigger":{"enable":true,"severity":2}}`, ""},
+		{"host triggers have no exp", models.HOST, `{"triggers":[{"type":"target_miss","duration":60,"severity":2}]}`, ""},
+		// n9e-plus 老智能告警规则（prod=anomaly）经 AlertRuleModifyHook 迁移后的 GET 返回形态：
+		// queries 是算法输入（无 prom_ql/severity），事件 severity 由 anomaly_trigger 承载
+		{"anomaly migrated queries are exempt", models.PROMETHEUS, `{"version":"","queries":[{"ref":"A","query":"cpu_usage_active","unit":""}],"triggers":null,"anomaly_trigger":{"enable":true,"severity":2,"algorithm":"holt-winters"}}`, ""},
+		{"anomaly migrated shape still validates anomaly severity", models.PROMETHEUS, `{"queries":[{"ref":"A","query":"cpu_usage_active"}],"anomaly_trigger":{"enable":true,"severity":4}}`, "severity must be 1, 2 or 3"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ar := &models.AlertRule{Name: "testrule", Cate: tt.cate, RuleConfig: tt.ruleConfig}
+			err := ar.Verify()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got: %v", tt.wantErr, err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- reject active alert rule severities outside 1, 2, and 3
- cover legacy rules, query-based rules, trigger-based rules, no-data alerts, and anomaly detection
- apply the shared validation to create, update, import/upsert, and batch-update paths
- preserve zero-valued inactive legacy shadow fields for backward compatibility

## Tests

- `go test ./models ./center/router`
- `go test ./...` (remaining failures require local ClickHouse/MySQL/PostgreSQL services or reproduce unchanged on `main` in `pkg/promql` and `pushgw/writer`)