### PR TITLE
feat(pushgw): control target tags and host tags separately

### DIFF
--- a/etc/config.toml
+++ b/etc/config.toml
@@ -223,6 +223,10 @@ BasicAuthPass = ""
 # DatasourceUrl = ""
 
 [Pushgw]
+# append user-defined target tags to incoming series
+EnableTargetTagAppend = true
+# append heartbeat-reported target host tags to incoming series
+EnableTargetHostTagAppend = true
 # use target labels in database instead of in series
 LabelRewrite = true
 ForceUseServerTS = true

--- a/etc/edge/edge.toml
+++ b/etc/edge/edge.toml
@@ -82,6 +82,10 @@ EngineName = "edge"
 # MaxConcurrentQueries = 2
 
 [Pushgw]
+# append user-defined target tags to incoming series
+EnableTargetTagAppend = true
+# append heartbeat-reported target host tags to incoming series
+EnableTargetHostTagAppend = true
 # use target labels in database instead of in series
 LabelRewrite = true
 # # default busigroup key name

--- a/models/target.go
+++ b/models/target.go
@@ -32,6 +32,8 @@ type Target struct {
 	Tags         string            `json:"-"` // user tags
 	TagsJSON     []string          `json:"tags" gorm:"-"`
 	TagsMap      map[string]string `json:"tags_maps" gorm:"-"` // internal use, append tags to series
+	UserTagsMap  map[string]string `json:"-" gorm:"-"`         // parsed user-defined tags
+	HostTagsMap  map[string]string `json:"-" gorm:"-"`         // parsed heartbeat-reported tags
 	UpdateAt     int64             `json:"update_at"`
 	HostIp       string            `json:"host_ip"` //ipv4，do not needs range select
 	AgentVersion string            `json:"agent_version"`
@@ -302,6 +304,12 @@ func TargetFilterQueryBuild(ctx *ctx.Context, query []map[string]interface{}, li
 func TargetGetsAll(ctx *ctx.Context) ([]*Target, error) {
 	if !ctx.IsCenter {
 		lst, err := poster.GetByUrls[[]*Target](ctx, "/v1/n9e/targets")
+		if err != nil {
+			return lst, err
+		}
+		for i := 0; i < len(lst); i++ {
+			lst[i].fillTagsMaps()
+		}
 		return lst, err
 	}
 
@@ -568,34 +576,32 @@ func (t *Target) DelTags(ctx *ctx.Context, tags []string) error {
 
 func (t *Target) FillTagsMap() {
 	t.TagsJSON = strings.Fields(t.Tags)
-	t.TagsMap = make(map[string]string)
-	m := make(map[string]string)
-	allTags := append(t.TagsJSON, t.HostTags...)
-	for _, item := range allTags {
-		arr := strings.Split(item, "=")
-		if len(arr) != 2 {
-			continue
-		}
-		m[arr[0]] = arr[1]
-	}
+	t.fillTagsMaps()
+}
 
-	t.TagsMap = m
+func (t *Target) fillTagsMaps() {
+	t.UserTagsMap = tagsToMap(t.TagsJSON)
+	t.HostTagsMap = tagsToMap(t.HostTags)
+	t.TagsMap = make(map[string]string, len(t.UserTagsMap)+len(t.HostTagsMap))
+	for key, value := range t.UserTagsMap {
+		t.TagsMap[key] = value
+	}
+	for key, value := range t.HostTagsMap {
+		t.TagsMap[key] = value
+	}
 }
 
 func (t *Target) GetTagsMap() map[string]string {
-	tagsJSON := strings.Fields(t.Tags)
-	m := make(map[string]string)
-	for _, item := range tagsJSON {
-		if arr := strings.Split(item, "="); len(arr) == 2 {
-			m[arr[0]] = arr[1]
-		}
-	}
-	return m
+	return tagsToMap(strings.Fields(t.Tags))
 }
 
 func (t *Target) GetHostTagsMap() map[string]string {
+	return tagsToMap(t.HostTags)
+}
+
+func tagsToMap(tags []string) map[string]string {
 	m := make(map[string]string)
-	for _, item := range t.HostTags {
+	for _, item := range tags {
 		arr := strings.Split(item, "=")
 		if len(arr) != 2 {
 			continue

--- a/models/target_tags_test.go
+++ b/models/target_tags_test.go
@@ -1,0 +1,85 @@
+package models
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestTargetFillTagsMapCachesSourcesSeparately(t *testing.T) {
+	target := &Target{
+		Tags:     "custom=custom-value duplicate=custom-value ",
+		HostTags: []string{"reported=reported-value", "duplicate=reported-value"},
+	}
+
+	target.FillTagsMap()
+
+	if want := map[string]string{
+		"custom":    "custom-value",
+		"duplicate": "custom-value",
+	}; !reflect.DeepEqual(target.UserTagsMap, want) {
+		t.Fatalf("unexpected user tags: got %v, want %v", target.UserTagsMap, want)
+	}
+	if want := map[string]string{
+		"reported":  "reported-value",
+		"duplicate": "reported-value",
+	}; !reflect.DeepEqual(target.HostTagsMap, want) {
+		t.Fatalf("unexpected host tags: got %v, want %v", target.HostTagsMap, want)
+	}
+	if want := map[string]string{
+		"custom":    "custom-value",
+		"reported":  "reported-value",
+		"duplicate": "reported-value",
+	}; !reflect.DeepEqual(target.TagsMap, want) {
+		t.Fatalf("unexpected merged tags: got %v, want %v", target.TagsMap, want)
+	}
+}
+
+func TestTargetFillTagsMapsFromAPIFields(t *testing.T) {
+	target := &Target{
+		TagsJSON: []string{"custom=custom-value", "duplicate=custom-value"},
+		HostTags: []string{"reported=reported-value", "duplicate=reported-value"},
+	}
+
+	target.fillTagsMaps()
+
+	if target.UserTagsMap["custom"] != "custom-value" {
+		t.Fatalf("user tags were not rebuilt from TagsJSON: %v", target.UserTagsMap)
+	}
+	if target.HostTagsMap["reported"] != "reported-value" {
+		t.Fatalf("host tags were not rebuilt from HostTags: %v", target.HostTagsMap)
+	}
+	if target.TagsMap["duplicate"] != "reported-value" {
+		t.Fatalf("host tag precedence was not preserved: %v", target.TagsMap)
+	}
+}
+
+func TestTargetInternalTagMapsAreNotSerialized(t *testing.T) {
+	target := &Target{
+		Tags:     "custom=custom-value ",
+		HostTags: []string{"reported=reported-value"},
+	}
+	target.FillTagsMap()
+
+	data, err := json.Marshal(target)
+	if err != nil {
+		t.Fatalf("marshal target: %v", err)
+	}
+
+	var got map[string]json.RawMessage
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal target JSON: %v", err)
+	}
+
+	for _, key := range []string{"UserTagsMap", "HostTagsMap", "user_tags_map", "host_tags_map"} {
+		if _, exists := got[key]; exists {
+			t.Fatalf("internal tag cache %q leaked into target JSON: %s", key, data)
+		}
+	}
+	if _, exists := got["tags_maps"]; !exists {
+		t.Fatalf("existing tags_maps field is missing from target JSON: %s", data)
+	}
+	if _, exists := got["host_tags"]; !exists {
+		t.Fatalf("existing host_tags field is missing from target JSON: %s", data)
+	}
+}

--- a/pushgw/pconf/conf.go
+++ b/pushgw/pconf/conf.go
@@ -40,13 +40,15 @@ type Pushgw struct {
 	// 降到 max(latency)，同时缩短 in-flight slot 持有时间、缓解慢 writer 拖累健康 writer。
 	ProxyConcurrentForward bool
 
-	LabelRewrite     bool
-	ForceUseServerTS bool
-	DebugSample      map[string]string
-	DropSample       []map[string]string
-	WriterOpt        WriterGlobalOpt
-	Writers          []WriterOptions
-	KafkaWriters     []KafkaWriterOptions
+	EnableTargetTagAppend     bool `default:"true"`
+	EnableTargetHostTagAppend bool `default:"true"`
+	LabelRewrite              bool
+	ForceUseServerTS          bool
+	DebugSample               map[string]string
+	DropSample                []map[string]string
+	WriterOpt                 WriterGlobalOpt
+	Writers                   []WriterOptions
+	KafkaWriters              []KafkaWriterOptions
 }
 
 type WriterGlobalOpt struct {

--- a/pushgw/pconf/conf_test.go
+++ b/pushgw/pconf/conf_test.go
@@ -1,0 +1,53 @@
+package pconf
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/koding/multiconfig"
+)
+
+func TestTargetTagAppendDefaults(t *testing.T) {
+	var config struct {
+		Pushgw Pushgw
+	}
+
+	loader := multiconfig.MultiLoader(
+		&multiconfig.TagLoader{},
+		&multiconfig.TOMLLoader{Reader: strings.NewReader("[Pushgw]\n")},
+	)
+	if err := loader.Load(&config); err != nil {
+		t.Fatalf("load config defaults: %v", err)
+	}
+
+	if !config.Pushgw.EnableTargetTagAppend {
+		t.Fatal("EnableTargetTagAppend should default to true")
+	}
+	if !config.Pushgw.EnableTargetHostTagAppend {
+		t.Fatal("EnableTargetHostTagAppend should default to true")
+	}
+}
+
+func TestTargetTagAppendExplicitlyDisabled(t *testing.T) {
+	var config struct {
+		Pushgw Pushgw
+	}
+
+	loader := multiconfig.MultiLoader(
+		&multiconfig.TagLoader{},
+		&multiconfig.TOMLLoader{Reader: strings.NewReader(`[Pushgw]
+EnableTargetTagAppend = false
+EnableTargetHostTagAppend = false
+`)},
+	)
+	if err := loader.Load(&config); err != nil {
+		t.Fatalf("load config overrides: %v", err)
+	}
+
+	if config.Pushgw.EnableTargetTagAppend {
+		t.Fatal("EnableTargetTagAppend should honor explicit false")
+	}
+	if config.Pushgw.EnableTargetHostTagAppend {
+		t.Fatal("EnableTargetHostTagAppend should honor explicit false")
+	}
+}

--- a/pushgw/router/fns.go
+++ b/pushgw/router/fns.go
@@ -19,7 +19,17 @@ func (rt *Router) AppendLabels(pt *prompb.TimeSeries, target *models.Target, bgC
 		labelKeys[pt.Labels[j].Name] = j
 	}
 
-	for key, value := range target.TagsMap {
+	var targetLabels map[string]string
+	switch {
+	case rt.Pushgw.EnableTargetTagAppend && rt.Pushgw.EnableTargetHostTagAppend:
+		targetLabels = target.TagsMap
+	case rt.Pushgw.EnableTargetTagAppend:
+		targetLabels = target.UserTagsMap
+	case rt.Pushgw.EnableTargetHostTagAppend:
+		targetLabels = target.HostTagsMap
+	}
+
+	for key, value := range targetLabels {
 		if index, has := labelKeys[key]; has {
 			// e.g. busigroup=cloud
 			if _, has := labelKeys[rt.Pushgw.BusiGroupLabelKey]; has {

--- a/pushgw/router/fns_test.go
+++ b/pushgw/router/fns_test.go
@@ -1,0 +1,158 @@
+package router
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/ccfos/nightingale/v6/memsto"
+	"github.com/ccfos/nightingale/v6/models"
+	"github.com/ccfos/nightingale/v6/pushgw/pconf"
+	"github.com/prometheus/prometheus/prompb"
+)
+
+func TestAppendLabelsTargetTagControls(t *testing.T) {
+	tests := []struct {
+		name           string
+		appendTags     bool
+		appendHostTags bool
+		want           map[string]string
+	}{
+		{
+			name:           "both enabled preserves host tag precedence",
+			appendTags:     true,
+			appendHostTags: true,
+			want: map[string]string{
+				"__name__":  "test_metric",
+				"custom":    "custom-value",
+				"reported":  "reported-value",
+				"duplicate": "reported-value",
+			},
+		},
+		{
+			name:       "only custom target tags enabled",
+			appendTags: true,
+			want: map[string]string{
+				"__name__":  "test_metric",
+				"custom":    "custom-value",
+				"duplicate": "custom-value",
+			},
+		},
+		{
+			name:           "only reported host tags enabled",
+			appendHostTags: true,
+			want: map[string]string{
+				"__name__":  "test_metric",
+				"reported":  "reported-value",
+				"duplicate": "reported-value",
+			},
+		},
+		{
+			name: "both disabled",
+			want: map[string]string{
+				"__name__": "test_metric",
+			},
+		},
+	}
+
+	target := &models.Target{
+		Tags:     "custom=custom-value duplicate=custom-value ",
+		HostTags: []string{"reported=reported-value", "duplicate=reported-value"},
+	}
+	target.FillTagsMap()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rt := &Router{Pushgw: pconf.Pushgw{
+				EnableTargetTagAppend:     tt.appendTags,
+				EnableTargetHostTagAppend: tt.appendHostTags,
+				LabelRewrite:              true,
+			}}
+			series := &prompb.TimeSeries{Labels: []prompb.Label{
+				{Name: "__name__", Value: "test_metric"},
+			}}
+
+			rt.AppendLabels(series, target, nil)
+
+			if got := seriesLabelsMap(series); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("unexpected labels: got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAppendLabelsRewriteBehavior(t *testing.T) {
+	target := &models.Target{
+		Tags:     "duplicate=custom-value custom=custom-value ",
+		HostTags: []string{"duplicate=reported-value"},
+	}
+	target.FillTagsMap()
+
+	tests := []struct {
+		name    string
+		rewrite bool
+		want    string
+	}{
+		{name: "preserve incoming label", rewrite: false, want: "series-value"},
+		{name: "rewrite incoming label", rewrite: true, want: "reported-value"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rt := &Router{Pushgw: pconf.Pushgw{
+				EnableTargetTagAppend:     true,
+				EnableTargetHostTagAppend: true,
+				LabelRewrite:              tt.rewrite,
+			}}
+			series := &prompb.TimeSeries{Labels: []prompb.Label{
+				{Name: "__name__", Value: "test_metric"},
+				{Name: "duplicate", Value: "series-value"},
+			}}
+
+			rt.AppendLabels(series, target, nil)
+
+			if got := seriesLabelsMap(series)["duplicate"]; got != tt.want {
+				t.Fatalf("unexpected duplicate label: got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAppendLabelsBusinessGroupUnaffected(t *testing.T) {
+	bgCache := &memsto.BusiGroupCacheType{}
+	bgCache.Set(map[int64]*models.BusiGroup{
+		1: {Id: 1, LabelEnable: 1, LabelValue: "production"},
+	}, 1, 1)
+
+	rt := &Router{Pushgw: pconf.Pushgw{
+		EnableTargetTagAppend:     false,
+		EnableTargetHostTagAppend: false,
+		BusiGroupLabelKey:         "busigroup",
+	}}
+	series := &prompb.TimeSeries{Labels: []prompb.Label{
+		{Name: "__name__", Value: "test_metric"},
+	}}
+	target := &models.Target{
+		GroupId:  1,
+		Tags:     "custom=custom-value ",
+		HostTags: []string{"reported=reported-value"},
+	}
+	target.FillTagsMap()
+
+	rt.AppendLabels(series, target, bgCache)
+
+	want := map[string]string{
+		"__name__":  "test_metric",
+		"busigroup": "production",
+	}
+	if got := seriesLabelsMap(series); !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected labels: got %v, want %v", got, want)
+	}
+}
+
+func seriesLabelsMap(series *prompb.TimeSeries) map[string]string {
+	labels := make(map[string]string, len(series.Labels))
+	for _, label := range series.Labels {
+		labels[label.Name] = label.Value
+	}
+	return labels
+}


### PR DESCRIPTION
**What type of PR is this?**

  Feature

  **What this PR does / why we need it**:

  This PR adds independent Pushgw controls for appending user-defined target
  tags and heartbeat-reported host tags to incoming time series.

  Configuration options:

  - `EnableTargetTagAppend = true`
  - `EnableTargetHostTagAppend = true`

  Behavior:

  - `EnableTargetTagAppend` controls appending `Target.tags`.
  - `EnableTargetHostTagAppend` controls appending `Target.host_tags`.
  - Both options default to `true` for backward compatibility.
  - Existing `LabelRewrite` behavior and host tag precedence are preserved.
  - Business group label handling and heartbeat processing are unchanged.
  - Parsed user and host tag maps are cached on Target refresh to avoid
    per-series parsing and allocations.
  - Center and Edge Target cache paths are both supported.

  This allows deployments that already enrich metrics upstream to disable stale
  heartbeat host tags while continuing to append user-defined target tags.

  **Which issue(s) this PR fixes**:

  Fixes #3360

  **Special notes for your reviewer**:

  Tests passed:

  - `go test -race ./models ./pushgw/pconf ./pushgw/router`
  - `go vet ./models ./pushgw/...`
  - `git diff --check`

  `go test -race ./pushgw/...` currently encounters the existing
  `pushgw/writer` failure
  `TestProcess/Conditional_relabeling_does_not_match`. The same failure is
  reproducible on the unmodified upstream `main` commit.