### PR TITLE
fix(es): unauthenticated SQL client and SQL rows flattened in batch q…

### DIFF
--- a/center/router/router_query_batch_v2.go
+++ b/center/router/router_query_batch_v2.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/ccfos/nightingale/v6/datasource"
+	"github.com/ccfos/nightingale/v6/datasource/es"
 	"github.com/ccfos/nightingale/v6/dscache"
 	"github.com/ccfos/nightingale/v6/models"
 	"github.com/ccfos/nightingale/v6/pkg/ginx"
@@ -418,7 +419,7 @@ func (e queryBatchV2Executor) executeDatasourceQuery(
 		if err != nil {
 			return queryBatchV2Value{}, queryBatchV2FailureFromError(query.RefID, queryBatchV2DatasourceErrorCode(err), err)
 		}
-		records := queryBatchV2Records(cate, items)
+		records := queryBatchV2Records(cate, items, queryBatchV2ElasticsearchSQLPayload(cate, payload))
 		value := queryBatchV2Value{ResultType: resultTypeLogs, Records: records}
 		return value, queryBatchV2Success(query.RefID, value)
 	}
@@ -611,7 +612,26 @@ func queryBatchV2MetricLabels(metric model.Metric) map[string]string {
 	return labels
 }
 
-func queryBatchV2Records(cate string, items []interface{}) []QueryBatchV2Record {
+// queryBatchV2ElasticsearchSQLPayload reports whether the payload selects the
+// ES plugin's SQL branch. Only the elasticsearch plugin (datasource/es) has
+// that branch: QueryLog routes such a payload to XPackSQL and returns plain
+// column→value row maps, not SearchHit objects, so the _source unwrapping in
+// queryBatchV2Records must be skipped for them. The payload inspection is
+// delegated to es.IsSQLQueryLog, which shares the decode with the plugin's
+// own routing (extractSQLRequest), so this check cannot drift from what the
+// plugin actually does — e.g. a payload with a non-string index makes the
+// plugin fall back to the DSL path, and this check reports false too.
+// OpenSearch has no SQL branch — its plugin ignores "sql" and always returns
+// SearchHits — so opensearch cates must keep the unwrapping no matter what
+// the payload carries.
+func queryBatchV2ElasticsearchSQLPayload(cate string, payload map[string]interface{}) bool {
+	if strings.TrimSuffix(cate, ".logging") != "elasticsearch" {
+		return false
+	}
+	return es.IsSQLQueryLog(payload)
+}
+
+func queryBatchV2Records(cate string, items []interface{}, esSQLMode bool) []QueryBatchV2Record {
 	records := make([]QueryBatchV2Record, 0, len(items))
 	for _, item := range items {
 		fields, ok := item.(map[string]interface{})
@@ -624,10 +644,12 @@ func queryBatchV2Records(cate string, items []interface{}) []QueryBatchV2Record 
 		if fields == nil {
 			fields = map[string]interface{}{"value": item}
 		}
-		// Elasticsearch QueryLog returns SearchHit objects. V2 ES records expose
-		// only the source document; ES metadata (_id, _index and sort) remains
-		// available on the legacy logs-query endpoint used for pagination.
-		if queryBatchV2IsElasticsearchCate(cate) {
+		// Elasticsearch QueryLog returns SearchHit objects on the DSL path. V2
+		// ES records expose only the source document; ES metadata (_id, _index
+		// and sort) remains available on the legacy logs-query endpoint used
+		// for pagination. The SQL path returns row maps without _source, which
+		// must pass through untouched instead of being wiped to an empty object.
+		if queryBatchV2IsElasticsearchCate(cate) && !esSQLMode {
 			source, _ := fields["_source"].(map[string]interface{})
 			if source == nil {
 				source = map[string]interface{}{}

--- a/center/router/router_query_batch_v2_test.go
+++ b/center/router/router_query_batch_v2_test.go
@@ -498,7 +498,7 @@ func TestQueryBatchV2RecordsUsesElasticsearchSource(t *testing.T) {
 		"_index":  "logs-2026.07.25",
 		"_source": map[string]interface{}{"message": "hello", "status": "200"},
 		"sort":    []interface{}{float64(1784971399013)},
-	}})
+	}}, false)
 	if len(records) != 1 {
 		t.Fatalf("record count = %d, want 1", len(records))
 	}
@@ -508,28 +508,85 @@ func TestQueryBatchV2RecordsUsesElasticsearchSource(t *testing.T) {
 
 	withoutSource := queryBatchV2Records("elasticsearch.logging", []interface{}{map[string]interface{}{
 		"_id": "document-without-source", "_index": "logs-2026.07.25",
-	}})
+	}}, false)
 	if len(withoutSource[0].Fields) != 0 {
 		t.Fatalf("ES metadata leaked without _source: %#v", withoutSource[0].Fields)
 	}
 
