### PR TITLE
fix: close SSRF guard bypass via 6to4/NAT64/site-local IPv6 addresses

### DIFF
--- a/aiagent/tools/http.go
+++ b/aiagent/tools/http.go
@@ -316,32 +316,77 @@ func isPublicIP(ip net.IP) bool {
 		return false
 	}
 	if ip4 := ip.To4(); ip4 != nil {
-		// 100.64.0.0/10 — Carrier-Grade NAT.
-		if ip4[0] == 100 && ip4[1] >= 64 && ip4[1] <= 127 {
-			return false
-		}
-		// 192.0.0.0/24 — IETF Protocol Assignments.
-		if ip4[0] == 192 && ip4[1] == 0 && ip4[2] == 0 {
-			return false
-		}
-		// 192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24 — TEST-NET.
-		if ip4[0] == 192 && ip4[1] == 0 && ip4[2] == 2 {
-			return false
-		}
-		if ip4[0] == 198 && ip4[1] == 51 && ip4[2] == 100 {
-			return false
-		}
-		if ip4[0] == 203 && ip4[1] == 0 && ip4[2] == 113 {
-			return false
-		}
-		// 198.18.0.0/15 — benchmarking.
-		if ip4[0] == 198 && (ip4[1] == 18 || ip4[1] == 19) {
-			return false
-		}
-		// 240.0.0.0/4 — reserved (includes 255.255.255.255).
-		if ip4[0] >= 240 {
-			return false
-		}
+		return isPublicIPv4(ip4)
+	}
+	// ip.To4() only unwraps the standard "::ffff:a.b.c.d" IPv4-mapped form.
+	// A forbidden IPv4 address (e.g. cloud instance metadata,
+	// 169.254.169.254) can also reach here disguised as a 6to4 or NAT64
+	// IPv6 address, so those encodings must be unwrapped and re-checked
+	// too, and the deprecated IPv6 site-local range rejected outright.
+	ip16 := ip.To16()
+	if ip16 == nil {
+		return true
+	}
+	if ip16[0] == 0xfe && ip16[1]&0xc0 == 0xc0 {
+		// fec0::/10 — deprecated IPv6 site-local, still routed on some networks.
+		return false
+	}
+	if ip16[0] == 0x20 && ip16[1] == 0x02 {
+		// 2002::/16 — 6to4. The embedded IPv4 address is bytes 2-5.
+		return isPublicIPv4(net.IPv4(ip16[2], ip16[3], ip16[4], ip16[5]).To4())
+	}
+	nat64WellKnown := net.IP{0, 0x64, 0xff, 0x9b, 0, 0, 0, 0, 0, 0, 0, 0}
+	if ip16[:12].Equal(nat64WellKnown) {
+		// 64:ff9b::/96 — NAT64 well-known prefix. The embedded IPv4 address
+		// is the last 4 bytes.
+		return isPublicIPv4(net.IPv4(ip16[12], ip16[13], ip16[14], ip16[15]).To4())
+	}
+	nat64LocalUse := net.IP{0, 0x64, 0xff, 0x9b, 0, 1, 0, 0, 0, 0, 0, 0}
+	if ip16[:6].Equal(nat64LocalUse[:6]) {
+		// 64:ff9b:1::/48 — NAT64 local-use prefix. Per RFC 8215 this is only
+		// ever valid within a single administrative domain and must never be
+		// treated as a globally routable address, so reject the whole prefix
+		// rather than attempting to decode an embedded IPv4 address out of it.
+		return false
+	}
+	return true
+}
+
+func isPublicIPv4(ip4 net.IP) bool {
+	if ip4 == nil {
+		return false
+	}
+	// 100.64.0.0/10 — Carrier-Grade NAT.
+	if ip4[0] == 100 && ip4[1] >= 64 && ip4[1] <= 127 {
+		return false
+	}
+	// 192.0.0.0/24 — IETF Protocol Assignments.
+	if ip4[0] == 192 && ip4[1] == 0 && ip4[2] == 0 {
+		return false
+	}
+	// 192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24 — TEST-NET.
+	if ip4[0] == 192 && ip4[1] == 0 && ip4[2] == 2 {
+		return false
+	}
+	if ip4[0] == 198 && ip4[1] == 51 && ip4[2] == 100 {
+		return false
+	}
+	if ip4[0] == 203 && ip4[1] == 0 && ip4[2] == 113 {
+		return false
+	}
+	// 198.18.0.0/15 — benchmarking.
+	if ip4[0] == 198 && (ip4[1] == 18 || ip4[1] == 19) {
+		return false
+	}
+	// 240.0.0.0/4 — reserved (includes 255.255.255.255).
+	if ip4[0] >= 240 {
+		return false
+	}
+	// Loopback/private/link-local/CGNAT-mapped forms embedded via 6to4/NAT64
+	// must be caught even though they arrive as a plain 4-byte net.IP here.
+	if ip4.IsLoopback() || ip4.IsPrivate() || ip4.IsLinkLocalUnicast() ||
+		ip4.IsLinkLocalMulticast() || ip4.IsMulticast() || ip4.IsUnspecified() {
+		return false
 	}
 	return true
 }

