### PR TITLE
fix: tolerate the redundant SET IDENTITY_INSERT on migrated DaMeng schemas

### DIFF
--- a/pkg/ormx/dm.go
+++ b/pkg/ormx/dm.go
@@ -1,6 +1,7 @@
 package ormx
 
 import (
+	"database/sql"
 	"fmt"
 	"net/url"
 	"strings"
@@ -21,10 +22,18 @@ import (
 // LENGTH_IN_CHAR 是建库期参数、事后不可改，开启该选项后无论客户建库时怎么选，列宽语义
 // 都与 MySQL 一致（N 个字符），也就不会因为列比现状窄而触发缩窄 ALTER。
 func dmDialector(dsn string) gorm.Dialector {
-	return dameng.New(dameng.Config{
+	cfg := dameng.Config{
 		DSN:                     dsn,
 		VarcharSizeIsCharLength: true,
-	})
+	}
+
+	// 自己开 *sql.DB 并包一层，用来容忍迁移库上多余的 SET IDENTITY_INSERT，
+	// 原因见 dm_identity.go。开不出来就退回让驱动自己用 DSN 连，错误由它报。
+	if sqlDB, err := sql.Open(dameng.DriverName, dsn); err == nil {
+		cfg.Conn = &dmIdentityInsertPool{sqlDB}
+	}
+
+	return dameng.New(cfg)
 }
 
 // splitDMSchema 从 DSN 中分离出 schema 名与去掉 schema 参数后的 DSN。

--- a/pkg/ormx/dm_identity.go
+++ b/pkg/ormx/dm_identity.go
@@ -1,0 +1,87 @@
+package ormx
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+
+	"gorm.io/gorm"
+)
+
+// 达梦有两种自增形态，行为并不等价：
+//
+//	IDENTITY(1, 1)  —— gorm 建表时生成的形态。往这种列里写显式值，必须先
+//	                   SET IDENTITY_INSERT <表> ON，否则报 -2723。
+//	AUTO_INCREMENT  —— 从 MySQL 迁移过来的形态。这种列本来就允许写显式值，
+//	                   而 SET IDENTITY_INSERT 对它无效，直接报
+//	                   -2717 表[xxx]不存在IDENTITY列。
+//
+// gorm-dameng 的 Create 只看模型（主键是自增且被赋了非零值）就无条件发
+// SET IDENTITY_INSERT，不看列的真实形态；该语句失败会中断整条 INSERT。于是同一份代码
+// 在自建库上正常、在迁移库上所有"显式指定主键再插入"的写入全部失败——数据源同步就是
+// 典型受害者，而且对调用方完全静默（接口报成功、数据没落库）。
+//
+// 这里在连接池层把这条语句的 -2717 吞掉：对 AUTO_INCREMENT 形态而言它本就多余，
+// 失败无害，后续 INSERT 会照常执行；对 IDENTITY 形态它会成功，不受影响。
+// 只针对 SET IDENTITY_INSERT 这一条语句、且只吞 -2717 这一个错误码，不影响其它语句。
+
+// dmIdentityInsertPool 包装 *sql.DB。
+// 注意 BeginTx 的签名与 *sql.DB 的不同，会遮蔽被提升的方法，使本类型只满足
+// gorm.ConnPoolBeginner 而不满足 gorm.TxBeginner——gorm 的 Begin 优先匹配后者，
+// 这样才能保证事务内的语句也走到包装过的 ExecContext。
+type dmIdentityInsertPool struct {
+	*sql.DB
+}
+
+func (p *dmIdentityInsertPool) GetDBConn() (*sql.DB, error) { return p.DB, nil }
+
+func (p *dmIdentityInsertPool) BeginTx(ctx context.Context, opts *sql.TxOptions) (gorm.ConnPool, error) {
+	tx, err := p.DB.BeginTx(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+	return &dmIdentityInsertTx{tx}, nil
+}
+
+func (p *dmIdentityInsertPool) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+	return dmExecTolerateIdentityInsert(ctx, p.DB, query, args...)
+}
+
+// dmIdentityInsertTx 让事务内的语句同样经过处理。Commit/Rollback 由 *sql.Tx 提升，
+// 因此本类型同时满足 gorm.ConnPool 与 gorm.TxCommitter。
+//
+// 必须以指针形式使用：gorm 的 Commit/Rollback 会对 TxCommitter 做
+// reflect.ValueOf(x).IsNil()，而 IsNil 对结构体值会 panic。
+type dmIdentityInsertTx struct {
+	*sql.Tx
+}
+
+func (t *dmIdentityInsertTx) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+	return dmExecTolerateIdentityInsert(ctx, t.Tx, query, args...)
+}
+
+type dmExecer interface {
+	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
+}
+
+func dmExecTolerateIdentityInsert(ctx context.Context, e dmExecer, query string, args ...interface{}) (sql.Result, error) {
+	res, err := e.ExecContext(ctx, query, args...)
+	if err != nil && isDMSetIdentityInsert(query) && isDMNoIdentityColumn(err) {
+		return dmNoopResult{}, nil
+	}
+	return res, err
+}
+
+func isDMSetIdentityInsert(query string) bool {
+	return strings.HasPrefix(strings.ToUpper(strings.TrimSpace(query)), "SET IDENTITY_INSERT")
+}
+
+// -2717 是达梦的「表[xxx]不存在IDENTITY列」。只认这一个错误码，其它一律照常报出去。
+func isDMNoIdentityColumn(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "-2717")
+}
+
+type dmNoopResult struct{}
+
+func (dmNoopResult) LastInsertId() (int64, error) { return 0, nil }
+func (dmNoopResult) RowsAffected() (int64, error) { return 0, nil }