-	generic := queryBatchV2Records("loki", []interface{}{map[string]interface{}{"message": "hello"}})
+	generic := queryBatchV2Records("loki", []interface{}{map[string]interface{}{"message": "hello"}}, false)
 	if generic[0].Fields["message"] != "hello" {
 		t.Fatalf("generic log record = %#v", generic[0].Fields)
 	}
 
 	openSearch := queryBatchV2Records("opensearch.logging", []interface{}{map[string]interface{}{
 		"_id": "document-id", "_index": "logs", "_source": map[string]interface{}{"message": "opensearch"},
-	}})
+	}}, false)
 	if openSearch[0].Fields["message"] != "opensearch" || openSearch[0].Fields["_id"] != nil {
 		t.Fatalf("OpenSearch record = %#v", openSearch[0].Fields)
 	}
 
 	nonES := queryBatchV2Records("mongodb", []interface{}{map[string]interface{}{
 		"_id": "document-id", "_index": "business-index", "message": "preserve",
-	}})
+	}}, false)
 	if nonES[0].Fields["message"] != "preserve" || nonES[0].Fields["_id"] != "document-id" {
 		t.Fatalf("non-ES record was stripped: %#v", nonES[0].Fields)
+	}
+}
+
+// The ES SQL branch of QueryLog returns plain column→value row maps instead of
+// SearchHit objects. Those rows carry no _source, so the unwrap must be
+// skipped or every SQL log record would be flattened to an empty fields map.
+// The detection is scoped to the elasticsearch cate: the opensearch plugin has
+// no SQL branch and always returns SearchHits, even if a stray sql field
+// rides along in the payload. The payload inspection is delegated to the es
+// package (IsSQLQueryLog), so the router sees exactly what the plugin's
+// extractSQLRequest sees — a payload whose sql/index/start/end does not
+// decode (e.g. a wrong-typed index) sends QueryLog down the DSL path and must
+// not be detected as SQL mode here either.
+func TestQueryBatchV2RecordsKeepsElasticsearchSQLRows(t *testing.T) {
+	sqlPayload := map[string]interface{}{"sql": "SELECT COUNT(\"x\") AS cnt FROM \"idx*\"", "index": "idx*"}
+	if !queryBatchV2ElasticsearchSQLPayload("elasticsearch", sqlPayload) {
+		t.Fatalf("non-empty sql payload was not detected as SQL mode")
+	}
+	if queryBatchV2ElasticsearchSQLPayload("elasticsearch", map[string]interface{}{"sql": "", "index": "idx*"}) {
+		t.Fatalf("empty sql payload must not be detected as SQL mode")
+	}
+	if queryBatchV2ElasticsearchSQLPayload("elasticsearch", map[string]interface{}{"index": "idx*"}) {
+		t.Fatalf("payload without sql must not be detected as SQL mode")
+	}
+	if queryBatchV2ElasticsearchSQLPayload("elasticsearch", map[string]interface{}{"sql": "SELECT 1", "index": 123}) {
+		t.Fatalf("payload with wrong-typed index must not be detected as SQL mode: plugin decodes via mapstructure and falls back to DSL")
+	}
+	if queryBatchV2ElasticsearchSQLPayload("elasticsearch", map[string]interface{}{"sql": 123}) {
+		t.Fatalf("payload with wrong-typed sql must not be detected as SQL mode")
+	}
+	if queryBatchV2ElasticsearchSQLPayload("elasticsearch", nil) {
+		t.Fatalf("nil payload must not be detected as SQL mode")
+	}
+	if queryBatchV2ElasticsearchSQLPayload("opensearch", sqlPayload) {
+		t.Fatalf("opensearch must never be detected as SQL mode")
+	}
+	if queryBatchV2ElasticsearchSQLPayload("opensearch.logging", sqlPayload) {
+		t.Fatalf("opensearch.logging must never be detected as SQL mode")
+	}
+
+	records := queryBatchV2Records("elasticsearch", []interface{}{
+		map[string]interface{}{"cnt": float64(202)},
+	}, queryBatchV2ElasticsearchSQLPayload("elasticsearch", sqlPayload))
+	if len(records) != 1 {
+		t.Fatalf("record count = %d, want 1", len(records))
+	}
+	if records[0].Fields["cnt"] != float64(202) {
+		t.Fatalf("SQL row was not preserved: %#v", records[0].Fields)
+	}
+
+	// An opensearch payload carrying a stray sql field still runs DSL and
+	// returns SearchHit-shaped maps, so the _source unwrap must stay active.
+	openSearchSQLStray := queryBatchV2Records("opensearch", []interface{}{map[string]interface{}{
+		"_id": "document-id", "_index": "logs", "_source": map[string]interface{}{"message": "hello"},
+	}}, queryBatchV2ElasticsearchSQLPayload("opensearch", sqlPayload))
+	if openSearchSQLStray[0].Fields["message"] != "hello" || openSearchSQLStray[0].Fields["_id"] != nil {
+		t.Fatalf("opensearch record with stray sql field was not unwrapped: %#v", openSearchSQLStray[0].Fields)
 	}
 }
 