--- a/aiagent/tools/http_test.go
+++ b/aiagent/tools/http_test.go
@@ -1,9 +1,11 @@
 package tools
 
 import (
+	"context"
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -56,6 +58,67 @@ func TestIsPublicIP(t *testing.T) {
 		got := isPublicIP(net.ParseIP(c.ip))
 		if got != c.want {
 			t.Errorf("isPublicIP(%s) = %v, want %v", c.ip, got, c.want)
+		}
+	}
+}
+
+// TestIsPublicIP_RejectsIPv6EmbeddedForbiddenRanges guards against a
+// regression where isPublicIP only unwrapped the standard "::ffff:a.b.c.d"
+// IPv4-mapped form via ip.To4() and never inspected 6to4 (2002::/16), NAT64
+// (64:ff9b::/96, 64:ff9b:1::/48), or the deprecated IPv6 site-local range
+// (fec0::/10) for an embedded/forbidden address such as the cloud
+// instance-metadata endpoint, 169.254.169.254.
+func TestIsPublicIP_RejectsIPv6EmbeddedForbiddenRanges(t *testing.T) {
+	cases := []struct {
+		name string
+		ip   string
+	}{
+		// 2002:a9fe:a9fe:: is the 6to4 encoding of 169.254.169.254 (IMDS).
+		{"6to4-IMDS", "2002:a9fe:a9fe::"},
+		// 64:ff9b::a9fe:a9fe is the well-known NAT64 encoding of 169.254.169.254.
+		{"NAT64-IMDS", "64:ff9b::a9fe:a9fe"},
+		// 64:ff9b:1::a9fe:a9fe is the NAT64 local-use encoding of the same address.
+		{"NAT64-local-IMDS", "64:ff9b:1::a9fe:a9fe"},
+		// fec0::1 is deprecated IPv6 site-local, still routed on some networks.
+		{"sitelocal-fec0", "fec0::1"},
+		// 169.254.169.254 and its IPv4-mapped form were already correctly
+		// rejected; kept here so a regression in the new code can't
+		// accidentally start allowing these too.
+		{"direct-IMDS", "169.254.169.254"},
+		{"mapped-IMDS", "::ffff:169.254.169.254"},
+	}
+	for _, c := range cases {
+		ip := net.ParseIP(c.ip)
+		if ip == nil {
+			t.Fatalf("net.ParseIP(%q) returned nil", c.ip)
+		}
+		if got := isPublicIP(ip); got {
+			t.Errorf("isPublicIP(%s / %s) = true, want false", c.name, c.ip)
+		}
+	}
+
+	// A 6to4 address that embeds a genuinely public IPv4 address must still
+	// be allowed; the fix must not turn 2002::/16 into a blanket block.
+	if ip := net.ParseIP("2002:0808:0808::"); !isPublicIP(ip) {
+		t.Errorf("isPublicIP(6to4 embedding 8.8.8.8) = false, want true")
+	}
+}
+
+// TestSafeDialContext_RejectsIPv6EmbeddedForbiddenRange drives the
+// unmodified safeDialContext (the function net/http actually uses to open
+// the TCP connection for http_fetch) with the 6to4 encoding of
+// 169.254.169.254 and confirms it is rejected at the gate before any network
+// dial is attempted, the same as the existing loopback/RFC1918/link-local
+// controls.
+func TestSafeDialContext_RejectsIPv6EmbeddedForbiddenRange(t *testing.T) {
+	ctx := context.Background()
+
+	for _, target := range []string{
+		net.JoinHostPort("127.0.0.1", "9"),
+		net.JoinHostPort("2002:a9fe:a9fe::", "9"),
+	} {
+		if _, err := safeDialContext(ctx, "tcp", target); err == nil || !strings.Contains(err.Error(), "non-public address") {
+			t.Errorf("safeDialContext(%s) should be rejected at the gate, got err=%v", target, err)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #3363.

`isPublicIP()` in `aiagent/tools/http.go` (the SSRF guard for the `http_fetch` AI-agent tool) only unwrapped the standard `::ffff:a.b.c.d` IPv4-mapped IPv6 form before checking an address against the forbidden-range list. 6to4 (`2002::/16`) and NAT64 (`64:ff9b::/96`, `64:ff9b:1::/48`) encodings, which can embed a forbidden IPv4 address such as the cloud instance-metadata endpoint `169.254.169.254`, passed through unclassified as public. The deprecated IPv6 site-local range (`fec0::/10`) was likewise treated as public.

## Changes

- Split the IPv4 range checks out into `isPublicIPv4()` so they can be reused after unwrapping an embedded address.
- In `isPublicIP()`, for an address that isn't a plain/mapped IPv4 form:
  - Reject `fec0::/10` (deprecated site-local) outright.
  - Extract the embedded IPv4 address from a 6to4 (`2002::/16`) literal and re-run `isPublicIPv4()` against it, so a 6to4 address that legitimately embeds a public IPv4 address is still allowed.
  - Extract the embedded IPv4 address from the NAT64 well-known prefix (`64:ff9b::/96`) and re-run `isPublicIPv4()` against it.
  - Reject the NAT64 local-use prefix (`64:ff9b:1::/48`) outright — per RFC 8215 this is only ever valid within a single administrative domain and must never be treated as globally routable, so no legitimate `http_fetch` target needs it.

## Test plan

- [x] `go build ./aiagent/...`
- [x] `go vet ./aiagent/tools/...`
- [x] `go test ./aiagent/tools/...` — full package suite passes
- [x] Added `TestIsPublicIP_RejectsIPv6EmbeddedForbiddenRanges` (direct `isPublicIP()` cases for 6to4/NAT64-well-known/NAT64-local-use/site-local embeddings of the metadata address, plus a control confirming a 6to4 address embedding a genuinely public IPv4 address is still allowed)
- [x] Added `TestSafeDialContext_RejectsIPv6EmbeddedForbiddenRange` (drives the unmodified `safeDialContext()` dial path with the 6to4 encoding of the metadata address, confirms it's rejected at the gate alongside the existing loopback control)
- [x] Confirmed both new tests fail against the pre-fix code and pass against this change
