### PR TITLE
feat(iotdb): migrate table-model queries to native RPC

### DIFF
--- a/center/router/router_datasource.go
+++ b/center/router/router_datasource.go
@@ -13,8 +13,10 @@ import (
 	"strings"
 	"time"
 
+	iotdbdatasource "github.com/ccfos/nightingale/v6/datasource/iotdb"
 	"github.com/ccfos/nightingale/v6/datasource/opensearch"
 	"github.com/ccfos/nightingale/v6/dskit/clickhouse"
+	iotdbkit "github.com/ccfos/nightingale/v6/dskit/iotdb"
 	"github.com/ccfos/nightingale/v6/models"
 	"github.com/ccfos/nightingale/v6/pkg/ginx"
 	"github.com/gin-gonic/gin"
@@ -388,7 +390,48 @@ func (rt *Router) datasourceUpsert(c *gin.Context) {
 }
 
 func DatasourceCheck(c *gin.Context, ds models.Datasource) error {
-	if ds.PluginType == models.PROMETHEUS || ds.PluginType == models.LOKI || ds.PluginType == models.TDENGINE || ds.PluginType == models.IOTDB {
+	if ds.PluginType == models.IOTDB {
+		settings := make(map[string]interface{}, len(ds.SettingsJson)+8)
+		for k, v := range ds.SettingsJson {
+			settings[k] = v
+		}
+		if strings.TrimSpace(ds.HTTPJson.Url) != "" {
+			settings["iotdb.addr"] = ds.HTTPJson.Url
+		}
+		if _, ok := settings["iotdb.timeout"]; !ok {
+			settings["iotdb.timeout"] = ds.HTTPJson.Timeout
+		}
+		if _, ok := settings["iotdb.dial_timeout"]; !ok {
+			settings["iotdb.dial_timeout"] = ds.HTTPJson.DialTimeout
+		}
+		if _, ok := settings["iotdb.max_idle_conns_per_host"]; !ok {
+			settings["iotdb.max_idle_conns_per_host"] = ds.HTTPJson.MaxIdleConnsPerHost
+		}
+		if _, ok := settings["iotdb.headers"]; !ok {
+			settings["iotdb.headers"] = ds.HTTPJson.Headers
+		}
+		if _, ok := settings["iotdb.skip_tls_verify"]; !ok {
+			settings["iotdb.skip_tls_verify"] = ds.HTTPJson.TLS.SkipTlsVerify
+		}
+		settings["iotdb.basic"] = iotdbkit.IotdbBasicAuth{
+			User: ds.AuthJson.BasicAuthUser, Password: ds.AuthJson.BasicAuthPassword,
+		}
+		plug, err := new(iotdbdatasource.IoTDB).Init(settings)
+		if err != nil {
+			return fmt.Errorf("invalid IoTDB configuration: %w", err)
+		}
+		iot := plug.(*iotdbdatasource.IoTDB)
+		if err := iot.Validate(c.Request.Context()); err != nil {
+			return err
+		}
+		if err := iot.InitClient(); err != nil {
+			return err
+		}
+		defer iot.Close()
+		return iot.TestRPC(c.Request.Context())
+	}
+
+	if ds.PluginType == models.PROMETHEUS || ds.PluginType == models.LOKI || ds.PluginType == models.TDENGINE {
 		if ds.HTTPJson.Url == "" {
 			return fmt.Errorf("url is empty")
 		}

--- a/datasource/datasource.go
+++ b/datasource/datasource.go
@@ -16,7 +16,10 @@ type DatasourceType struct {
 }
 
 type Keys struct {
-	ValueKey   string `json:"valueKey" mapstructure:"valueKey"` // 多个用空格分隔
+	ValueKey string `json:"valueKey" mapstructure:"valueKey"` // 多个用空格分隔
+	// MetricKey is accepted for compatibility with older IoTDB/TDengine
+	// dashboard payloads. New clients should send valueKey.
+	MetricKey  string `json:"metricKey,omitempty" mapstructure:"metricKey"`
 	LabelKey   string `json:"labelKey" mapstructure:"labelKey"` // 多个用空格分隔
 	TimeKey    string `json:"timeKey" mapstructure:"timeKey"`
 	TimeFormat string `json:"timeFormat" mapstructure:"timeFormat"`

--- a/datasource/iotdb/iotdb.go
+++ b/datasource/iotdb/iotdb.go
@@ -3,7 +3,9 @@ package iotdb
 import (
 	"context"
 	"fmt"
+	"math"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -26,6 +28,15 @@ const (
 
 type IoTDB struct {
 	iot.Iotdb `json:",inline" mapstructure:",squash"`
+}
+
+// String intentionally omits authentication material because datasource
+// instances may be included in generic cache/error logs.
+func (it *IoTDB) String() string {
+	if it == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("IoTDB{addr:%q rpc_addr:%q database:%q}", it.Addr, it.RPCAddr, it.Database)
 }
 
 type QueryParam struct {
@@ -66,6 +77,8 @@ func (it *IoTDB) Equal(other datasource.Datasource) bool {
 	}
 
 	if it.Addr != otherIoTDB.Addr ||
+		it.RPCAddr != otherIoTDB.RPCAddr ||
+		it.Database != otherIoTDB.Database ||
 		it.Timeout != otherIoTDB.Timeout ||
 		it.DialTimeout != otherIoTDB.DialTimeout ||
 		it.MaxIdleConnsPerHost != otherIoTDB.MaxIdleConnsPerHost ||
@@ -91,8 +104,8 @@ func (it *IoTDB) Equal(other datasource.Datasource) bool {
 }
 
 func (it *IoTDB) Validate(ctx context.Context) error {
-	if strings.TrimSpace(it.Addr) == "" {
-		return fmt.Errorf("iotdb addr is invalid, please check datasource setting")
+	if strings.TrimSpace(it.Addr) == "" && strings.TrimSpace(it.RPCAddr) == "" {
+		return fmt.Errorf("iotdb REST or RPC address is required")
 	}
 	return nil
 }
@@ -131,7 +144,8 @@ func (it *IoTDB) QueryData(ctx context.Context, query interface{}) ([]models.Dat
 	if err != nil {
 		return nil, err
 	}
-	if normalizeRowsTime(rows, queryParam.Keys.TimeKey) {
+	timeKey := effectiveTimeKey(rows, queryParam.Keys.TimeKey)
+	if normalizeRowsTime(rows, timeKey) {
 		// After normalizing IoTDB epoch values to seconds, let the generic
 		// timeseries parser treat them as unix timestamps instead of re-parsing
 		// them with a datetime layout.
@@ -139,6 +153,9 @@ func (it *IoTDB) QueryData(ctx context.Context, query interface{}) ([]models.Dat
 	}
 
 	valueKey := strings.TrimSpace(queryParam.Keys.ValueKey)
+	if valueKey == "" {
+		valueKey = strings.TrimSpace(queryParam.Keys.MetricKey)
+	}
 	if valueKey == "" {
 		valueKey = strings.Join(metricKeysFromRows(rows), " ")
 	}
@@ -149,7 +166,7 @@ func (it *IoTDB) QueryData(ctx context.Context, query interface{}) ([]models.Dat
 	items := sqlbase.FormatMetricValues(types.Keys{
 		ValueKey:   valueKey,
 		LabelKey:   queryParam.Keys.LabelKey,
-		TimeKey:    queryParam.Keys.TimeKey,
+		TimeKey:    timeKey,
 		TimeFormat: queryParam.Keys.TimeFormat,
 	}, rows)
 
@@ -185,6 +202,9 @@ func (it *IoTDB) QueryLog(ctx context.Context, query interface{}) ([]interface{}
 }
 
 func (it *IoTDB) queryRows(ctx context.Context, queryParam *QueryParam) ([]map[string]interface{}, error) {
+	if strings.TrimSpace(queryParam.Database) == "" {
+		queryParam.Database = strings.TrimSpace(it.Database)
+	}
 	sqlText := strings.TrimSpace(queryParam.SQL)
 	if sqlText == "" {
 		sqlText = strings.TrimSpace(queryParam.Query)
@@ -207,7 +227,7 @@ func (it *IoTDB) queryRows(ctx context.Context, queryParam *QueryParam) ([]map[s
 		if err != nil {
 			return nil, fmt.Errorf("parse to failed: %w", err)
 		}
-		sqlText, err = macros.Macro(sqlText, from, to, IoTDBType)
+		sqlText, err = expandIoTDBMacros(sqlText, from, to)
 		if err != nil {
 			return nil, err
 		}
@@ -215,6 +235,11 @@ func (it *IoTDB) queryRows(ctx context.Context, queryParam *QueryParam) ([]map[s
 		var err error
 		sqlText, err = appendTimeFilter(sqlText, queryParam)
 		if err != nil {
+			return nil, err
+		}
+	}
+	if types.ReadOnlyEnforced(ctx) {
+		if err := sqlbase.ValidateReadOnly(sqlText); err != nil {
 			return nil, err
 		}
 	}
@@ -233,6 +258,57 @@ func (it *IoTDB) queryRows(ctx context.Context, queryParam *QueryParam) ([]map[s
 	}
 
 	return responseToRows(resp), nil
+}
+
+// expandIoTDBMacros expands the macros supported by the table-model query
+// path. The shared macro registry currently owns $__timeFilter, while
+// $__timeFrom and $__timeTo are scalar bounds that are specific to SQL data
+// sources. IoTDB TIMESTAMP comparisons use Unix milliseconds, which is also
+// the unit returned by the table-model REST/RPC APIs.
+func expandIoTDBMacros(sqlText string, from, to int64) (string, error) {
+	var hasTimeFrom, hasTimeTo bool
+	sqlText, hasTimeFrom = replaceIoTDBMacro(sqlText, iotdbTimeFromPattern, strconv.FormatInt(from*1000, 10))
+	sqlText, hasTimeTo = replaceIoTDBMacro(sqlText, iotdbTimeToPattern, strconv.FormatInt(to*1000, 10))
+	if (hasTimeFrom && from == 0) || (hasTimeTo && to == 0) {
+		return "", fmt.Errorf("$__timeFrom/$__timeTo requires a query time range, got none")
+	}
+	return macros.ExpandTimeFilter(sqlText, from, to, IoTDBType)
+}
+
+// replaceIoTDBMacro replaces complete scalar time macros while leaving an
+// identifier that merely starts with the macro text untouched (for example,
+// $__timeFromExtra). Go's regexp package has no lookaround, so the boundary
+// check is done while stitching the matched spans back together.
+func replaceIoTDBMacro(sqlText string, pattern *regexp.Regexp, replacement string) (string, bool) {
+	matches := pattern.FindAllStringIndex(sqlText, -1)
+	if len(matches) == 0 {
+		return sqlText, false
+	}
+
+	var builder strings.Builder
+	last := 0
+	replaced := false
+	for _, match := range matches {
+		if len(match) != 2 || match[0] < last {
+			continue
+		}
+		if match[1] < len(sqlText) && isMacroIdentifierByte(sqlText[match[1]]) {
+			continue
+		}
+		builder.WriteString(sqlText[last:match[0]])
+		builder.WriteString(replacement)
+		last = match[1]
+		replaced = true
+	}
+	if !replaced {
+		return sqlText, false
+	}
+	builder.WriteString(sqlText[last:])
+	return builder.String(), true
+}
+
+func isMacroIdentifierByte(value byte) bool {
+	return value == '_' || value >= 'a' && value <= 'z' || value >= 'A' && value <= 'Z' || value >= '0' && value <= '9'
 }
 
 func decodeQueryParam(query interface{}) (*QueryParam, error) {
@@ -295,14 +371,65 @@ func responseToRows(resp iot.APIResponse) []map[string]interface{} {
 					row[expr] = nil
 					continue
 				}
-				row[expr] = resp.Values[colIdx][rowIdx]
+				row[expr] = sanitizeJSONValue(resp.Values[colIdx][rowIdx])
 			}
+			canonicalizeTimeColumn(row)
 			rows = append(rows, row)
 		}
 		return rows
 	}
 
-	return iotColumnarToRows(resp)
+	rows := iotColumnarToRows(resp)
+	for _, row := range rows {
+		canonicalizeTimeColumn(row)
+	}
+	return rows
+}
+
+// Table-model servers may preserve the selected column's spelling (for
+// example, returning "Time" for an unquoted time column). Keep the default
+// timeseries key usable without forcing every query editor to spell out a
+// case-sensitive timeKey.
+func canonicalizeTimeColumn(row map[string]interface{}) {
+	if _, exists := row["time"]; exists {
+		return
+	}
+	for key, value := range row {
+		if strings.EqualFold(key, "time") {
+			row["time"] = value
+			delete(row, key)
+			return
+		}
+	}
+}
+
+// effectiveTimeKey keeps an explicitly configured case variant usable after
+// responseToRows canonicalizes the server's time column to "time".
+func effectiveTimeKey(rows []map[string]interface{}, configured string) string {
+	configured = strings.TrimSpace(configured)
+	if configured == "" {
+		return ""
+	}
+	for _, row := range rows {
+		if _, exists := row[configured]; exists {
+			return configured
+		}
+	}
+	for _, row := range rows {
+		for key := range row {
+			if strings.EqualFold(key, configured) {
+				return key
+			}
+		}
+	}
+	if configured != "time" {
+		for _, row := range rows {
+			if _, exists := row["time"]; exists {
+				return "time"
+			}
+		}
+	}
+	return configured
 }
 
 func iotColumnarToRows(resp iot.APIResponse) []map[string]interface{} {
@@ -324,7 +451,7 @@ func iotColumnarToRows(resp iot.APIResponse) []map[string]interface{} {
 					row[colName] = nil
 					continue
 				}
-				row[colName] = rawRow[colIdx]
+				row[colName] = sanitizeJSONValue(rawRow[colIdx])
 			}
 			rows = append(rows, row)
 		}
@@ -346,11 +473,28 @@ func iotColumnarToRows(resp iot.APIResponse) []map[string]interface{} {
 				row[colName] = nil
 				continue
 			}
-			row[colName] = resp.Values[colIdx][rowIdx]
+			row[colName] = sanitizeJSONValue(resp.Values[colIdx][rowIdx])
 		}
 		rows = append(rows, row)
 	}
 	return rows
+}
+
+// IoTDB DOUBLE columns can contain NaN or Infinity. These values are valid
+// floating-point values but are not representable in JSON, so normalize them
+// at the datasource boundary before log rows reach the HTTP renderer.
+func sanitizeJSONValue(value interface{}) interface{} {
+	switch v := value.(type) {
+	case float64:
+		if math.IsNaN(v) || math.IsInf(v, 0) {
+			return nil
+		}
+	case float32:
+		if math.IsNaN(float64(v)) || math.IsInf(float64(v), 0) {
+			return nil
+		}
+	}
+	return value
 }
 
 func metricKeysFromRows(rows []map[string]interface{}) []string {
@@ -360,11 +504,12 @@ func metricKeysFromRows(rows []map[string]interface{}) []string {
 
 	keys := make([]string, 0)
 	for k := range rows[0] {
-		if k == "__time__" {
+		if k == "__time__" || strings.EqualFold(k, "time") {
 			continue
 		}
 		keys = append(keys, k)
 	}
+	sort.Strings(keys)
 	return keys
 }
 
@@ -434,6 +579,8 @@ func scaleEpoch(ts int64) int64 {
 var (
 	explicitTimeFilterOperators = []string{">=", "<=", "<>", "!=", ">", "<", "="}
 	sqlTailClauses              = []string{"group by", "having", "fill", "order by", "offset", "limit"}
+	iotdbTimeFromPattern        = regexp.MustCompile(`\$__timeFrom(?:\(\))?`)
+	iotdbTimeToPattern          = regexp.MustCompile(`\$__timeTo(?:\(\))?`)
 )
 
 func applyIntervalWindow(queryParam *QueryParam) {

--- a/datasource/iotdb/iotdb_test.go
+++ b/datasource/iotdb/iotdb_test.go
@@ -1,10 +1,162 @@
 package iotdb
 
 import (
+	"context"
+	"encoding/json"
+	"math"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/ccfos/nightingale/v6/datasource"
+	iot "github.com/ccfos/nightingale/v6/dskit/iotdb"
+	"github.com/ccfos/nightingale/v6/dskit/sqlbase"
+	"github.com/ccfos/nightingale/v6/dskit/types"
 )
+
+func TestInitRPCSettings(t *testing.T) {
+	plug, err := (&IoTDB{}).Init(map[string]interface{}{
+		"iotdb.addr":         "http://127.0.0.1:18080",
+		"iotdb.rpc_addr":     "127.0.0.1:6667",
+		"iotdb.database":     "telemetry",
+		"iotdb.dial_timeout": 1200,
+		"iotdb.timeout":      3400,
+		"iotdb.basic":        iot.IotdbBasicAuth{User: "root", Password: "secret"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := plug.(*IoTDB)
+	if got.RPCAddr != "127.0.0.1:6667" || got.Database != "telemetry" || got.DialTimeout != 1200 || got.Timeout != 3400 {
+		t.Fatalf("decoded settings: rpc=%q database=%q dial_timeout=%d timeout=%d", got.RPCAddr, got.Database, got.DialTimeout, got.Timeout)
+	}
+	if got.Basic == nil || got.Basic.Password != "secret" {
+		t.Fatalf("basic auth was not decoded")
+	}
+}
+
+func TestQueryDataRequiresDatabase(t *testing.T) {
+	it := &IoTDB{}
+	_, err := it.QueryData(context.Background(), map[string]interface{}{
+		"sql":  "select time, value from table1",
+		"keys": map[string]interface{}{"valueKey": "value", "timeKey": "time"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "database is required") {
+		t.Fatalf("expected database validation error, got %v", err)
+	}
+}
+
+func TestQueryDataReadOnlyRejectsWrites(t *testing.T) {
+	ctx := types.WithCallContext(context.Background(), types.CallContext{EnforceReadOnly: true})
+	it := &IoTDB{}
+	_, err := it.QueryData(ctx, map[string]interface{}{
+		"database": "metrics",
+		"sql":      "DELETE FROM table1",
+		"keys":     map[string]interface{}{"valueKey": "value", "timeKey": "time"},
+	})
+	if err == nil || !strings.Contains(strings.ToLower(err.Error()), "read-only") {
+		t.Fatalf("expected read-only validation error, got %v", err)
+	}
+}
+
+func TestResponseToRowsPreservesTableValues(t *testing.T) {
+	ts := time.UnixMilli(1778493600000).UTC()
+	rows := responseToRows(iot.APIResponse{
+		ColumnNames: []string{"time", "instance", "value"},
+		Values:      [][]interface{}{{ts, "node-a", float64(1.5)}, {ts.Add(time.Minute), "node-b", nil}},
+	})
+	if len(rows) != 2 || rows[0]["instance"] != "node-a" || rows[0]["value"] != float64(1.5) || rows[1]["value"] != nil {
+		t.Fatalf("unexpected rows: %#v", rows)
+	}
+}
+
+func TestResponseToRowsSupportsColumnarValues(t *testing.T) {
+	rows := responseToRows(iot.APIResponse{
+		ColumnNames: []string{"time", "instance", "value"},
+		Values: [][]interface{}{
+			{time.UnixMilli(1778493600000).UTC(), time.UnixMilli(1778493660000).UTC()},
+			{"node-a", "node-b"},
+			{float64(1), float64(2)},
+		},
+	})
+	if len(rows) != 2 || rows[0]["instance"] != "node-a" || rows[1]["value"] != float64(2) {
+		t.Fatalf("unexpected columnar rows: %#v", rows)
+	}
+}
+
+func TestResponseToRowsCanonicalizesTimeColumnCase(t *testing.T) {
+	rows := responseToRows(iot.APIResponse{
+		ColumnNames: []string{"Time", "value"},
+		Values:      [][]interface{}{{time.Unix(1778493600, 0).UTC(), float64(1)}},
+	})
+	if len(rows) != 1 || rows[0]["time"] == nil || rows[0]["Time"] != nil {
+		t.Fatalf("expected canonical time column, got %#v", rows)
+	}
+}
+
+func TestResponseToRowsSanitizesNonFiniteValues(t *testing.T) {
+	rows := responseToRows(iot.APIResponse{
+		ColumnNames: []string{"time", "value"},
+		Values:      [][]interface{}{{time.Unix(1778493600, 0).UTC(), math.NaN()}, {time.Unix(1778493660, 0).UTC(), math.Inf(1)}},
+	})
+	if len(rows) != 2 || rows[0]["value"] != nil || rows[1]["value"] != nil {
+		t.Fatalf("expected non-finite values to become nil, got %#v", rows)
+	}
+	if _, err := json.Marshal(rows); err != nil {
+		t.Fatalf("sanitized rows must be JSON encodable: %v", err)
+	}
+}
+
+func TestEffectiveTimeKeyUsesCanonicalColumn(t *testing.T) {
+	rows := responseToRows(iot.APIResponse{
+		ColumnNames: []string{"TIME", "value"},
+		Values:      [][]interface{}{{time.Unix(1778493600, 0).UTC(), float64(1)}},
+	})
+	if got := effectiveTimeKey(rows, "TIME"); got != "time" {
+		t.Fatalf("effective time key=%q, want time", got)
+	}
+}
+
+func TestFormatIoTDBRowsCreatesMultiSeriesAndSkipsInvalidValues(t *testing.T) {
+	rows := []map[string]interface{}{
+		{"time": int64(1778493600000), "instance": "node-a", "value": float64(1)},
+		{"time": int64(1778493660000), "instance": "node-a", "value": math.NaN()},
+		{"time": int64(1778493720000), "instance": "node-b", "value": math.Inf(1)},
+		{"time": int64(1778493780000), "instance": "node-b", "value": float64(2)},
+		{"time": int64(1778493840000), "instance": nil, "value": float64(3)},
+	}
+	items := sqlbase.FormatMetricValues(types.Keys{ValueKey: "value", LabelKey: "instance", TimeKey: "time"}, rows)
+	if len(items) != 3 {
+		t.Fatalf("series=%d, want 3 (node-a, node-b, and unlabeled)", len(items))
+	}
+	for _, item := range items {
+		if len(item.Values) != 1 {
+			t.Fatalf("metric %s has %d values, want one finite sample: %#v", item.Metric, len(item.Values), item.Values)
+		}
+		if math.IsNaN(item.Values[0][1]) || math.IsInf(item.Values[0][1], 0) {
+			t.Fatalf("non-finite sample leaked into %s: %#v", item.Metric, item.Values)
+		}
+	}
+}
+
+func TestExpandIoTDBMacros(t *testing.T) {
+	sqlText := "SELECT time, value FROM table1 WHERE time >= $__timeFrom() AND time < $__timeTo AND $__timeFilter(time)"
+	got, err := expandIoTDBMacros(sqlText, 1778493600, 1778497200)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "SELECT time, value FROM table1 WHERE time >= 1778493600000 AND time < 1778497200000 AND (time >= 1778493600000 AND time < 1778497200000)"
+	if got != want {
+		t.Fatalf("expanded SQL=%q, want %q", got, want)
+	}
+}
+
+func TestExpandIoTDBMacrosRejectsMissingRange(t *testing.T) {
+	_, err := expandIoTDBMacros("SELECT $__timeFrom()", 0, 0)
+	if err == nil || !strings.Contains(err.Error(), "requires a query time range") {
+		t.Fatalf("expected missing range error, got %v", err)
+	}
+}
 
 func TestAppendTimeFilterNoWhere(t *testing.T) {
 	got, err := appendTimeFilter("select time, temperature, device_id from sensor_data", queryParamWithRange(""))

--- a/dscache/sync.go
+++ b/dscache/sync.go
@@ -192,13 +192,28 @@ func tdN9eToDatasourceInfo(ds *datasource.DatasourceInfo, item models.Datasource
 
 func iotdbN9eToDatasourceInfo(ds *datasource.DatasourceInfo, item models.Datasource) {
 	ds.Settings = make(map[string]interface{})
+	for k, v := range item.SettingsJson {
+		ds.Settings[k] = v
+	}
 	ds.Settings["iotdb.cluster_name"] = item.Name
-	ds.Settings["iotdb.addr"] = item.HTTPJson.Url
-	ds.Settings["iotdb.timeout"] = item.HTTPJson.Timeout
-	ds.Settings["iotdb.dial_timeout"] = item.HTTPJson.DialTimeout
-	ds.Settings["iotdb.max_idle_conns_per_host"] = item.HTTPJson.MaxIdleConnsPerHost
-	ds.Settings["iotdb.headers"] = item.HTTPJson.Headers
-	ds.Settings["iotdb.skip_tls_verify"] = item.HTTPJson.TLS.SkipTlsVerify
+	if _, ok := ds.Settings["iotdb.addr"]; !ok {
+		ds.Settings["iotdb.addr"] = item.HTTPJson.Url
+	}
+	if _, ok := ds.Settings["iotdb.timeout"]; !ok {
+		ds.Settings["iotdb.timeout"] = item.HTTPJson.Timeout
+	}
+	if _, ok := ds.Settings["iotdb.dial_timeout"]; !ok {
+		ds.Settings["iotdb.dial_timeout"] = item.HTTPJson.DialTimeout
+	}
+	if _, ok := ds.Settings["iotdb.max_idle_conns_per_host"]; !ok {
+		ds.Settings["iotdb.max_idle_conns_per_host"] = item.HTTPJson.MaxIdleConnsPerHost
+	}
+	if _, ok := ds.Settings["iotdb.headers"]; !ok {
+		ds.Settings["iotdb.headers"] = item.HTTPJson.Headers
+	}
+	if _, ok := ds.Settings["iotdb.skip_tls_verify"]; !ok {
+		ds.Settings["iotdb.skip_tls_verify"] = item.HTTPJson.TLS.SkipTlsVerify
+	}
 	ds.Settings["iotdb.basic"] = iotdbkit.IotdbBasicAuth{
 		User:     item.AuthJson.BasicAuthUser,
 		Password: item.AuthJson.BasicAuthPassword,

--- a/dskit/iotdb/iotdb.go
+++ b/dskit/iotdb/iotdb.go
@@ -6,18 +6,24 @@ import (
 	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/apache/iotdb-client-go/v2/client"
 	"github.com/ccfos/nightingale/v6/dskit/types"
 )
 
 type Iotdb struct {
 	Addr                string            `json:"iotdb.addr" mapstructure:"iotdb.addr"`
+	RPCAddr             string            `json:"iotdb.rpc_addr" mapstructure:"iotdb.rpc_addr"`
+	Database            string            `json:"iotdb.database" mapstructure:"iotdb.database"`
 	Basic               *IotdbBasicAuth   `json:"iotdb.basic" mapstructure:"iotdb.basic"`
 	Timeout             int64             `json:"iotdb.timeout" mapstructure:"iotdb.timeout"`
 	DialTimeout         int64             `json:"iotdb.dial_timeout" mapstructure:"iotdb.dial_timeout"`
@@ -25,14 +31,30 @@ type Iotdb struct {
 	Headers             map[string]string `json:"iotdb.headers" mapstructure:"iotdb.headers"`
 	SkipTlsVerify       bool              `json:"iotdb.skip_tls_verify" mapstructure:"iotdb.skip_tls_verify"`
 
-	header map[string][]string `json:"-"`
-	client *http.Client        `json:"-"`
+	header map[string][]string      `json:"-"`
+	client *http.Client             `json:"-"`
+	poolMu sync.Mutex               `json:"-"`
+	pool   *client.TableSessionPool `json:"-"`
+
+	queryMu sync.RWMutex `json:"-"` // read-lease held by in-flight queries; Close takes the write side
+	closed  bool         `json:"-"` // set by Close; guarded by queryMu
 }
 
 type IotdbBasicAuth struct {
 	User      string `json:"iotdb.user" mapstructure:"iotdb.user"`
 	Password  string `json:"iotdb.password" mapstructure:"iotdb.password"`
 	IsEncrypt bool   `json:"iotdb.is_encrypt" mapstructure:"iotdb.is_encrypt"`
+}
+
+// String deliberately omits authentication material. Datasource instances
+// are commonly included in generic initialization/error logs, where the
+// default struct formatter would otherwise make it too easy to expose a
+// password accidentally.
+func (it *Iotdb) String() string {
+	if it == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("Iotdb{addr:%q rpc_addr:%q database:%q}", it.Addr, it.RPCAddr, it.Database)
 }
 
 type APIResponse struct {
@@ -49,6 +71,11 @@ type queryRequest struct {
 	SQL      string `json:"sql"`
 	RowLimit int    `json:"row_limit,omitempty"`
 }
+
+const (
+	defaultRPCPort              = "6667"
+	defaultQueryTimeoutMs int64 = 30000
+)
 
 func (it *Iotdb) InitCli() {
 	timeout := time.Duration(it.Timeout) * time.Millisecond
@@ -98,8 +125,304 @@ func (it *Iotdb) InitCli() {
 	}
 }
 
+// Close releases the native RPC session pool and HTTP transport resources.
+// It is intentionally optional on datasource.Datasource and is called by dscache
+// when a datasource is replaced or removed.
+func (it *Iotdb) Close() error {
+	// Take the write side of queryMu so we wait for every in-flight query to
+	// finish before closing the pool. Closing the pool while another goroutine
+	// is inside GetSession would make the client panic on a closed channel.
+	it.queryMu.Lock()
+	defer it.queryMu.Unlock()
+	it.closed = true
+
+	it.poolMu.Lock()
+	if it.pool != nil {
+		it.pool.Close()
+		it.pool = nil
+	}
+	it.poolMu.Unlock()
+
+	if it.client != nil {
+		it.client.CloseIdleConnections()
+	}
+	return nil
+}
+
+var errDatasourceClosed = errors.New("iotdb datasource is closed")
+
+// beginQuery takes the read-side lease that keeps the RPC pool alive for the
+// duration of a query. Close takes the write side of the same lock, so it waits
+// for in-flight queries and cannot close the pool underneath one — the client's
+// SessionPool.GetSession panics if it runs after Close. The returned func
+// releases the lease.
+func (it *Iotdb) beginQuery() (func(), error) {
+	it.queryMu.RLock()
+	if it.closed {
+		it.queryMu.RUnlock()
+		return nil, errDatasourceClosed
+	}
+	return it.queryMu.RUnlock, nil
+}
+
+func (it *Iotdb) rpcEndpoint() (string, string, error) {
+	addr := strings.TrimSpace(it.RPCAddr)
+	if addr != "" {
+		if strings.Contains(addr, "://") {
+			u, err := url.Parse(addr)
+			if err != nil || u.Hostname() == "" {
+				return "", "", fmt.Errorf("invalid iotdb.rpc_addr %q", addr)
+			}
+			port := u.Port()
+			if port == "" {
+				port = defaultRPCPort
+			}
+			return u.Hostname(), port, nil
+		}
+		if u, err := url.Parse(addr); err == nil && u.Hostname() != "" {
+			port := u.Port()
+			if port == "" {
+				port = defaultRPCPort
+			}
+			return u.Hostname(), port, nil
+		}
+		if host, port, err := net.SplitHostPort(addr); err == nil {
+			if strings.TrimSpace(host) == "" || strings.TrimSpace(port) == "" {
+				return "", "", fmt.Errorf("invalid iotdb.rpc_addr %q", addr)
+			}
+			return host, port, nil
+		}
+		if strings.HasPrefix(addr, "[") && strings.HasSuffix(addr, "]") {
+			host := strings.Trim(addr, "[]")
+			if host != "" {
+				return host, defaultRPCPort, nil
+			}
+			return "", "", fmt.Errorf("invalid iotdb.rpc_addr %q", addr)
+		}
+		if strings.Count(addr, ":") == 1 {
+			parts := strings.SplitN(addr, ":", 2)
+			if strings.TrimSpace(parts[0]) != "" && strings.TrimSpace(parts[1]) != "" {
+				return parts[0], parts[1], nil
+			}
+			return "", "", fmt.Errorf("invalid iotdb.rpc_addr %q", addr)
+		}
+		if !strings.Contains(addr, ":") && !strings.ContainsAny(addr, "/?#") {
+			return addr, defaultRPCPort, nil
+		}
+		if strings.Count(addr, ":") > 1 {
+			host := strings.Trim(addr, "[]")
+			if net.ParseIP(host) != nil {
+				return host, defaultRPCPort, nil
+			}
+		}
+		return "", "", fmt.Errorf("invalid iotdb.rpc_addr %q", addr)
+	}
+	raw := strings.TrimSpace(it.Addr)
+	if u, err := url.Parse(raw); err == nil && u.Hostname() != "" {
+		return u.Hostname(), defaultRPCPort, nil
+	}
+	if !strings.Contains(raw, "://") {
+		if u, err := url.Parse("http://" + raw); err == nil && u.Hostname() != "" {
+			return u.Hostname(), defaultRPCPort, nil
+		}
+	}
+	return "", "", fmt.Errorf("cannot derive IoTDB RPC host; set iotdb.rpc_addr")
+}
+
+// tablePool lazily creates the single shared native-client session pool. The
+// pool carries no database in its configuration: every query selects its own
+// database with a USE statement on the session it checks out, so a session's
+// leftover database state can never leak into the next query.
+func (it *Iotdb) tablePool() (*client.TableSessionPool, error) {
+	it.poolMu.Lock()
+	defer it.poolMu.Unlock()
+	if it.pool != nil {
+		return it.pool, nil
+	}
+	host, port, err := it.rpcEndpoint()
+	if err != nil {
+		return nil, err
+	}
+	connectTimeout := int(it.DialTimeout)
+	if connectTimeout <= 0 {
+		connectTimeout = 10000
+	}
+	waitTimeout := connectTimeout
+	if waitTimeout < 1000 {
+		waitTimeout = 1000
+	}
+	maxSize := it.MaxIdleConnsPerHost
+	if maxSize <= 0 || maxSize > 64 {
+		maxSize = 8
+	}
+	user, password := "", ""
+	if it.Basic != nil {
+		user, password = it.Basic.User, it.Basic.Password
+	}
+	conf := &client.PoolConfig{Host: host, Port: port, UserName: user, Password: password}
+	pool := client.NewTableSessionPool(conf, maxSize, connectTimeout, waitTimeout, false)
+	it.pool = &pool
+	return it.pool, nil
+}
+
+func (it *Iotdb) rpcTarget() string {
+	host, port, err := it.rpcEndpoint()
+	if err != nil {
+		return "<unknown>"
+	}
+	return net.JoinHostPort(host, port)
+}
+
+// TestRPC performs a real table-model RPC round-trip for Save & Test and
+// deliberately does not log credentials or SQL. When a default database is
+// configured it is validated with a USE statement; otherwise the connection is
+// checked with a database-independent query.
+func (it *Iotdb) TestRPC(ctx context.Context) error {
+	release, err := it.beginQuery()
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	pool, err := it.tablePool()
+	if err != nil {
+		return err
+	}
+	session, err := pool.GetSession()
+	if err != nil {
+		return fmt.Errorf("cannot connect to IoTDB RPC at %s: %w", it.rpcTarget(), err)
+	}
+	defer session.Close()
+	if database := strings.TrimSpace(it.Database); database != "" {
+		// Validating the default database with USE exercises the exact
+		// session-database path queries rely on. ExecuteNonQueryStatement has
+		// no timeout parameter and does not observe ctx cancellation, so a
+		// hung server can stall this one-shot diagnostic; that is accepted.
+		if err := session.ExecuteNonQueryStatement("USE " + quoteIdentifier(database)); err != nil {
+			return fmt.Errorf("cannot USE database %q: %w", database, err)
+		}
+		return nil
+	}
+	timeout := it.queryTimeoutMs(ctx)
+	result, err := session.ExecuteQueryStatement("show databases", &timeout)
+	if err != nil {
+		return fmt.Errorf("IoTDB RPC query failed: %w", err)
+	}
+	return result.Close()
+}
+
+func (it *Iotdb) queryTimeoutMs(ctx context.Context) int64 {
+	timeout := time.Duration(it.Timeout) * time.Millisecond
+	if timeout <= 0 {
+		timeout = time.Duration(defaultQueryTimeoutMs) * time.Millisecond
+	}
+	if deadline, ok := ctx.Deadline(); ok {
+		if remaining := time.Until(deadline); remaining > 0 && remaining < timeout {
+			timeout = remaining
+		}
+	}
+	ms := timeout.Milliseconds()
+	if ms < 1 {
+		ms = 1
+	}
+	return ms
+}
+
+// QueryTable executes table-model SQL over native RPC. The requested database
+// is selected on the checked-out session with a USE statement before the query
+// runs, so a session's leftover database state from an earlier query can never
+// change which database the statement resolves against.
 func (it *Iotdb) QueryTable(ctx context.Context, database, query string, rowLimit int) (APIResponse, error) {
+	var response APIResponse
+	if err := ctx.Err(); err != nil {
+		return response, err
+	}
+	release, err := it.beginQuery()
+	if err != nil {
+		return response, err
+	}
+	defer release()
+
+	database = strings.TrimSpace(database)
+	if database == "" {
+		database = strings.TrimSpace(it.Database)
+	}
+	if database == "" {
+		return response, fmt.Errorf("IoTDB database is required: set a datasource default database or query database")
+	}
+	pool, err := it.tablePool()
+	if err != nil {
+		return response, err
+	}
+	session, err := pool.GetSession()
+	if err != nil {
+		return response, fmt.Errorf("cannot connect to IoTDB RPC at %s: %w", it.rpcTarget(), err)
+	}
+	defer session.Close()
+	result, err := queryOnSession(session, database, query, it.queryTimeoutMs(ctx))
+	if err != nil {
+		return response, err
+	}
+	defer result.Close()
+	columns := result.GetColumnNames()
+	response.ColumnNames = append([]string(nil), columns...)
+	response.Expressions = append([]string(nil), columns...)
+	response.Values = make([][]interface{}, 0)
+	for {
+		hasNext, err := result.Next()
+		if err != nil {
+			return response, err
+		}
+		if !hasNext {
+			break
+		}
+		row := make([]interface{}, len(columns))
+		for i := range columns {
+			value, err := result.GetObjectByIndex(int32(i + 1))
+			if err != nil {
+				return response, err
+			}
+			row[i] = value
+		}
+		response.Values = append(response.Values, row)
+		if rowLimit > 0 && len(response.Values) >= rowLimit {
+			break
+		}
+	}
+	return response, nil
+}
+
+// queryOnSession selects the database on the session and runs the query. It is
+// split out so the USE-before-query ordering and error propagation can be
+// unit-tested against a fake ITableSession without a live server.
+func queryOnSession(session client.ITableSession, database, query string, timeoutMs int64) (*client.SessionDataSet, error) {
+	if err := session.ExecuteNonQueryStatement("USE " + quoteIdentifier(database)); err != nil {
+		return nil, fmt.Errorf("cannot USE database %q: %w", database, err)
+	}
+	result, err := session.ExecuteQueryStatement(strings.TrimSpace(query), ptrInt64(timeoutMs))
+	if err != nil {
+		return nil, fmt.Errorf("IoTDB RPC query failed: %w", err)
+	}
+	if result == nil {
+		return nil, fmt.Errorf("IoTDB RPC query returned no result set")
+	}
+	return result, nil
+}
+
+func ptrInt64(value int64) *int64 { return &value }
+
+func quoteIdentifier(value string) string {
+	return `"` + strings.ReplaceAll(value, `"`, `""`) + `"`
+}
+
+func (it *Iotdb) queryREST(ctx context.Context, database, query string, rowLimit int) (APIResponse, error) {
 	var apiResp APIResponse
+	if strings.TrimSpace(it.Addr) == "" {
+		return apiResp, fmt.Errorf("IoTDB REST address is required for metadata queries")
+	}
+	if it.client == nil {
+		it.InitCli()
+	}
 
 	body, err := json.Marshal(queryRequest{
 		Database: database,
@@ -155,7 +478,7 @@ func (it *Iotdb) QueryTable(ctx context.Context, database, query string, rowLimi
 }
 
 func (it *Iotdb) ShowDatabases(ctx context.Context) ([]string, error) {
-	resp, err := it.QueryTable(ctx, "", "show databases", 0)
+	resp, err := it.queryREST(ctx, "", "show databases", 0)
 	if err != nil {
 		return nil, err
 	}
@@ -165,14 +488,14 @@ func (it *Iotdb) ShowDatabases(ctx context.Context) ([]string, error) {
 func (it *Iotdb) ShowTables(ctx context.Context, database string) ([]string, error) {
 	sql := "show tables"
 	if database == "" {
-		resp, err := it.QueryTable(ctx, "", sql, 0)
+		resp, err := it.queryREST(ctx, "", sql, 0)
 		if err != nil {
 			return nil, err
 		}
 		return firstColumn(resp), nil
 	}
 
-	resp, err := it.QueryTable(ctx, database, sql, 0)
+	resp, err := it.queryREST(ctx, database, sql, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -191,7 +514,7 @@ func (it *Iotdb) DescribeTable(ctx context.Context, query interface{}) ([]*types
 		return nil, fmt.Errorf("table is empty")
 	}
 
-	resp, err := it.QueryTable(ctx, database, fmt.Sprintf("describe %s", table), 0)
+	resp, err := it.queryREST(ctx, database, fmt.Sprintf("describe %s", table), 0)
 	if err != nil {
 		return nil, err
 	}

--- a/dskit/iotdb/iotdb_integration_test.go
+++ b/dskit/iotdb/iotdb_integration_test.go
@@ -1,0 +1,59 @@
+package iotdb
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestRPCIntegration is opt-in because it requires a reachable IoTDB instance
+// and credentials. Keep credentials in the process environment only; never put
+// them in the repository or test output.
+func TestRPCIntegration(t *testing.T) {
+	if os.Getenv("IOTDB_INTEGRATION") != "1" {
+		t.Skip("set IOTDB_INTEGRATION=1 to run the live IoTDB RPC test")
+	}
+
+	addr := strings.TrimSpace(os.Getenv("IOTDB_RPC_ADDR"))
+	user := os.Getenv("IOTDB_USER")
+	password := os.Getenv("IOTDB_PASSWORD")
+	database := strings.TrimSpace(os.Getenv("IOTDB_DATABASE"))
+	if addr == "" || user == "" || password == "" || database == "" {
+		t.Skip("IOTDB_RPC_ADDR, IOTDB_USER, IOTDB_PASSWORD and IOTDB_DATABASE are required")
+	}
+
+	it := &Iotdb{
+		RPCAddr:     addr,
+		Database:    database,
+		Basic:       &IotdbBasicAuth{User: user, Password: password},
+		DialTimeout: 5000,
+		Timeout:     10000,
+	}
+	t.Cleanup(func() { _ = it.Close() })
+
+	ctx := context.Background()
+	if err := it.TestRPC(ctx); err != nil {
+		t.Fatalf("IoTDB RPC health query failed: %v", err)
+	}
+
+	table := strings.TrimSpace(os.Getenv("IOTDB_TEST_TABLE"))
+	if table == "" {
+		table = "active_loading_files_number_total"
+	}
+	valueColumn := strings.TrimSpace(os.Getenv("IOTDB_TEST_VALUE_COLUMN"))
+	if valueColumn == "" {
+		valueColumn = table
+	}
+	resp, err := it.QueryTable(ctx, database,
+		"SELECT time, instance, "+valueColumn+" FROM "+table+" LIMIT 3", 3)
+	if err != nil {
+		t.Fatalf("IoTDB RPC table query failed: %v", err)
+	}
+	if len(resp.ColumnNames) != 3 {
+		t.Fatalf("unexpected columns: %#v", resp.ColumnNames)
+	}
+	if len(resp.Values) == 0 || len(resp.Values) > 3 {
+		t.Fatalf("unexpected row count: %d", len(resp.Values))
+	}
+}

--- a/dskit/iotdb/iotdb_test.go
+++ b/dskit/iotdb/iotdb_test.go
@@ -1,0 +1,208 @@
+package iotdb
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/apache/iotdb-client-go/v2/client"
+)
+
+func TestRPCEndpoint(t *testing.T) {
+	tests := []struct {
+		name, addr, rest, wantHost, wantPort string
+	}{
+		{name: "explicit host port", addr: "192.168.1.2:7777", wantHost: "192.168.1.2", wantPort: "7777"},
+		{name: "explicit url", addr: "http://iotdb.example:7777", wantHost: "iotdb.example", wantPort: "7777"},
+		{name: "explicit host", addr: "iotdb.example", wantHost: "iotdb.example", wantPort: "6667"},
+		{name: "derived from url", rest: "http://iotdb.example:18080", wantHost: "iotdb.example", wantPort: "6667"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotHost, gotPort, err := (&Iotdb{RPCAddr: tt.addr, Addr: tt.rest}).rpcEndpoint()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if gotHost != tt.wantHost || gotPort != tt.wantPort {
+				t.Fatalf("endpoint=%s:%s, want %s:%s", gotHost, gotPort, tt.wantHost, tt.wantPort)
+			}
+		})
+	}
+}
+
+func TestRPCEndpointRequiresAddress(t *testing.T) {
+	_, _, err := (&Iotdb{}).rpcEndpoint()
+	if err == nil || !strings.Contains(err.Error(), "iotdb.rpc_addr") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRPCEndpointRejectsMalformedAddress(t *testing.T) {
+	for _, addr := range []string{"http://", ":6667", "host:", "host/path"} {
+		t.Run(addr, func(t *testing.T) {
+			if _, _, err := (&Iotdb{RPCAddr: addr}).rpcEndpoint(); err == nil {
+				t.Fatalf("expected malformed RPC address %q to fail", addr)
+			}
+		})
+	}
+}
+
+func TestRPCEndpointSupportsIPv6(t *testing.T) {
+	host, port, err := (&Iotdb{RPCAddr: "[2001:db8::1]:7777"}).rpcEndpoint()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if host != "2001:db8::1" || port != "7777" {
+		t.Fatalf("endpoint=%s:%s, want 2001:db8::1:7777", host, port)
+	}
+}
+
+func TestQuoteIdentifier(t *testing.T) {
+	if got := quoteIdentifier(`db"name`); got != `"db""name"` {
+		t.Fatalf("quoted identifier=%q", got)
+	}
+}
+
+func TestQueryTimeoutUsesContextDeadline(t *testing.T) {
+	it := &Iotdb{Timeout: 30000}
+	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Millisecond)
+	defer cancel()
+	time.Sleep(time.Millisecond)
+	got := it.queryTimeoutMs(ctx)
+	if got <= 0 || got > 40 {
+		t.Fatalf("timeout=%dms, want positive value <= 40ms", got)
+	}
+}
+
+func TestRESTQueryErrorPreservesServerMessage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"code":701,"message":"invalid SQL"}`))
+	}))
+	defer server.Close()
+
+	it := &Iotdb{Addr: server.URL, Timeout: 1000}
+	_, err := it.queryREST(context.Background(), "metrics", "select", 0)
+	if err == nil || !strings.Contains(err.Error(), "invalid SQL") {
+		t.Fatalf("expected server error message, got %v", err)
+	}
+}
+
+func TestRPCPoolCreationDoesNotLogPassword(t *testing.T) {
+	it := &Iotdb{RPCAddr: "127.0.0.1:6667", Basic: &IotdbBasicAuth{User: "root", Password: "super-secret"}}
+	if got := fmt.Sprintf("%+v", it); strings.Contains(got, "super-secret") {
+		t.Fatalf("password leaked in formatted datasource: %s", got)
+	}
+}
+
+func TestIotdbStringOmitsPassword(t *testing.T) {
+	it := &Iotdb{RPCAddr: "127.0.0.1:6667", Basic: &IotdbBasicAuth{User: "root", Password: "super-secret"}}
+	if got := it.String(); strings.Contains(got, "super-secret") {
+		t.Fatalf("password leaked in datasource string: %s", got)
+	}
+}
+
+type fakeTableSession struct {
+	calls     []string
+	useErr    error
+	queryErr  error
+	nilResult bool
+}
+
+func (f *fakeTableSession) Insert(_ *client.Tablet) error { return nil }
+
+func (f *fakeTableSession) ExecuteNonQueryStatement(sql string) error {
+	f.calls = append(f.calls, "nonquery:"+sql)
+	return f.useErr
+}
+
+func (f *fakeTableSession) ExecuteQueryStatement(sql string, _ *int64) (*client.SessionDataSet, error) {
+	f.calls = append(f.calls, "query:"+sql)
+	if f.nilResult {
+		return nil, nil
+	}
+	return &client.SessionDataSet{}, f.queryErr
+}
+
+func (f *fakeTableSession) Close() error { return nil }
+
+func TestQueryOnSessionUsesDatabaseBeforeQuery(t *testing.T) {
+	session := &fakeTableSession{}
+	if _, err := queryOnSession(session, "metrics", "SELECT 1", 1000); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{`nonquery:USE "metrics"`, "query:SELECT 1"}
+	if !reflect.DeepEqual(session.calls, want) {
+		t.Fatalf("calls=%v, want %v", session.calls, want)
+	}
+}
+
+func TestQueryOnSessionQuotesDatabaseIdentifier(t *testing.T) {
+	session := &fakeTableSession{}
+	if _, err := queryOnSession(session, `db"name`, "SELECT 1", 1000); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := session.calls[0]; got != `nonquery:USE "db""name"` {
+		t.Fatalf("USE statement=%q, want quoted identifier", got)
+	}
+}
+
+func TestQueryOnSessionSurfacesUseError(t *testing.T) {
+	session := &fakeTableSession{useErr: errors.New("database not found")}
+	_, err := queryOnSession(session, "missing", "SELECT 1", 1000)
+	if err == nil || !strings.Contains(err.Error(), "cannot USE database") {
+		t.Fatalf("expected USE error to surface, got %v", err)
+	}
+	if len(session.calls) != 1 {
+		t.Fatalf("query must not run after a USE error, calls=%v", session.calls)
+	}
+}
+
+func TestQueryOnSessionSurfacesQueryError(t *testing.T) {
+	session := &fakeTableSession{queryErr: errors.New("syntax error")}
+	_, err := queryOnSession(session, "metrics", "SELECT bad", 1000)
+	if err == nil || !strings.Contains(err.Error(), "IoTDB RPC query failed") {
+		t.Fatalf("expected query error to surface, got %v", err)
+	}
+}
+
+func TestQueryOnSessionRejectsNilResult(t *testing.T) {
+	session := &fakeTableSession{nilResult: true}
+	if _, err := queryOnSession(session, "metrics", "SELECT 1", 1000); err == nil {
+		t.Fatal("expected a nil result set to be rejected")
+	}
+}
+
+func TestTablePoolIsReused(t *testing.T) {
+	it := &Iotdb{RPCAddr: "127.0.0.1:6667"}
+	defer it.Close()
+
+	p1, err := it.tablePool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	p2, err := it.tablePool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p1 != p2 {
+		t.Fatal("table pool was not reused")
+	}
+}
+
+func TestBeginQueryRejectsClosedDatasource(t *testing.T) {
+	it := &Iotdb{RPCAddr: "127.0.0.1:6667"}
+	if err := it.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if release, err := it.beginQuery(); err == nil {
+		release()
+		t.Fatal("expected a closed datasource to reject queries")
+	}
+}

--- a/dskit/sqlbase/timeseries.go
+++ b/dskit/sqlbase/timeseries.go
@@ -114,6 +114,9 @@ func FormatMetricValues(keys types.Keys, rows []map[string]interface{}, ignoreDe
 				}
 				metricValue[k] = val
 			case "label":
+				if v == nil {
+					continue
+				}
 				labels[k] = fmt.Sprintf("%v", v)
 			case "time":
 				ts, err := ParseTime(v, keys.TimeFormat)
@@ -125,6 +128,9 @@ func FormatMetricValues(keys types.Keys, rows []map[string]interface{}, ignoreDe
 				// Default to labels for any unrecognized columns
 				if !ignore && keys.LabelKey == "" {
 					// 只有当 labelKey 为空时，才将剩余的列作为 label
+					if v == nil {
+						continue
+					}
 					labels[k] = fmt.Sprintf("%v", v)
 				}
 			}
@@ -132,8 +138,9 @@ func FormatMetricValues(keys types.Keys, rows []map[string]interface{}, ignoreDe
 
 		// Compile and store the metric values
 		for metricName, value := range metricValue {
-			// NaN 无法执行json.Marshal(), 接口会报错
-			if math.IsNaN(value) {
+			// JSON cannot represent NaN or Infinity; skip non-finite samples so a
+			// single malformed/null-derived value does not fail the whole response.
+			if math.IsNaN(value) || math.IsInf(value, 0) {
 				continue
 			}
 

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/alibabacloud-go/openapi-util v0.1.1
 	github.com/alibabacloud-go/tea v1.3.13
 	github.com/alibabacloud-go/tea-utils/v2 v2.0.7
+	github.com/apache/iotdb-client-go/v2 v2.0.8
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de
 	github.com/bitly/go-simplejson v0.5.1
 	github.com/coreos/go-oidc v2.2.1+incompatible
@@ -106,6 +107,7 @@ require (
 	github.com/alibabacloud-go/debug v1.0.1 // indirect
 	github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a // indirect
 	github.com/aliyun/credentials-go v1.4.6 // indirect
+	github.com/apache/thrift v0.24.0 // indirect
 	github.com/aws/aws-sdk-go v1.48.14 // indirect
 	github.com/clbanning/mxj/v2 v2.7.0 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
@@ -230,5 +232,7 @@ require (
 )
 
 replace github.com/olivere/elastic/v7 => github.com/n9e/elastic/v7 v7.0.33-0.20251031061708-f480a2dfcfa7
+
+replace github.com/apache/iotdb-client-go/v2 => /Users/zxq/develop/iotdb-client-go
 
 // replace github.com/flashcatcloud/ibex => ../github.com/flashcatcloud/ibex

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,11 @@ github.com/andybalholm/brotli v1.1.0 h1:eLKJA0d02Lf0mVpIDgYnqXcUn0GqVmEFny3VuID1
 github.com/andybalholm/brotli v1.1.0/go.mod h1:sms7XGricyQI9K10gOSf56VKKWS4oLer58Q+mhRPtnY=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
+github.com/apache/iotdb-client-go/v2 v2.0.8 h1:4Z2bmnoeH9gPNz0cDSfqbvwfyY0Ocbo18vtPfjKo34k=
+github.com/apache/iotdb-client-go/v2 v2.0.8/go.mod h1:keIG+1Xfw8n2NukUbrEcYnnyN9VxP8OJLYvnHsg1k2s=
+github.com/apache/thrift v0.15.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
+github.com/apache/thrift v0.24.0 h1:zy31L1a49QTNB2bG1BBfMXol3yJrTH975G3pPubQVLQ=
+github.com/apache/thrift v0.24.0/go.mod h1:zPt6WxgvTOM6hF92y8C+MkEM5LMxZuk4JcQOiU4Esvs=
 github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de h1:FxWPpzIjnTlhPwqqXc4/vE0f7GvRjuAsbW+HOIe8KnA=
 github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de/go.mod h1:DCaWoUhZrYW9p1lxo/cm8EmUOOzAPSEZNGF2DK1dJgw=
 github.com/armon/go-metrics v0.4.1 h1:hR91U9KYmb6bLBYLQjyM+3j+rcd/UhE+G78SFnF8gJA=
@@ -370,6 +375,7 @@ github.com/golang/mock v1.4.0/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt
 github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
+github.com/golang/mock v1.5.0/go.mod h1:CWnOUgYIOo4TcNZ0wHX3YZCqsaM1I1Jvs6v3mP3KVu8=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/pkg/macros/macros.go
+++ b/pkg/macros/macros.go
@@ -72,7 +72,7 @@ func ExpandTimeFilter(sql string, start, end int64, datasourceType string) (stri
 	// Literals mirror mysql.MySQLType and doris.DorisType; importing those
 	// packages here would create an import cycle, as they import this one.
 	switch datasourceType {
-	case "mysql", "doris":
+	case "mysql", "doris", "iotdb":
 	default:
 		return sql, nil
 	}
@@ -92,6 +92,9 @@ func ExpandTimeFilter(sql string, start, end int64, datasourceType string) (stri
 			return match
 		}
 
+		if datasourceType == "iotdb" {
+			return fmt.Sprintf("(%s >= %d AND %s < %d)", column, start*1000, column, end*1000)
+		}
 		return fmt.Sprintf("(%s >= FROM_UNIXTIME(%d) AND %s < FROM_UNIXTIME(%d))",
 			column, start, column, end)
 	})

--- a/pkg/macros/macros_test.go
+++ b/pkg/macros/macros_test.go
@@ -96,7 +96,7 @@ func TestExpandTimeFilter(t *testing.T) {
 func TestExpandTimeFilterLeavesUnknownDialectsAlone(t *testing.T) {
 	sql := "SELECT count(*) FROM t WHERE $__timeFilter(ts)"
 
-	for _, dsType := range []string{"elasticsearch", "pgsql", "ck", "iotdb", ""} {
+	for _, dsType := range []string{"elasticsearch", "pgsql", "ck", ""} {
 		got, err := ExpandTimeFilter(sql, 1784300000, 1784300060, dsType)
 		assert.NoError(t, err)
 		assert.Equal(t, sql, got, "datasource type %q", dsType)
@@ -108,6 +108,18 @@ func TestExpandTimeFilterLeavesUnknownDialectsAlone(t *testing.T) {
 	assert.Equal(t,
 		"SELECT count(*) FROM t WHERE (ts >= FROM_UNIXTIME(1784300000) AND ts < FROM_UNIXTIME(1784300060))",
 		got)
+}
+
+func TestExpandTimeFilterIoTDB(t *testing.T) {
+	sql := "SELECT time, metric_value FROM table1 WHERE $__timeFilter(time)"
+	got, err := ExpandTimeFilter(sql, 1784300000, 1784300060, "iotdb")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "SELECT time, metric_value FROM table1 WHERE (time >= 1784300000000 AND time < 1784300060000)"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
 }
 
 // A caller that never resolved a time window would otherwise get a predicate


### PR DESCRIPTION
## Summary

This PR migrates Apache IoTDB 2.x table-model SQL query execution from the REST API to the native `apache/iotdb-client-go` RPC client.

REST remains responsible for metadata operations, while table-model SQL queries are executed through a shared native session pool. This implements the backend part of [#3374](https://github.com/ccfos/nightingale/issues/3374).

## Changes

- Add native IoTDB RPC client support for table-model SQL queries.
- Use a shared `TableSessionPool` instead of creating a pool for each database or query.
- Execute `USE "<database>"` before every table-model query.
- Support datasource-level default databases and per-query database overrides.
- Execute IoTDB Save & Test through RPC.
- Keep REST for metadata operations such as:
  - `show databases`
  - `show tables`
  - `describe table`
- Add datasource-level RPC configuration for:
  - RPC address
  - Dial timeout
  - Query timeout
  - Connection pool size
- Protect the session pool from concurrent query and datasource close operations.
- Reject queries after the datasource has been closed and handle cancelled requests before opening a session.
- Preserve compatibility with legacy `metricKey` query payloads.
- Improve table-model response conversion:
  - Normalize time columns.
  - Handle columnar and row-based results.
  - Sanitize `NaN` and infinity values.
  - Skip nil labels and invalid metric values.
- Add IoTDB support for `$__timeFilter`, `$__timeFrom`, and `$__timeTo` macros.
- Preserve IoTDB RPC settings during datasource cache synchronization.

## Compatibility

Existing IoTDB datasources, dashboards, and queries remain supported. Queries without an explicit database use the datasource-level default database. Metadata operations continue to use the configured REST endpoint.

## Validation

- Unit tests and race tests for the IoTDB datasource and session-pool lifecycle.
- `go vet` checks for the affected packages.
- Integration testing against Apache IoTDB 2.0.11.

## Related

- Issue: [#3374](https://github.com/ccfos/nightingale/issues/3374)
- Frontend PR: [n9e/fe#2307](https://github.com/n9e/fe/pull/2307)