### PR TITLE
fix(postgresql): use configured database in InitClient

### DIFF
--- a/datasource/postgresql/postgresql.go
+++ b/datasource/postgresql/postgresql.go
@@ -51,7 +51,12 @@ func (p *PostgreSQL) InitClient() error {
 		return fmt.Errorf("not found postgresql addr, please check datasource config")
 	}
 	for _, shard := range p.Shards {
-		if db, err := shard.NewConn(context.TODO(), "postgres"); err != nil {
+		dbName := shard.DB
+		if dbName == "" {
+			dbName = "postgres"
+		}
+
+		if db, err := shard.NewConn(context.TODO(), dbName); err != nil {
 			defer sqlbase.CloseDB(db)
 			return err
 		}

--- a/datasource/postgresql/postgresql_test.go
+++ b/datasource/postgresql/postgresql_test.go
@@ -1,0 +1,64 @@
+package postgresql
+
+import (
+	"testing"
+
+	"github.com/ccfos/nightingale/v6/dskit/pool"
+	"github.com/ccfos/nightingale/v6/dskit/postgres"
+	"gorm.io/gorm"
+)
+
+func TestInitDecodesConfiguredDatabase(t *testing.T) {
+	p := new(PostgreSQL)
+	datasource, err := p.Init(map[string]interface{}{
+		"pgsql.shards": []map[string]interface{}{
+			{"pgsql.db": "customdb"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := datasource.(*PostgreSQL)
+	if len(got.Shards) != 1 {
+		t.Fatalf("expected one shard, got %d", len(got.Shards))
+	}
+	if got.Shards[0].DB != "customdb" {
+		t.Fatalf("expected database %q, got %q", "customdb", got.Shards[0].DB)
+	}
+}
+
+func TestInitClientUsesConfiguredDatabase(t *testing.T) {
+	shard := &postgres.PostgreSQL{
+		Shard: postgres.Shard{
+			Addr:     "127.0.0.1:1",
+			DB:       "customdb",
+			User:     "configured-db-user",
+			Password: "configured-db-password",
+		},
+	}
+	cacheKey := "127.0.0.1:1:configured-db-password:configured-db-user:customdb"
+	pool.PoolClient.Store(cacheKey, &gorm.DB{})
+	t.Cleanup(func() { pool.PoolClient.Delete(cacheKey) })
+
+	if err := (&PostgreSQL{Shards: []*postgres.PostgreSQL{shard}}).InitClient(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestInitClientFallsBackToPostgres(t *testing.T) {
+	shard := &postgres.PostgreSQL{
+		Shard: postgres.Shard{
+			Addr:     "127.0.0.1:1",
+			User:     "fallback-db-user",
+			Password: "fallback-db-password",
+		},
+	}
+	cacheKey := "127.0.0.1:1:fallback-db-password:fallback-db-user:postgres"
+	pool.PoolClient.Store(cacheKey, &gorm.DB{})
+	t.Cleanup(func() { pool.PoolClient.Delete(cacheKey) })
+
+	if err := (&PostgreSQL{Shards: []*postgres.PostgreSQL{shard}}).InitClient(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

Bug fix.

**What this PR does / why we need it**:

`PostgreSQL.InitClient` currently always connects to the `postgres` database, even when the datasource configuration contains a `pgsql.db` value.

This change uses the configured database when present while preserving the existing `postgres` fallback for configurations where `pgsql.db` is empty.

Regression tests cover both the configured-database path and the fallback behavior.

**Which issue(s) this PR fixes**:

Fixes #3359

**Testing**:

- `go test -count=1 ./datasource/postgresql/... ./dskit/postgres/...`
- `go vet ./datasource/postgresql/... ./dskit/postgres/...`
- `git diff --check`

All passed.

**Special notes for your reviewer**:

The change is intentionally scoped to `InitClient`. It does not modify `NewConn`, frontend configuration, query behavior, or datasource equality/cache behavior.

AI assistance was used for issue analysis, test planning, and review of the final diff. The implementation and test results were verified locally.