--- a/datasource/es/sql_exec_test.go
+++ b/datasource/es/sql_exec_test.go
@@ -461,3 +461,77 @@ func TestXPackSQL_ErrorResponse(t *testing.T) {
 		t.Fatal("expected error for bad SQL, got nil")
 	}
 }
+
+// TestXPackSQL_BasicAuth verifies that the SQL path authenticates the same way
+// the DSL path does. dscache-synced datasources (esN9eToDatasourceInfo) carry
+// username/password with BasicAuth.Enable left false; the SQL client must
+// still send credentials, otherwise security-enabled clusters reject /_sql
+// with 401 "missing authentication credentials" while DSL queries succeed.
+func TestXPackSQL_BasicAuth(t *testing.T) {
+	const (
+		authUser = "elastic"
+		authPass = "changeme"
+	)
+	newSecuredServer := func(t *testing.T) *httptest.Server {
+		t.Helper()
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("X-Elastic-Product", "Elasticsearch")
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/":
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"version": map[string]interface{}{"number": "8.15.0"},
+				})
+			case r.Method == http.MethodPost && r.URL.Path == "/_sql":
+				user, pass, ok := r.BasicAuth()
+				if !ok || user != authUser || pass != authPass {
+					w.Header().Set("WWW-Authenticate", `Basic realm="security" charset="UTF-8", ApiKey`)
+					w.WriteHeader(http.StatusUnauthorized)
+					w.Write([]byte(`{"error":{"root_cause":[{"type":"security_exception","reason":"missing authentication credentials for REST request [/_sql]"}],"type":"security_exception","reason":"missing authentication credentials for REST request [/_sql]"},"status":401}`))
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.Write([]byte(`{"columns":[{"name":"cnt","type":"long"}],"rows":[[202]]}`))
+			}
+		}))
+	}
+
+	cases := []struct {
+		name    string
+		basic   BasicAuth
+		wantErr bool
+	}{
+		// dscache/esN9eToDatasourceInfo shape: credentials set, Enable false.
+		{"username_without_enable_flag", BasicAuth{Username: authUser, Password: authPass}, false},
+		{"enable_flag_set", BasicAuth{Enable: true, Username: authUser, Password: authPass}, false},
+		// No credentials configured: the 401 is the expected cluster response.
+		{"no_credentials", BasicAuth{}, true},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := newSecuredServer(t)
+			defer srv.Close()
+
+			clientCache = syncMapNew()
+			escli := newTestElasticsearch("8.15.0", []string{srv.URL})
+			escli.Basic = tt.basic
+
+			resp, err := XPackSQL(context.Background(), escli, XPackSQLRequest{
+				Query: `SELECT COUNT("status.keyword") AS cnt FROM "log*"`,
+			})
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected 401 error without credentials, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("XPackSQL() with configured credentials error: %v", err)
+			}
+			if len(resp.Rows) != 1 || resp.Rows[0][0] != float64(202) {
+				t.Errorf("unexpected response: %+v", resp)
+			}
+		})
+	}
+}