### PR DESCRIPTION
Follow-up to #3356. Fixes the last DaMeng defect found while running the deployed image against a schema migrated from MySQL.

## The problem

DaMeng has two auto-increment forms and they are not interchangeable:

| Form | Where it comes from | Explicit value written to it |
|---|---|---|
| `IDENTITY(1, 1)` | what gorm generates | needs `SET IDENTITY_INSERT <table> ON` first, else `-2723` |
| `AUTO_INCREMENT` | what a schema migrated from MySQL carries | allowed outright; `SET IDENTITY_INSERT` does not apply and fails with `-2717 表[xxx]不存在IDENTITY列` |

`gorm-dameng`'s `Create` decides from the model alone — an auto-increment primary key holding a non-zero value makes it emit `SET IDENTITY_INSERT`, whatever the column actually is. That statement's failure aborts the INSERT.

So on a migrated schema, every write that assigns its own primary key fails. Datasource sync is the one that shows up in practice, and **it is silent from the caller's side**: the API answers 200 while the row never lands, and the only trace is a `-2717` line in the error log, repeating for every sync cycle.

This cannot be settled per-database either. `AutoMigrate` creates any new table in the IDENTITY form, so a migrated schema becomes mixed over time — on the instance this was found on, 184 tables are `AUTO_INCREMENT` and 3 are `IDENTITY`.

## Why this shape of fix

Converting the columns was the first thing tried. DaMeng has no `ALTER` that turns `AUTO_INCREMENT` into `IDENTITY` — four spellings were tested, all rejected — so it would mean rebuilding 184 tables with data, per deployment, forever.

Replacing the driver's create callback was the second. It is 236 lines that build their own SQL, including the MERGE INTO path and insert-id handling; copying it to drop four lines is not maintainable.

What is left is the narrow one: wrap the connection pool and swallow `-2717` for that one statement. On an `AUTO_INCREMENT` column the statement was never needed and the INSERT that follows succeeds; on an `IDENTITY` column it still succeeds exactly as before. Nothing else is caught — only a statement beginning with `SET IDENTITY_INSERT`, only that error code.

Transactions are wrapped as well, since gorm swaps `ConnPool` for the `*sql.Tx` once a transaction starts and the statement would otherwise bypass the wrapper. The wrappers are pointer types on purpose: gorm's `Commit`/`Rollback` run `reflect.ValueOf(committer).IsNil()`, which panics on a struct value — that one cost a crash before it was caught.

## Verification

Against both shapes of a real DM8 schema — one migrated from MySQL, one created by this code:

| | migrated (`AUTO_INCREMENT`) | fresh (`IDENTITY`) |
|---|---|---|
| explicit id, no transaction | pass | pass |
| explicit id, inside transaction | pass | pass |
| ordinary auto-increment insert | pass | pass |

Before the change the migrated column failed all explicit-id cases with `-2717`.