### PR TITLE
fix(dscache): back off failed client initialization

### DIFF
--- a/dscache/cache.go
+++ b/dscache/cache.go
@@ -3,6 +3,7 @@ package dscache
 import (
 	"io"
 	"sync"
+	"time"
 
 	"github.com/ccfos/nightingale/v6/datasource"
 	"github.com/toolkits/pkg/logger"
@@ -24,19 +25,38 @@ func closeIfPossible(cate string, dsId int64, ds datasource.Datasource, reason s
 }
 
 type Cache struct {
-	datas map[string]map[int64]datasource.Datasource
-	mutex *sync.RWMutex
+	datas        map[string]map[int64]datasource.Datasource
+	initAttempts map[string]map[int64]initAttempt
+	mutex        *sync.RWMutex
 }
 
+type initAttempt struct {
+	candidate  datasource.Datasource
+	generation uint64
+	inFlight   bool
+	retryAfter time.Time
+}
+
+// 配置没变而远端持续不可达时，不应跟着 2 秒同步周期反复建连、打日志。
+// 30 秒仍能很快感知恢复，同时把失败风暴降到原来的约 1/15。
+var failedInitRetryInterval = 30 * time.Second
+
 var DsCache = Cache{
-	datas: make(map[string]map[int64]datasource.Datasource),
-	mutex: new(sync.RWMutex),
+	datas:        make(map[string]map[int64]datasource.Datasource),
+	initAttempts: make(map[string]map[int64]initAttempt),
+	mutex:        new(sync.RWMutex),
 }
 
 func (cs *Cache) Put(cate string, dsId int64, ds datasource.Datasource) {
 	cs.mutex.Lock()
 	if _, found := cs.datas[cate]; !found {
 		cs.datas[cate] = make(map[int64]datasource.Datasource)
+	}
+	if cs.initAttempts == nil {
+		cs.initAttempts = make(map[string]map[int64]initAttempt)
+	}
+	if _, found := cs.initAttempts[cate]; !found {
+		cs.initAttempts[cate] = make(map[int64]initAttempt)
 	}
 
 	if _, found := cs.datas[cate][dsId]; found {
@@ -45,33 +65,61 @@ func (cs *Cache) Put(cate string, dsId int64, ds datasource.Datasource) {
 			return
 		}
 	}
+
+	now := time.Now()
+	previous, hasPrevious := cs.initAttempts[cate][dsId]
+	if hasPrevious && previous.candidate.Equal(ds) {
+		if previous.inFlight || now.Before(previous.retryAfter) {
+			cs.mutex.Unlock()
+			return
+		}
+	} else {
+		previous.generation++
+	}
+	attempt := initAttempt{
+		candidate:  ds,
+		generation: previous.generation,
+		inFlight:   true,
+	}
+	cs.initAttempts[cate][dsId] = attempt
 	cs.mutex.Unlock()
 
 	// InitClient() 在用户配置错误或远端不可用时, 会非常耗时, mutex被长期持有, 导致Get()会超时
 	err := ds.InitClient()
 	if err != nil {
-		logger.Errorf("init plugin:%s %d %+v client fail: %v", cate, dsId, ds, err)
+		// Datasource errors may embed a DSN or URL credentials. Log only the type;
+		// operators can identify the affected datasource by cate/id without leaking secrets.
+		logger.Errorf("init plugin:%s %d client fail: error_type=%T", cate, dsId, err)
 		// 防御性兜底: 当前 InitClient 实现在失败时通常不会留下半成品(各分支均在 return 前
 		// 自行 Close 或直接未赋值), 此处 Close 多数情况下为 no-op. 保留是为了未来 InitClient
 		// 出现部分初始化状态时不漏关. 注: gorm.Open 内部由 Dialector.Initialize 创建的
 		// *sql.DB 当前架构下无法触达, 那条泄漏需要 InitCli 改为自管 *sql.DB 才能根治.
 		closeIfPossible(cate, dsId, ds, "init failed")
+		cs.mutex.Lock()
+		current, found := cs.initAttempts[cate][dsId]
+		if found && current.generation == attempt.generation {
+			current.inFlight = false
+			current.retryAfter = time.Now().Add(failedInitRetryInterval)
+			cs.initAttempts[cate][dsId] = current
+		}
+		cs.mutex.Unlock()
 		return
 	}
 
-	logger.Debugf("init plugin:%s %d %+v client success", cate, dsId, ds)
+	logger.Debugf("init plugin:%s %d client success", cate, dsId)
 	cs.mutex.Lock()
+	current, found := cs.initAttempts[cate][dsId]
+	if !found || current.generation != attempt.generation {
+		cs.mutex.Unlock()
+		closeIfPossible(cate, dsId, ds, "superseded")
+		return
+	}
 	old := cs.datas[cate][dsId]
 	cs.datas[cate][dsId] = ds
+	delete(cs.initAttempts[cate], dsId)
 	cs.mutex.Unlock()
 	// 替换旧实例时关闭旧值, 在锁外执行避免阻塞读路径.
 	//
-	// TODO(ABA): Put 当前是"读-检查-解锁-初始化-加锁-覆盖"模式, 中间窗口内可能有别的
-	// goroutine 已成功写入更新的 ds. 本次 Put 仍会用本 goroutine 的 ds 无条件覆盖,
-	// 把已生效的更新实例 Close 掉(可能正被 Get 出来的查询使用), 导致并发查询拿到
-	// "sql: database is closed". *sql.DB.Close 会等待 in-flight 查询完成,
-	// 缓解了一部分但不能根治. 根治需要给缓存条目加版本号, Put 写回前对比版本一致才覆盖,
-	// 不一致就 Close 自己新建的 ds. 这是独立改造点, 不在本 PR 范围.
 	if old != nil {
 		closeIfPossible(cate, dsId, old, "replaced")
 	}
@@ -93,6 +141,9 @@ func (cs *Cache) Get(cate string, dsId int64) (datasource.Datasource, bool) {
 
 func (cs *Cache) Delete(cate string, dsId int64) {
 	cs.mutex.Lock()
+	if attempts, found := cs.initAttempts[cate]; found {
+		delete(attempts, dsId)
+	}
 	if _, found := cs.datas[cate]; !found {
 		cs.mutex.Unlock()
 		return
@@ -107,14 +158,30 @@ func (cs *Cache) Delete(cate string, dsId int64) {
 	logger.Debugf("delete plugin:%s %d from cache", cate, dsId)
 }
 
-// GetAllIds 返回缓存中所有数据源的 ID，按类型分组
+// GetAllIds 返回已成功缓存或仍在初始化/退避中的数据源 ID，按类型分组。
+// 同步删除阶段需要看见失败过但尚未入 datas 的条目，避免配置删除后留下退避状态。
 func (cs *Cache) GetAllIds() map[string][]int64 {
 	cs.mutex.RLock()
 	defer cs.mutex.RUnlock()
 	result := make(map[string][]int64)
 	for cate, dsMap := range cs.datas {
-		ids := make([]int64, 0, len(dsMap))
+		ids := make([]int64, 0, len(dsMap)+len(cs.initAttempts[cate]))
 		for dsId := range dsMap {
+			ids = append(ids, dsId)
+		}
+		for dsId := range cs.initAttempts[cate] {
+			if _, cached := dsMap[dsId]; !cached {
+				ids = append(ids, dsId)
+			}
+		}
+		result[cate] = ids
+	}
+	for cate, attempts := range cs.initAttempts {
+		if _, found := result[cate]; found {
+			continue
+		}
+		ids := make([]int64, 0, len(attempts))
+		for dsId := range attempts {
 			ids = append(ids, dsId)
 		}
 		result[cate] = ids

--- a/dscache/cache_test.go
+++ b/dscache/cache_test.go
@@ -1,0 +1,122 @@
+package dscache
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ccfos/nightingale/v6/datasource"
+	"github.com/ccfos/nightingale/v6/models"
+)
+
+type failingDatasource struct {
+	identity string
+	started  chan struct{}
+	release  chan struct{}
+	calls    *atomic.Int64
+	once     sync.Once
+}
+
+func (d *failingDatasource) Init(map[string]interface{}) (datasource.Datasource, error) {
+	return d, nil
+}
+func (d *failingDatasource) InitClient() error {
+	d.calls.Add(1)
+	if d.started != nil {
+		d.once.Do(func() { close(d.started) })
+	}
+	if d.release != nil {
+		<-d.release
+	}
+	return errors.New("fixture unavailable")
+}
+func (d *failingDatasource) Validate(context.Context) error { return nil }
+func (d *failingDatasource) Equal(other datasource.Datasource) bool {
+	value, ok := other.(*failingDatasource)
+	return ok && value.identity == d.identity
+}
+func (d *failingDatasource) MakeLogQuery(context.Context, interface{}, []string, int64, int64) (interface{}, error) {
+	return nil, nil
+}
+func (d *failingDatasource) MakeTSQuery(context.Context, interface{}, []string, int64, int64) (interface{}, error) {
+	return nil, nil
+}
+func (d *failingDatasource) QueryData(context.Context, interface{}) ([]models.DataResp, error) {
+	return nil, nil
+}
+func (d *failingDatasource) QueryLog(context.Context, interface{}) ([]interface{}, int64, error) {
+	return nil, 0, nil
+}
+func (d *failingDatasource) QueryMapData(context.Context, interface{}) ([]map[string]string, error) {
+	return nil, nil
+}
+
+func newTestCache() *Cache {
+	return &Cache{
+		datas:        make(map[string]map[int64]datasource.Datasource),
+		initAttempts: make(map[string]map[int64]initAttempt),
+		mutex:        new(sync.RWMutex),
+	}
+}
+
+func TestPutCoalescesInflightAndBacksOffUnchangedFailure(t *testing.T) {
+	cache := newTestCache()
+	var calls atomic.Int64
+	started := make(chan struct{})
+	release := make(chan struct{})
+	first := &failingDatasource{
+		identity: "same",
+		started:  started,
+		release:  release,
+		calls:    &calls,
+	}
+
+	done := make(chan struct{})
+	go func() {
+		cache.Put("fixture", 1, first)
+		close(done)
+	}()
+	<-started
+	cache.Put("fixture", 1, &failingDatasource{identity: "same", calls: &calls})
+	close(release)
+	<-done
+	cache.Put("fixture", 1, &failingDatasource{identity: "same", calls: &calls})
+
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("unchanged in-flight/backoff datasource should initialize once, got %d", got)
+	}
+}
+
+func TestPutRetriesChangedConfigurationImmediately(t *testing.T) {
+	cache := newTestCache()
+	var calls atomic.Int64
+	oldInterval := failedInitRetryInterval
+	failedInitRetryInterval = time.Hour
+	defer func() { failedInitRetryInterval = oldInterval }()
+
+	cache.Put("fixture", 1, &failingDatasource{identity: "old", calls: &calls})
+	cache.Put("fixture", 1, &failingDatasource{identity: "new", calls: &calls})
+
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("changed datasource configuration should retry immediately, got %d calls", got)
+	}
+}
+
+func TestFailedAttemptRemainsVisibleForDeleteReconciliation(t *testing.T) {
+	cache := newTestCache()
+	var calls atomic.Int64
+	cache.Put("fixture", 7, &failingDatasource{identity: "removed", calls: &calls})
+
+	ids := cache.GetAllIds()["fixture"]
+	if len(ids) != 1 || ids[0] != 7 {
+		t.Fatalf("failed attempt should remain visible to deletion reconciliation, got %v", ids)
+	}
+
+	cache.Delete("fixture", 7)
+	if ids := cache.GetAllIds()["fixture"]; len(ids) != 0 {
+		t.Fatalf("deleted failed attempt should not remain tracked, got %v", ids)
+	}
+}

--- a/dscache/sync.go
+++ b/dscache/sync.go
@@ -128,8 +128,12 @@ func getDatasourcesFromDBLoop(ctx *ctx.Context, fromAPI bool) {
 
 			var dss []datasource.DatasourceInfo
 			for _, item := range items {
-
-				// logger.Debugf("get datasource: %+v", item)
+				// disabled 数据源不建立运行时查询 client：既符合「禁用」语义，也避免导入的待补充鉴权
+				// (pending_auth) 源每 2s 反复 InitClient，堆积连接/goroutine/DB 句柄。排除后
+				// 它们不进 PutDatasources 的 validIds，已注册的会被一并从缓存移除。
+				if item.Status == "disabled" {
+					continue
+				}
 				ds := datasource.DatasourceInfo{
 					Id:             item.Id,
 					Name:           item.Name,
@@ -259,14 +263,14 @@ func PutDatasources(items []datasource.DatasourceInfo, isCenter bool) {
 		}
 
 		if item.Name == "" {
-			logger.Warningf("cluster name is empty, ignore %+v", item)
+			logger.Warningf("cluster name is empty, ignore datasource_id=%d plugin_type=%s", item.Id, item.Type)
 			continue
 		}
 		typ := strings.ReplaceAll(item.Type, ".logging", "")
 
 		ds, err := datasource.GetDatasourceByType(typ, item.Settings)
 		if err != nil {
-			logger.Debugf("get plugin:%+v fail: %v", item, err)
+			logger.Debugf("get plugin datasource_id=%d plugin_type=%s fail: error_type=%T", item.Id, typ, err)
 			continue
 		}
 
@@ -274,7 +278,7 @@ func PutDatasources(items []datasource.DatasourceInfo, isCenter bool) {
 
 		err = ds.Validate(context.Background())
 		if err != nil {
-			logger.Warningf("get plugin:%+v fail: %v", item, err)
+			logger.Warningf("get plugin datasource_id=%d plugin_type=%s fail: error_type=%T", item.Id, typ, err)
 			continue
 		}
 		ids = append(ids, item.Id)
@@ -289,7 +293,7 @@ func PutDatasources(items []datasource.DatasourceInfo, isCenter bool) {
 		go func() {
 			defer func() {
 				if r := recover(); r != nil {
-					logger.Errorf("panic in datasource item: %+v panic:%v", item, r)
+					logger.Errorf("panic in datasource init datasource_id=%d plugin_type=%s panic_type=%T", item.Id, typ, r)
 				}
 			}()
 			DsCache.Put(typ, item.Id, ds)


### PR DESCRIPTION
## 问题\n\n数据源同步每 2 秒执行一次。配置不变且 InitClient 持续失败时，旧逻辑会不断并发重试并打印可能包含鉴权信息的完整对象，造成连接、goroutine 和日志风暴。disabled 数据源也不应初始化运行时 client。\n\n## 修复\n\n- 相同配置的初始化失败退避 30 秒，并合并并发中的重复初始化\n- 配置变化立即重试；用 generation 防止旧初始化覆盖新配置\n- disabled 数据源不建立 client\n- 日志只保留 datasource id/type 和错误类型，不打印配置或错误正文\n- 删除失败数据源时同步清理退避状态\n\n## 验证\n\n- go test ./dscache\n- go test -race ./dscache