--- a/datasource/es/sql_officialclient.go
+++ b/datasource/es/sql_officialclient.go
@@ -67,7 +67,12 @@ func officialClient(escli *Elasticsearch) (*elasticsearch8.Client, error) {
 		Transport: &productCheckTransport{base: transport},
 	}
 
-	if escli.Basic.Enable {
+	// Mirror InitClient()'s condition (Basic.Username != "") instead of
+	// checking only Basic.Enable: datasources synced through dscache
+	// (esN9eToDatasourceInfo) populate username/password but leave Enable
+	// false, which made every SQL request go out unauthenticated and fail
+	// with 401 against security-enabled clusters while DSL queries worked.
+	if escli.Basic.Enable || escli.Basic.Username != "" {
 		cfg.Username = escli.Basic.Username
 		cfg.Password = escli.Basic.Password
 	}

--- a/datasource/es/sql_querylog.go
+++ b/datasource/es/sql_querylog.go
@@ -18,11 +18,8 @@ type sqlQueryParam struct {
 // extractSQLRequest checks if queryParam contains a non-empty "sql" field.
 // If so, it returns the constructed XPackSQLRequest and true.
 func extractSQLRequest(queryParam interface{}) (*XPackSQLRequest, bool) {
-	var p sqlQueryParam
-	if err := mapstructure.Decode(queryParam, &p); err != nil {
-		return nil, false
-	}
-	if p.SQL == "" {
+	p, ok := decodeSQLQueryParam(queryParam)
+	if !ok {
 		return nil, false
 	}
 
@@ -32,6 +29,32 @@ func extractSQLRequest(queryParam interface{}) (*XPackSQLRequest, bool) {
 		To:                      p.End,
 		FieldMultiValueLeniency: true,
 	}, true
+}
+
+// IsSQLQueryLog reports whether QueryLog routes queryParam through the SQL
+// branch (and thus returns plain column→value row maps instead of SearchHit
+// objects). It shares decodeSQLQueryParam with extractSQLRequest, so callers
+// outside the plugin — e.g. the batch query v2 router, which must know the
+// shape of QueryLog's return value — cannot drift from the plugin's own
+// routing decision by re-parsing the payload themselves.
+func IsSQLQueryLog(queryParam interface{}) bool {
+	_, ok := decodeSQLQueryParam(queryParam)
+	return ok
+}
+
+// decodeSQLQueryParam is the single source of truth for the SQL branch
+// routing decision: mapstructure must decode the payload and "sql" must be
+// non-empty. A decode failure (e.g. a wrong-typed sql/index/start/end field)
+// means QueryLog falls back to the DSL path and returns SearchHits.
+func decodeSQLQueryParam(queryParam interface{}) (sqlQueryParam, bool) {
+	var p sqlQueryParam
+	if err := mapstructure.Decode(queryParam, &p); err != nil {
+		return p, false
+	}
+	if p.SQL == "" {
+		return p, false
+	}
+	return p, true
 }
 
 // queryLogViaSQL executes a SQL query and flattens the result into the

--- a/datasource/es/sql_querylog_test.go
+++ b/datasource/es/sql_querylog_test.go
@@ -1,0 +1,67 @@
+package es
+
+import (
+	"testing"
+)
+
+// IsSQLQueryLog and extractSQLRequest must answer the SQL-branch question
+// identically: they share decodeSQLQueryParam, and the batch query v2 router
+// relies on IsSQLQueryLog to know the shape of QueryLog's return value (row
+// maps vs SearchHit objects). If the two ever disagreed — e.g. a payload with
+// a non-empty sql but a wrong-typed index fails the mapstructure decode and
+// makes QueryLog fall back to the DSL path — the router would skip the
+// _source unwrapping while the plugin returns SearchHits, leaking _id/_index
+// into the records.
+func TestIsSQLQueryLogMatchesExtractSQLRequest(t *testing.T) {
+	cases := []struct {
+		name       string
+		queryParam interface{}
+		want       bool
+	}{
+		{"sql_only", map[string]interface{}{"sql": `SELECT 1`}, true},
+		{"sql_with_range", map[string]interface{}{"sql": `SELECT 1`, "start": int64(1), "end": int64(2)}, true},
+		{"empty_sql", map[string]interface{}{"sql": "", "index": "idx*"}, false},
+		{"missing_sql", map[string]interface{}{"index": "idx*"}, false},
+		{"nil_payload", nil, false},
+		{"wrong_typed_sql", map[string]interface{}{"sql": 123, "index": "idx*"}, false},
+		// Divergence hazard: sql decodes fine, index does not. The decode
+		// failure must send BOTH the plugin and the router to the DSL path.
+		{"wrong_typed_index", map[string]interface{}{"sql": `SELECT 1`, "index": 123}, false},
+		{"wrong_typed_start", map[string]interface{}{"sql": `SELECT 1`, "start": "yesterday"}, false},
+		{"sql_log_shape", map[string]interface{}{
+			"sql": `SELECT COUNT("status") AS cnt FROM "idx*"`, "index": "idx*",
+			"start": int64(1784971399), "end": int64(1784974999),
+		}, true},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsSQLQueryLog(tt.queryParam)
+			if got != tt.want {
+				t.Fatalf("IsSQLQueryLog(%#v) = %v, want %v", tt.queryParam, got, tt.want)
+			}
+
+			_, routed := extractSQLRequest(tt.queryParam)
+			if routed != got {
+				t.Fatalf("extractSQLRequest(%#v) routes SQL = %v, IsSQLQueryLog = %v", tt.queryParam, routed, got)
+			}
+		})
+	}
+
+	req, ok := extractSQLRequest(map[string]interface{}{
+		"sql": `SELECT COUNT("status") AS cnt FROM "idx*"`,
+		"start": int64(1784971399), "end": int64(1784974999),
+	})
+	if !ok {
+		t.Fatal("extractSQLRequest() = false for a valid SQL payload")
+	}
+	if req.Query != `SELECT COUNT("status") AS cnt FROM "idx*"` {
+		t.Errorf("Query = %q", req.Query)
+	}
+	if req.From != 1784971399 || req.To != 1784974999 {
+		t.Errorf("range = [%d, %d], want [1784971399, 1784974999]", req.From, req.To)
+	}
+	if !req.FieldMultiValueLeniency {
+		t.Error("FieldMultiValueLeniency = false, want true")
+	}
+}


### PR DESCRIPTION
…uery v2

ES SQL client: apply Basic auth when username is set even if Enable is false, mirroring InitClient(). Datasources synced through dscache carry username/password with BasicAuth.Enable left false, which made SQL requests go out unauthenticated and fail with 401 on security-enabled clusters while DSL queries worked.

Query batch v2: the ES SQL branch of QueryLog returns plain column→value row maps instead of SearchHit objects. Skip the _source unwrapping in queryBatchV2Records for those rows, so SQL log records are not flattened to empty maps. The SQL-mode decision is delegated to the new exported es.IsSQLQueryLog, which shares the mapstructure decode with the plugin's own routing (extractSQLRequest) instead of re-parsing the payload in the router — a wrong-typed sql/index/start/end field sends both sides down the DSL path, so the two can no longer disagree. OpenSearch has no SQL branch and keeps the unwrapping no matter what the payload carries.

Add tests for Basic auth on the SQL path, SQL-mode detection consistency between IsSQLQueryLog and extractSQLRequest, SQL row passthrough, and the cate-scoped unwrap behavior.

**What type of PR is this?**

**What this PR does / why we need it**:
<!--
"Nice to have" "You need it" is not a good reason. :)
-->

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or "Fixes (paste link of issue)"
-->
Fixes #
 
**Special notes for your reviewer**: