### PR TITLE
feat(aiagent): add ibex script task dispatch tool

### DIFF
--- a/aiagent/chat/actions.go
+++ b/aiagent/chat/actions.go
@@ -313,6 +313,7 @@ func selectGeneralChatTools(req *AIChatRequest) []string {
 		"list_alert_mutes", "get_alert_mute_detail",
 		"list_alert_subscribes", "get_alert_subscribe_detail",
 		"list_task_tpls", "get_task_tpl_detail",
+		"get_task_status", "list_task_records",
 		"list_notify_rules", "get_notify_rule_detail",
 		"list_notify_channels", "list_message_templates", "list_notify_rule_custom_params",
 		"list_datasources", "get_datasource_detail",
@@ -347,6 +348,9 @@ func selectGeneralChatTools(req *AIChatRequest) []string {
 		"create_notify_rule", "create_alert_mute", "create_alert_subscribe",
 		"update_alert_rule", "update_dashboard",
 		"update_notify_rule", "update_alert_mute", "update_alert_subscribe",
+		// 任务下发：把 AI 现场生成的脚本下发到指定目标机执行（高危写操作，自动走
+		// 两阶段人在环确认，见 update_proposal 范式）。
+		"dispatch_task_stateless",
 		// 技能创作（skill-creator）：让用户在对话里把流程固化成可复用技能。
 		// 写工具自带 /ai-config/skills 权限门 + 两阶段确认门，只读的发现工具无副作用。
 		"list_skill_builtin_tools", "get_skill", "create_skill", "update_skill",

--- a/aiagent/idempotency.go
+++ b/aiagent/idempotency.go
@@ -8,7 +8,7 @@ import "strings"
 
 // writeToolPrefixes 标记"会产生副作用"的内置工具命名前缀（与路由层抽卡名单的
 // create_*/update_*/import_* 同一命名约定）。
-var writeToolPrefixes = []string{"create_", "update_", "import_", "delete_", "add_"}
+var writeToolPrefixes = []string{"create_", "update_", "import_", "delete_", "add_", "dispatch_"}
 
 // isWriteTool 按命名约定判断工具是否为写类工具。
 func isWriteTool(name string) bool {

--- a/aiagent/idempotency_test.go
+++ b/aiagent/idempotency_test.go
@@ -11,16 +11,17 @@ import (
 
 func TestIsWriteTool(t *testing.T) {
 	for name, want := range map[string]bool{
-		"create_alert_rule": true,
-		"update_dashboard":  true,
-		"import_dashboard":  true,
-		"delete_panel":      true,
-		"get_dashboard":     false,
-		"list_dashboards":   false,
-		"query_prometheus":  false,
-		"load_skill":        false,
-		"search_n9e_docs":   false,
-		"updated_metrics":   false, // 前缀必须是 update_，updated_ 不算
+		"create_alert_rule":       true,
+		"update_dashboard":        true,
+		"import_dashboard":        true,
+		"delete_panel":            true,
+		"dispatch_task_stateless": true, // 一次性下发任务脚本，属高危写操作，参与去重
+		"get_dashboard":           false,
+		"list_dashboards":         false,
+		"query_prometheus":        false,
+		"load_skill":              false,
+		"search_n9e_docs":         false,
+		"updated_metrics":         false, // 前缀必须是 update_，updated_ 不算
 	} {
 		if got := isWriteTool(name); got != want {
 			t.Fatalf("isWriteTool(%q) = %v, want %v", name, got, want)

--- a/aiagent/interrupt.go
+++ b/aiagent/interrupt.go
@@ -35,6 +35,13 @@ type ToolInterrupt struct {
 	// preflight 表单字节级同构）。router 把它渲染成 ContentTypeFormSelect
 	// response——前端契约与 preflight 路径完全一致。
 	Form string `json:"form,omitempty"`
+
+	// ResumeAfterConfirm 仅 approval 类：用户确认并成功重放工具后，是否把工具结果
+	// 回接 agent 续跑（由模型基于结果继续分析）。默认 false = 确认后以回执文案终结
+	// 本轮（update_* 等一次性写操作）；true = 回接 agent（dispatch 场景）。
+	// 归在确认信号（ToolInterrupt）而非 AgentTool：与"是否需要确认"（本中断）天然成对，
+	// 且确认是否触发本就是运行期动态的——由提出确认的 handler 一并决定。
+	ResumeAfterConfirm bool `json:"resume_after_confirm,omitempty"`
 }
 
 const (

--- a/aiagent/native.go
+++ b/aiagent/native.go
@@ -392,6 +392,8 @@ func emitInterrupt(config *ToolLoopConfig, ti *ToolInterrupt, toolName string) {
 			// form 仅 input 类非空：form_select 载荷，路由层渲染成与 preflight
 			// 同契约的表单 response。
 			"form": ti.Form,
+			// 仅 approval 类：确认并重放成功后，是否把工具结果回接 agent 续跑。
+			"resume_after_confirm": ti.ResumeAfterConfirm,
 		},
 		RequestID: config.RequestID,
 		Timestamp: time.Now().UnixMilli(),

--- a/aiagent/tools/defs/defs.go
+++ b/aiagent/tools/defs/defs.go
@@ -956,6 +956,50 @@ var GetTaskTplDetail = aiagent.AgentTool{
 }
 
 // =============================================================================
+// Ibex task dispatch & result
+// =============================================================================
+
+var DispatchTaskStateless = aiagent.AgentTool{
+	Name:        "dispatch_task_stateless",
+	Description: "把一段脚本直接下发到指定目标机执行（无需预建任务模板）。脚本由你现场生成，适合临时/按需运维。靶机上执行脚本属于高危操作，首次调用仅展示脚本全文供用户确认，用户确认后才真正下发。",
+	Type:        aiagent.ToolTypeBuiltin,
+	Parameters: []aiagent.ToolParameter{
+		{Name: "busi_group_id", Type: "integer", Description: "任务所属业务组 ID", Required: true},
+		{Name: "host", Type: "string", Description: "目标机 ident，如 host01", Required: true},
+		{Name: "script", Type: "string", Description: "要在目标机上执行的脚本完整内容（sh/python 等），由你现场生成", Required: true},
+		{Name: "title", Type: "string", Description: "任务标题（展示用），默认 honor: <host>", Required: false},
+		{Name: "account", Type: "string", Description: "执行脚本的操作系统账号，默认 root", Required: false},
+		{Name: "args", Type: "string", Description: "执行脚本时附加的命令行参数", Required: false},
+		{Name: "stdin", Type: "string", Description: "注入脚本 stdin 的 JSON 字符串", Required: false},
+		{Name: "timeout", Type: "integer", Description: "单机执行超时（秒），默认30，上限432000（5天）", Required: false},
+		{Name: "wait_seconds", Type: "integer", Description: "用户确认后自动等待脚本执行结果的最长时间（秒），默认30，上限300；超时未完成会返回当前进度，可再用 get_task_status 查看完整结果", Required: false},
+		{Name: "auth_level", Type: "integer", Description: "AI 任务授权等级 0-3，默认0（沿用业务组授权策略）", Required: false},
+	},
+}
+
+var GetTaskStatus = aiagent.AgentTool{
+	Name:        "get_task_status",
+	Description: "查询一次已下发任务（dispatch_task_stateless）的记录元数据及各目标机的实时执行状态与脚本输出（host/status/stdout/stderr，用于下发后闭环查看结果。",
+	Type:        aiagent.ToolTypeBuiltin,
+	Parameters: []aiagent.ToolParameter{
+		{Name: "task_id", Type: "integer", Description: "任务ID（dispatch_task_stateless 返回的 task_id）", Required: true},
+	},
+}
+
+var ListTaskRecords = aiagent.AgentTool{
+	Name:        "list_task_records",
+	Description: "查询当前用户可见的已下发任务记录（task_record）列表，可按业务组/关键词/时间窗过滤。",
+	Type:        aiagent.ToolTypeBuiltin,
+	Parameters: []aiagent.ToolParameter{
+		{Name: "busi_group_id", Type: "integer", Description: "业务组 ID 过滤；不传则返回当前用户可见的所有业务组记录", Required: false},
+		{Name: "query", Type: "string", Description: "搜索关键词，匹配任务标题", Required: false},
+		{Name: "days", Type: "integer", Description: "只看最近 N 天的记录，默认7", Required: false},
+		{Name: "limit", Type: "integer", Description: "返回数量限制，默认20，最大100", Required: false},
+		{Name: "auth_level", Type: "string", Description: "逗号分隔的授权等级过滤，如 \"0,1\"；不传不过滤", Required: false},
+	},
+}
+
+// =============================================================================
 // Team
 // =============================================================================
 

--- a/aiagent/tools/ibex_task.go
+++ b/aiagent/tools/ibex_task.go
@@ -1,0 +1,461 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	imodels "github.com/flashcatcloud/ibex/src/models"
+
+	"github.com/ccfos/nightingale/v6/aiagent"
+	"github.com/ccfos/nightingale/v6/aiagent/tools/defs"
+	"github.com/ccfos/nightingale/v6/alert/sender"
+	n9emodels "github.com/ccfos/nightingale/v6/models"
+	"github.com/toolkits/pkg/logger"
+)
+
+// 权限常量，与 center/router/router.go 中 /job-tasks 路由的 perm() 一致。
+const (
+	PermJobTasks    = "/job-tasks"
+	PermJobTasksAdd = "/job-tasks/add"
+)
+
+func init() {
+	register(defs.DispatchTaskStateless, dispatchTaskStateless)
+	register(defs.GetTaskStatus, getTaskStatus)
+	register(defs.ListTaskRecords, listTaskRecords)
+}
+
+// dispatchEnabledErr 在 ibex 未启用时给出清晰提示（对齐 run_skill_script 的写法），
+// 避免未开启 ibex 的部署拿到一串 DB/Redis 报错。
+func dispatchEnabledErr() error {
+	return fmt.Errorf("ibex 任务下发未启用，请联系系统管理员开启 ibex；若已开启请确认配置无误")
+}
+
+// checkTargetsExist 校验目标机在平台中存在（对齐 router 的 CheckTargetsExistByIndent）。
+func checkTargetsExist(deps *aiagent.ToolDeps, idents []string) error {
+	notExists, err := n9emodels.TargetNoExistIdents(deps.DBCtx, idents)
+	if err != nil {
+		return err
+	}
+	if len(notExists) > 0 {
+		return fmt.Errorf("targets not exist: %s", strings.Join(notExists, ", "))
+	}
+	return nil
+}
+
+// checkTargetPerm 校验用户对目标机有操作权限（对齐 router 的 CheckTargetPerm）。
+func checkTargetPerm(deps *aiagent.ToolDeps, user *n9emodels.User, idents []string) error {
+	nopri, err := user.NopriIdents(deps.DBCtx, idents)
+	if err != nil {
+		return err
+	}
+	if len(nopri) > 0 {
+		return fmt.Errorf("forbidden: no permission on targets: %s", strings.Join(nopri, ", "))
+	}
+	return nil
+}
+
+// parseAuthLevelsStr 把逗号分隔的授权等级字符串解析为 []int，供 task_record 过滤。
+func parseAuthLevelsStr(s string) []int {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	levels := make([]int, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		if v, err := strconv.Atoi(p); err == nil {
+			levels = append(levels, v)
+		}
+	}
+	return levels
+}
+
+// =============================================================================
+// dispatch_task_stateless：把 AI 现场生成的脚本下发到指定目标机执行。
+//
+// 高危写操作，强制两阶段人在环确认（update_proposal 范式）：
+//   - 首次调用（无 proposal_id 且未 confirmed）：做完整只读校验（权限/业务组/目标机
+//     存在性/脚本格式）后只展示脚本全文并中断等用户确认，不落库、不下发；
+//   - 用户确认后，运行时以保留的 ResumeArgs 确定性重放本工具（confirmed=true +
+//     proposal_id），真正 sender.TaskAdd 下发 + 写 task_record——确认环节零 LLM 参与，
+//     杜绝模型幻觉确认或越权自执行。
+//
+// =============================================================================
+func dispatchTaskStateless(ctx context.Context, deps *aiagent.ToolDeps, args map[string]interface{}, params map[string]string) (string, error) {
+	if deps == nil || !deps.IbexEnabled {
+		return "", dispatchEnabledErr()
+	}
+
+	user, err := getUser(deps, params)
+	if err != nil {
+		return "", err
+	}
+	if err := checkPerm(deps, user, PermJobTasksAdd); err != nil {
+		return "", err
+	}
+
+	bgid := getArgInt64(args, "busi_group_id")
+	host := strings.TrimSpace(getArgString(args, "host"))
+	script := getArgString(args, "script")
+	if bgid == 0 {
+		return "", fmt.Errorf("busi_group_id is required")
+	}
+	if host == "" {
+		return "", fmt.Errorf("host is required")
+	}
+	if strings.TrimSpace(script) == "" {
+		return "", fmt.Errorf("script is required")
+	}
+
+	bg, err := n9emodels.BusiGroupGetById(deps.DBCtx, bgid)
+	if err != nil || bg == nil {
+		return "", fmt.Errorf("busi group not found: %d", bgid)
+	}
+	if err := checkBgRW(deps, user, bg); err != nil {
+		return "", err
+	}
+
+	account := getArgString(args, "account")
+	if account == "" {
+		account = "root"
+	}
+	timeout := getArgInt(args, "timeout", 30)
+	if timeout <= 0 {
+		timeout = 30
+	}
+	if timeout > 3600*24*5 {
+		timeout = 3600 * 24 * 5
+	}
+	authLevel := getArgInt(args, "auth_level", 0)
+	if authLevel < 0 || authLevel > 3 {
+		return "", fmt.Errorf("auth_level invalid, expect 0/1/2/3")
+	}
+	title := strings.TrimSpace(getArgString(args, "title"))
+	if title == "" {
+		title = fmt.Sprintf("AI execute: %s", host)
+	}
+
+	form := n9emodels.TaskForm{
+		Title:     title,
+		Account:   account,
+		Batch:     getArgInt(args, "batch", 0),
+		Tolerance: getArgInt(args, "tolerance", 0),
+		Timeout:   timeout,
+		Script:    script,
+		Args:      getArgString(args, "args"),
+		Stdin:     getArgString(args, "stdin"),
+		Action:    "start",
+		AuthLevel: authLevel,
+		Hosts:     []string{host},
+	}
+
+	// 目标机存在性 + 操作权限校验（均为只读），在不真正下发的前提下尽早拦截。
+	if err := checkTargetsExist(deps, []string{host}); err != nil {
+		return "", err
+	}
+	if err := checkTargetPerm(deps, user, []string{host}); err != nil {
+		return "", err
+	}
+	if err := form.Verify(); err != nil {
+		return "", err
+	}
+
+	baseline := hashConfigs(fmt.Sprintf("%d\x00%s\x00%s", bgid, host, script))
+
+	confirmed := getArgBool(args, "confirmed")
+	if proposalID := getArgString(args, "proposal_id"); !confirmed && proposalID == "" {
+		changeDescs := []string{
+			fmt.Sprintf("目标机: `%s`", host),
+			fmt.Sprintf("执行账号: `%s`", account),
+			fmt.Sprintf("超时: %d 秒", timeout),
+		}
+		if v := getArgString(args, "args"); v != "" {
+			changeDescs = append(changeDescs, fmt.Sprintf("命令行参数: `%s`", v))
+		}
+		changeDescs = append(changeDescs, fmt.Sprintf("脚本正文:\n```\n%s\n```", script))
+
+		resumeArgs := make(map[string]interface{}, len(args))
+		for k, v := range args {
+			resumeArgs[k] = v
+		}
+
+		return proposeUpdateResume(ctx, deps, params, &updateProposal{
+			Kind:         "ibex_task",
+			TargetID:     bgid,
+			BaselineHash: baseline,
+			Changes:      changeDescs,
+		}, renderUpdateProposalPrompt(params["lang"], fmt.Sprintf(
+			aiagent.LangText(params["lang"],
+				"在目标机 **%s** 上执行以下脚本（业务组 %d）",
+				"run the following script on host **%s** (busi group %d)"), host, bgid), changeDescs), resumeArgs)
+	}
+
+	if _, err := confirmUpdateGate(ctx, deps, params, "dispatch_task_stateless", "ibex_task", bgid, getArgString(args, "proposal_id"), confirmed, baseline); err != nil {
+		return "", err
+	}
+
+	taskID, err := sender.TaskAdd(form, user.Username, deps.DBCtx.IsCenter)
+	if err != nil {
+		return "", fmt.Errorf("ibex task add failed: %v", err)
+	}
+
+	record := n9emodels.TaskRecord{
+		Id:        taskID,
+		GroupId:   bgid,
+		Title:     form.Title,
+		Account:   form.Account,
+		Batch:     form.Batch,
+		Tolerance: form.Tolerance,
+		Timeout:   form.Timeout,
+		Script:    form.Script,
+		Args:      form.Args,
+		AuthLevel: form.AuthLevel,
+		CreateAt:  time.Now().Unix(),
+		CreateBy:  user.Username,
+	}
+	if err := record.Add(deps.DBCtx); err != nil {
+		return "", fmt.Errorf("persist task record failed: %v", err)
+	}
+
+	logger.Infof("dispatch_task_stateless: user=%s, task_id=%d, host=%s, title=%s", user.Username, taskID, host, form.Title)
+
+	// confirm 腿：下发成功后自动等待脚本执行完成（最多 wait_seconds，默认30s），
+	// 把最终结果（含 stdout/stderr）直接带回来，避免"确认完就结束、还要用户再问
+	// get_task_status"的断档。超时未完成则返回当前进度并提示用 get_task_status 继续看。
+	waitSeconds := getArgInt(args, "wait_seconds", 30)
+	if waitSeconds < 0 {
+		waitSeconds = 0
+	}
+	if waitSeconds > 300 {
+		waitSeconds = 300
+	}
+	return waitTaskResult(taskID, host, waitSeconds), nil
+}
+
+// ibexTerminalStatuses 是任务的终态集合（来自 ibex agentd/server 的 SetStatus 与
+// 超时处理）。非终态为 waiting/running/killing。
+var ibexTerminalStatuses = map[string]bool{
+	"success": true, "failed": true, "killed": true, "killfailed": true, "timeout": true,
+}
+
+// waitTaskResult 在用户确认下发后轮询 ibex 直到任务终态或超时，返回给用户的可读
+// 结果（markdown）。waitSeconds<=0 表示不等待、直接返回已下发的简要信息。
+func waitTaskResult(taskID int64, host string, waitSeconds int) string {
+	var sts []map[string]string
+	deadline := time.Now().Add(time.Duration(waitSeconds) * time.Second)
+	completed := false
+	for {
+		sts = ibexHostStatus(taskID)
+		if len(sts) > 0 && taskAllTerminal(sts) {
+			completed = true
+		}
+		if completed || waitSeconds <= 0 || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(time.Second)
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "✅ 已在 `%s` 上执行（任务ID: %d）\n", host, taskID)
+	if len(sts) == 0 {
+		sb.WriteString("任务已下发，执行状态暂不可读（可稍后用 get_task_status 查看）。")
+		return sb.String()
+	}
+	for _, s := range sts {
+		fmt.Fprintf(&sb, "- `%s`: **%s**\n", s["host"], s["status"])
+	}
+	for _, key := range []string{"stdout", "stderr"} {
+		if out := sts[0][key]; out != "" {
+			label := "脚本输出"
+			if key == "stderr" {
+				label = "错误输出"
+			}
+			fmt.Fprintf(&sb, "\n%s：\n```\n%s\n```\n", label, out)
+		}
+	}
+	if !completed {
+		sb.WriteString("\n（任务仍在执行中，可稍后用 get_task_status 查看完整结果）")
+	}
+	return sb.String()
+}
+
+// taskAllTerminal 判断所有目标机的执行状态是否都已到达终态。
+func taskAllTerminal(sts []map[string]string) bool {
+	if len(sts) == 0 {
+		return false
+	}
+	for _, s := range sts {
+		if !ibexTerminalStatuses[s["status"]] {
+			return false
+		}
+	}
+	return true
+}
+
+// ibexHostStatus 读取指定任务各目标机的执行状态与脚本输出（stdout/stderr）。
+// 用 imodels.TaskHostGets（而非 TaskHostStatus）以拿到完整字段。ibex 的存储 DB
+// 在本进程内初始化（center 启动 ServerStart 时注入共享 db），读取为只读查询。
+// 用 recover 兜底，避免 ibex 存储未初始化（如 headless/CLI 场景）时 nil 指针 panic。
+// 超大输出会在 stdout/stderr 各截断到 maxOutputBytes，防止撑爆模型上下文。
+func ibexHostStatus(taskID int64) (statuses []map[string]string) {
+	const maxOutputBytes = 16 * 1024 // 单段输出上限 16KiB
+	defer func() {
+		if r := recover(); r != nil {
+			statuses = nil
+		}
+	}()
+	hosts, err := imodels.TaskHostGets(taskID)
+	if err != nil {
+		return nil
+	}
+	for _, h := range hosts {
+		statuses = append(statuses, map[string]string{
+			"host":   h.Host,
+			"status": h.Status,
+			"stdout": truncateUTF8(h.Stdout, maxOutputBytes),
+			"stderr": truncateUTF8(h.Stderr, maxOutputBytes),
+		})
+	}
+	return statuses
+}
+
+// truncateUTF8 按字节界截断字符串，并保证不会从 UTF-8 字符中间切断。
+func truncateUTF8(s string, maxBytes int) string {
+	if len(s) <= maxBytes {
+		return s
+	}
+	for maxBytes > 0 && (s[maxBytes-1]&0xC0) == 0x80 {
+		maxBytes--
+	}
+	return s[:maxBytes] + "...[truncated]"
+}
+
+// =============================================================================
+// get_task_status：查询一次已下发任务记录的元数据及目标机实时执行状态。
+// =============================================================================
+func getTaskStatus(_ context.Context, deps *aiagent.ToolDeps, args map[string]interface{}, params map[string]string) (string, error) {
+	user, err := getUser(deps, params)
+	if err != nil {
+		return "", err
+	}
+	if err := checkPerm(deps, user, PermJobTasks); err != nil {
+		return "", err
+	}
+
+	taskID := getArgInt64(args, "task_id")
+	if taskID == 0 {
+		return "", fmt.Errorf("task_id is required")
+	}
+
+	rec, err := n9emodels.TaskRecordGetById(deps.DBCtx, taskID)
+	if err != nil {
+		return "", fmt.Errorf("failed to get task record: %v", err)
+	}
+	if rec == nil {
+		return fmt.Sprintf(`{"task_id":%d,"error":"task record not found"}`, taskID), nil
+	}
+
+	if !user.IsAdmin() {
+		bgids, _, err := getUserBgids(deps, user)
+		if err != nil {
+			return "", err
+		}
+		if !int64SliceContains(bgids, rec.GroupId) {
+			return "", fmt.Errorf("forbidden: no access to this task")
+		}
+	}
+
+	result := map[string]interface{}{
+		"task_id":    rec.Id,
+		"group_id":   rec.GroupId,
+		"title":      rec.Title,
+		"account":    rec.Account,
+		"timeout":    rec.Timeout,
+		"auth_level": rec.AuthLevel,
+		"create_at":  rec.CreateAt,
+		"create_by":  rec.CreateBy,
+	}
+
+	// 执行状态存于 ibex 侧；仅 ibex 启用时可读，读不到不阻塞返回记录元数据。
+	if deps != nil && deps.IbexEnabled {
+		if sts := ibexHostStatus(rec.Id); len(sts) > 0 {
+			result["hosts"] = sts
+		} else {
+			result["ibex_status_note"] = "执行状态暂不可读（任务可能未开始或 ibex 尚未回填）"
+		}
+	}
+
+	out, _ := json.Marshal(result)
+	return string(out), nil
+}
+
+// =============================================================================
+// list_task_records：按业务组/关键词/时间窗列出用户可见的下发任务记录。
+// =============================================================================
+func listTaskRecords(_ context.Context, deps *aiagent.ToolDeps, args map[string]interface{}, params map[string]string) (string, error) {
+	user, err := getUser(deps, params)
+	if err != nil {
+		return "", err
+	}
+	if err := checkPerm(deps, user, PermJobTasks); err != nil {
+		return "", err
+	}
+
+	limit := getArgInt(args, "limit", 20)
+	if limit < 1 {
+		limit = 20
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	days := getArgInt(args, "days", 7)
+	if days < 1 {
+		days = 7
+	}
+	query := getArgString(args, "query")
+	authLevels := parseAuthLevelsStr(getArgString(args, "auth_level"))
+
+	// 业务组粒度过滤：非管理员只能看自己有权限的组。
+	var gids []int64
+	if bgid := getArgInt64(args, "busi_group_id"); bgid != 0 {
+		if !user.IsAdmin() {
+			perms, _, err := getUserBgids(deps, user)
+			if err != nil {
+				return "", err
+			}
+			if !int64SliceContains(perms, bgid) {
+				return "", fmt.Errorf("forbidden: no access to busi group %d", bgid)
+			}
+		}
+		gids = []int64{bgid}
+	} else if !user.IsAdmin() {
+		var e error
+		gids, _, e = getUserBgids(deps, user)
+		if e != nil {
+			return "", e
+		}
+		if len(gids) == 0 {
+			return marshalList(0, []n9emodels.TaskRecord{}), nil
+		}
+	}
+
+	beginTime := time.Now().Unix() - int64(days)*24*3600
+	total, err := n9emodels.TaskRecordTotal(deps.DBCtx, gids, beginTime, "", query, authLevels)
+	if err != nil {
+		return "", fmt.Errorf("failed to count task records: %v", err)
+	}
+	list, err := n9emodels.TaskRecordGets(deps.DBCtx, gids, beginTime, "", query, authLevels, limit, 0)
+	if err != nil {
+		return "", fmt.Errorf("failed to list task records: %v", err)
+	}
+	return marshalList(int(total), list), nil
+}

--- a/aiagent/tools/ibex_task.go
+++ b/aiagent/tools/ibex_task.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	imodels "github.com/flashcatcloud/ibex/src/models"
 
@@ -238,7 +239,7 @@ func dispatchTaskStateless(ctx context.Context, deps *aiagent.ToolDeps, args map
 	if waitSeconds > 300 {
 		waitSeconds = 300
 	}
-	return waitTaskResult(taskID, host, waitSeconds), nil
+	return waitTaskResult(ctx, taskID, host, waitSeconds), nil
 }
 
 // ibexTerminalStatuses 是任务的终态集合（来自 ibex agentd/server 的 SetStatus 与
@@ -249,10 +250,14 @@ var ibexTerminalStatuses = map[string]bool{
 
 // waitTaskResult 在用户确认下发后轮询 ibex 直到任务终态或超时，返回给用户的可读
 // 结果（markdown）。waitSeconds<=0 表示不等待、直接返回已下发的简要信息。
-func waitTaskResult(taskID int64, host string, waitSeconds int) string {
+// ctx 取消（用户点了 /assistant/message/cancel）立即停止等待并返回当前进度——
+// 任务已经下发出去了，中断的只是等待，结果仍可用 get_task_status 补看。
+func waitTaskResult(ctx context.Context, taskID int64, host string, waitSeconds int) string {
 	var sts []map[string]string
 	deadline := time.Now().Add(time.Duration(waitSeconds) * time.Second)
 	completed := false
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
 	for {
 		sts = ibexHostStatus(taskID)
 		if len(sts) > 0 && taskAllTerminal(sts) {
@@ -261,9 +266,18 @@ func waitTaskResult(taskID int64, host string, waitSeconds int) string {
 		if completed || waitSeconds <= 0 || time.Now().After(deadline) {
 			break
 		}
-		time.Sleep(time.Second)
+		select {
+		case <-ctx.Done():
+			return renderTaskResult(taskID, host, sts, false)
+		case <-ticker.C:
+		}
 	}
 
+	return renderTaskResult(taskID, host, sts, completed)
+}
+
+// renderTaskResult 把各目标机状态渲染成给用户看的 markdown 回执。
+func renderTaskResult(taskID int64, host string, sts []map[string]string, completed bool) string {
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "✅ 已在 `%s` 上执行（任务ID: %d）\n", host, taskID)
 	if len(sts) == 0 {
@@ -329,11 +343,14 @@ func ibexHostStatus(taskID int64) (statuses []map[string]string) {
 }
 
 // truncateUTF8 按字节界截断字符串，并保证不会从 UTF-8 字符中间切断。
+// 判定要看第一个被排除的字节 s[maxBytes]：它是续字节就说明切点落在多字节字符
+// 中间，往前退到该字符的起始位置。看最后一个保留字节 s[maxBytes-1] 是错的——
+// 回退会停在前导字节上，把半个字符留在结果里，产出非法 UTF-8。
 func truncateUTF8(s string, maxBytes int) string {
 	if len(s) <= maxBytes {
 		return s
 	}
-	for maxBytes > 0 && (s[maxBytes-1]&0xC0) == 0x80 {
+	for maxBytes > 0 && !utf8.RuneStart(s[maxBytes]) {
 		maxBytes--
 	}
 	return s[:maxBytes] + "...[truncated]"

--- a/aiagent/tools/ibex_task.go
+++ b/aiagent/tools/ibex_task.go
@@ -155,6 +155,7 @@ func dispatchTaskStateless(ctx context.Context, deps *aiagent.ToolDeps, args map
 		Args:      getArgString(args, "args"),
 		Stdin:     getArgString(args, "stdin"),
 		Action:    "start",
+		Creator:   user.Username,
 		AuthLevel: authLevel,
 		Hosts:     []string{host},
 	}

--- a/aiagent/tools/ibex_task_test.go
+++ b/aiagent/tools/ibex_task_test.go
@@ -1,0 +1,78 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+)
+
+// truncateUTF8 的契约是"按字节截断但绝不切开一个 UTF-8 字符"。判定必须看第一个
+// 被排除的字节，看最后一个保留字节会把前导字节留在结果里，产出非法 UTF-8。
+func TestTruncateUTF8(t *testing.T) {
+	const suffix = "...[truncated]"
+	cases := []struct {
+		name     string
+		s        string
+		maxBytes int
+		want     string
+	}{
+		{"under limit", "abc", 8, "abc"},
+		{"exactly at limit", "abc", 3, "abc"},
+		{"ascii cut", "abcdef", 3, "abc" + suffix},
+		// "aa中中" = 61 61 e4b8ad e4b8ad：切点 3/4 落在第一个"中"内部，只能退到 2；
+		// 切点 5 正好是第二个"中"的起始，无需退让。修复前这三种都会把 e4 留在末尾。
+		{"cut inside first rune", "aa中中", 3, "aa" + suffix},
+		{"cut mid rune", "aa中中", 4, "aa" + suffix},
+		{"cut on rune boundary", "aa中中", 5, "aa中" + suffix},
+		{"cut after full rune", "中中中", 3, "中" + suffix},
+		{"emoji", "a😀b", 3, "a" + suffix},
+		{"all continuation bytes", "\x80\x80\x80", 2, suffix},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := truncateUTF8(c.s, c.maxBytes)
+			if got != c.want {
+				t.Fatalf("truncateUTF8(%q, %d) = %q, want %q", c.s, c.maxBytes, got, c.want)
+			}
+			if !utf8.ValidString(got) {
+				t.Fatalf("truncateUTF8(%q, %d) produced invalid UTF-8: % x", c.s, c.maxBytes, []byte(got))
+			}
+		})
+	}
+}
+
+// 输出会进模型上下文与 Redis 效果台账，长度必须收在 maxBytes 附近（截断标记除外），
+// 且任何切点都不能产出非法 UTF-8。
+func TestTruncateUTF8AlwaysValid(t *testing.T) {
+	s := strings.Repeat("中a😀", 64)
+	for n := 0; n < len(s); n++ {
+		got := truncateUTF8(s, n)
+		if !utf8.ValidString(got) {
+			t.Fatalf("maxBytes=%d produced invalid UTF-8: % x", n, []byte(got))
+		}
+		if n < len(s) && len(got) > n+len("...[truncated]") {
+			t.Fatalf("maxBytes=%d produced %d bytes, over budget", n, len(got))
+		}
+	}
+}
+
+// ctx 取消必须立即结束等待并返回当前进度回执，而不是把确认腿钉在轮询循环里
+// （wait_seconds 上限 300s，期间用户点取消曾经完全无效）。
+func TestWaitTaskResultStopsOnContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := make(chan string, 1)
+	go func() { done <- waitTaskResult(ctx, 1, "host01", 300) }()
+
+	select {
+	case out := <-done:
+		if !strings.Contains(out, "host01") {
+			t.Fatalf("unexpected result on cancel: %q", out)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("waitTaskResult ignored context cancellation")
+	}
+}

--- a/aiagent/tools/update_proposal.go
+++ b/aiagent/tools/update_proposal.go
@@ -224,16 +224,39 @@ func updateBaselineHash(v interface{}) string {
 // fills p.Kind/TargetID/BaselineHash/Changes (and Payload if it precomputes the
 // write); ID/ChatID/SeqID/CreatedAt are stamped here.
 func proposeUpdate(ctx context.Context, deps *aiagent.ToolDeps, params map[string]string, p *updateProposal, prompt string, resumeArgs map[string]interface{}) (string, error) {
+	interrupt, err := stashProposalFn(ctx, deps, params, p, prompt, resumeArgs)
+	if err != nil {
+		return "", err
+	}
+	return "", interrupt
+}
+
+// proposeUpdateResume 与 proposeUpdate 相同，但声明的中断在确认并重放成功后会把
+// 工具结果回接 agent 续跑（ResumeAfterConfirm=true）——而非以终结回执收尾。适合
+// dispatch_task_stateless 这类"确认后让模型基于运行结果继续分析"的工具。确认/重放
+// 的运行时逻辑与 proposedUpdate 完全一致，仅多携带一个续跑语义给路由层。
+func proposeUpdateResume(ctx context.Context, deps *aiagent.ToolDeps, params map[string]string, p *updateProposal, prompt string, resumeArgs map[string]interface{}) (string, error) {
+	interrupt, err := stashProposalFn(ctx, deps, params, p, prompt, resumeArgs)
+	if err != nil {
+		return "", err
+	}
+	interrupt.ResumeAfterConfirm = true
+	return "", interrupt
+}
+
+// stashProposal 生成提案 id、落存并构造发起中断的公共逻辑，proposeUpdate /
+// proposeUpdateResume 共用。
+func stashProposalFn(ctx context.Context, deps *aiagent.ToolDeps, params map[string]string, p *updateProposal, prompt string, resumeArgs map[string]interface{}) (*aiagent.ToolInterrupt, error) {
 	pid, err := newProposalID()
 	if err != nil {
-		return "", fmt.Errorf("failed to generate proposal id: %v", err)
+		return nil, fmt.Errorf("failed to generate proposal id: %v", err)
 	}
 	p.ID = pid
 	p.ChatID = params["chat_id"]
 	p.SeqID, _ = strconv.ParseInt(params["seq_id"], 10, 64)
 	p.CreatedAt = time.Now()
 	if err := updateProposals.put(ctx, deps.Redis, p); err != nil {
-		return "", fmt.Errorf("failed to stash %s proposal: %v", p.Kind, err)
+		return nil, fmt.Errorf("failed to stash %s proposal: %v", p.Kind, err)
 	}
 
 	replay := make(map[string]interface{}, len(resumeArgs)+2)
@@ -243,11 +266,11 @@ func proposeUpdate(ctx context.Context, deps *aiagent.ToolDeps, params map[strin
 	replay["proposal_id"] = pid
 	replay["confirmed"] = true
 	raw, _ := json.Marshal(replay)
-	return "", &aiagent.ToolInterrupt{
+	return &aiagent.ToolInterrupt{
 		Kind:       aiagent.InterruptKindApproval,
 		Prompt:     prompt,
 		ResumeArgs: string(raw),
-	}
+	}, nil
 }
 
 // confirmUpdateGate enforces the guarantees the prompt alone couldn't, shared

--- a/aiagent/types.go
+++ b/aiagent/types.go
@@ -216,6 +216,11 @@ type ToolDeps struct {
 	GetAlertEvalLogs       func(ruleId string) (logs []string, instance string, truncatedReason string, err error)
 	GetEventProcessingLogs func(eventHash string) (logs []string, instance string, truncatedReason string, err error)
 
+	// IbexEnabled 标记本进程是否启用了 ibex 任务下发能力（由宿主从 conf.Ibex.Enable
+	// 注入）。为 false 时，dispatch_task_stateless 等下发工具返回友好提示而非
+	// 一串 DB/Redis 报错；get_task_status 也据此决定是否尝试读取 ibex 侧执行状态。
+	IbexEnabled bool
+
 	// Redis 用于读取主机心跳 (n9e_meta_update_time_*) 和 HostMeta (n9e_meta_*)。
 	// host-health-diagnose skill 的实时态判断（BeatTime / Offset / CpuUtil / MemUtil）从这里来。
 	Redis storage.Redis

--- a/center/router/router_ai_assistant.go
+++ b/center/router/router_ai_assistant.go
@@ -296,8 +296,15 @@ func (rt *Router) processAssistantMessage(parentCtx context.Context, parentCance
 	// 处理（approve = 直接重放工具 apply 腿，分层裁决见 router_ai_interrupt.go），
 	// 不进入 action 解析与 agent 流程；语义不明的回复回归正常流程，pending 不再携带
 	// （旧提案由工具自身 TTL/单次消费门作废）。
-	if prevPending != nil && rt.tryResumePending(state, streamID, prevPending, history, prevRoute, lang) {
-		return
+	// 返回的 continuation（确认成功且工具声明 ResumeAfterConfirm）作为**正式历史上下文**
+	// 追加到 history 末尾，让模型基于工具执行结果继续分析——它是普通 transcript，
+	// 会随上下文投影正常进入模型、并在结束轮持久化到下一轮历史。
+	if prevPending != nil {
+		if handled, continuation := rt.tryResumePending(state, streamID, prevPending, history, prevRoute, lang); handled {
+			return
+		} else if continuation != "" {
+			history = append(history, aiagent.ChatMessage{Role: "user", Content: continuation})
+		}
 	}
 
 	// ② Create LLM client（agent 执行用）
@@ -624,13 +631,15 @@ func (rt *Router) processAssistantMessage(parentCtx context.Context, parentCance
 			toolName, _ := chunk.Metadata["tool"].(string)
 			resumeArgs, _ := chunk.Metadata["resume_args"].(string)
 			interruptForm, _ = chunk.Metadata["form"].(string)
+			resumeAfter, _ := chunk.Metadata["resume_after_confirm"].(bool)
 			pendingI = &models.PendingInterrupt{
-				Kind:       kind,
-				Tool:       toolName,
-				ResumeArgs: resumeArgs,
-				Params:     inputs,
-				Prompt:     chunk.Content,
-				SeqID:      msg.SeqID,
+				Kind:               kind,
+				Tool:               toolName,
+				ResumeArgs:         resumeArgs,
+				Params:             inputs,
+				Prompt:             chunk.Content,
+				SeqID:              msg.SeqID,
+				ResumeAfterConfirm: resumeAfter,
 			}
 		case aiagent.StreamTypeError:
 			errMsg := chunk.Error

--- a/center/router/router_ai_assistant.go
+++ b/center/router/router_ai_assistant.go
@@ -300,7 +300,7 @@ func (rt *Router) processAssistantMessage(parentCtx context.Context, parentCance
 	// 追加到 history 末尾，让模型基于工具执行结果继续分析——它是普通 transcript，
 	// 会随上下文投影正常进入模型、并在结束轮持久化到下一轮历史。
 	if prevPending != nil {
-		if handled, continuation := rt.tryResumePending(state, streamID, prevPending, history, prevRoute, lang); handled {
+		if handled, continuation := rt.tryResumePending(parentCtx, state, streamID, prevPending, history, prevRoute, lang); handled {
 			return
 		} else if continuation != "" {
 			history = append(history, aiagent.ChatMessage{Role: "user", Content: continuation})

--- a/center/router/router_ai_interrupt.go
+++ b/center/router/router_ai_interrupt.go
@@ -186,8 +186,16 @@ func parseApprovalVerdict(out string) string {
 
 // tryResumePending 处理待确认中断。返回 true 表示本轮已被确定性处理完毕
 // （已写终态、调用方直接 return）；false 表示回复语义不明，回归正常 agent 流程。
-func (rt *Router) tryResumePending(state *MessageState, streamID string, pending *models.PendingInterrupt, history []aiagent.ChatMessage, prevRoute *models.ConversationRoute, lang string) bool {
+// 返回 (handled, continuation)：
+//   - handled=true：本轮已被确定性处理完毕（含取消/终态回执），调用方直接 return；
+//   - handled=false 且 continuation==""：回复语义不明（或 input 类），回归正常 agent 流程；
+//   - handled=false 且 continuation!=""：确认成功且工具声明 ResumeAfterConfirm，
+//     由调用方把 continuation 作为正式历史上下文注入 agent，让模型基于结果继续分析。
+func (rt *Router) tryResumePending(state *MessageState, streamID string, pending *models.PendingInterrupt, history []aiagent.ChatMessage, prevRoute *models.ConversationRoute, lang string) (bool, string) {
 	msg := state.Msg()
+	if pending == nil {
+		return false, ""
+	}
 
 	// input 类中断（缺参表单）不做确定性重放：
 	// 表单选择可能改变后续生成（如换了数据源，PromQL 必须重写），重放陈旧参数会
@@ -196,7 +204,7 @@ func (rt *Router) tryResumePending(state *MessageState, streamID string, pending
 	if pending.Kind == aiagent.InterruptKindInput {
 		logger.Infof("[Assistant] pending input tool=%s: re-entering agent flow with enriched context (chat=%s seq=%d)",
 			pending.Tool, msg.ChatID, msg.SeqID)
-		return false
+		return false, ""
 	}
 
 	// 三层裁决：结构化 param → 整串精确匹配 → LLM 意图分类（仅自由文本）。
@@ -216,10 +224,16 @@ func (rt *Router) tryResumePending(state *MessageState, streamID string, pending
 	if verdict == approvalUnclear {
 		logger.Infof("[Assistant] pending %s tool=%s: reply unclear, falling back to agent flow (chat=%s seq=%d)",
 			pending.Kind, pending.Tool, msg.ChatID, msg.SeqID)
-		return false
+		return false, ""
 	}
 
 	var text string
+
+	// 是否"确认后回接 agent 续跑"由提出确认的工具在 propose 腿声明的 flag 决定
+	// （随 PendingInterrupt 持久化，见 ToolInterrupt.ResumeAfterConfirm），而非按
+	// 工具名或静态工具定义判断——与"是否需要确认"同源同址，新增此类工具无需改路由。
+	cont := pending.ResumeAfterConfirm
+
 	if verdict == approvalNo {
 		text = resumeText(lang,
 			"好的，已取消本次改动，原配置保持不变。如需继续调整，直接说明新的要求即可。",
@@ -228,7 +242,13 @@ func (rt *Router) tryResumePending(state *MessageState, streamID string, pending
 	} else if cached, ok := rt.getResumeEffect(resumeEffectKey(msg.ChatID, pending.SeqID, pending.Tool, pending.ResumeArgs)); ok {
 		// 效果台账命中：同一个 pending 已成功重放过
 		// （比如落库后终态持久化失败、客户端重试确认）。幂等返回首次效果，
-		// 绝不二次执行写操作。
+		// 绝不二次执行写操作。cont 工具则直接把首次效果喂回 agent 续跑分析，
+		// 同样避免重复执行。
+		if cont {
+			logger.Infof("[Assistant] pending tool=%s already applied, feeding result back to agent (chat=%s seq=%d)",
+				pending.Tool, msg.ChatID, msg.SeqID)
+			return false, toolContinuationText(lang, cached)
+		}
 		text = formatResumeResult(cached, lang)
 		logger.Infof("[Assistant] pending tool=%s already applied, served from effect ledger (chat=%s seq=%d)",
 			pending.Tool, msg.ChatID, msg.SeqID)
@@ -256,9 +276,16 @@ func (rt *Router) tryResumePending(state *MessageState, streamID string, pending
 				"确认失败：%v\n\n请重新发起修改。",
 				"Confirmation failed: %v\n\nPlease restart the modification."), err)
 		default:
-			text = formatResumeResult(out, lang)
 			// 仅成功记账：瞬时失败保持可重试。
 			rt.putResumeEffect(resumeEffectKey(msg.ChatID, pending.SeqID, pending.Tool, pending.ResumeArgs), out)
+			if cont {
+				// cont 工具确认腿已真正执行并拿到结果：不终结本轮，
+				// 把结果作为正式上下文交回 agent 继续分析（模型基于结果产出最终结论）。
+				logger.Infof("[Assistant] pending tool=%s approved, feeding result back to agent (chat=%s seq=%d)",
+					pending.Tool, msg.ChatID, msg.SeqID)
+				return false, toolContinuationText(lang, out)
+			}
+			text = formatResumeResult(out, lang)
 		}
 		logger.Infof("[Assistant] pending tool=%s approved, replayed deterministically (chat=%s seq=%d handled=%v err=%v)",
 			pending.Tool, msg.ChatID, msg.SeqID, handled, err)
@@ -269,7 +296,15 @@ func (rt *Router) tryResumePending(state *MessageState, streamID string, pending
 		Content:     text,
 	}}
 	rt.finishHaltedMessage(state, streamID, history, responses, prevRoute, text)
-	return true
+	return true, ""
+}
+
+// toolContinuationText 构造把工具执行结果注入 agent 续跑的 user input 载荷。
+// 通过 aiagent.LangText 做中英文案选取，符合 router 其余回执的一致性约定。
+func toolContinuationText(lang, result string) string {
+	return fmt.Sprintf(aiagent.LangText(lang,
+		"\n\n用户已确认，操作已执行完毕。请基于以下执行结果，结合原始请求给出结论（例如：需要处理的对象及理由、下一步建议）。\n\n执行结果：\n%s",
+		"\n\nThe user has confirmed and the operation has completed. Based on the execution result below and the original request, give a conclusion (for example: items to address with reasons, next-step suggestions).\n\nResult:\n%s"), result)
 }
 
 // resumeText 选取确定性 resume 路径的预制文案：这些文案不经 LLM、无法逐语言
@@ -366,6 +401,7 @@ func (rt *Router) buildToolDeps() *aiagent.ToolDeps {
 		GetEventProcessingLogs: rt.getEventLogs,
 		Redis:                  rt.Redis,
 		Sandbox:                rt.Sandbox,
+		IbexEnabled:            rt.Ibex.Enable,
 		// Skill Gateway HTTP passthrough: loopback base for n9e's own API + a hook
 		// to inject a freshly-created user token into the live auth cache so it
 		// works immediately (skips the ~9s sync). 127.0.0.1 reaches our own

--- a/center/router/router_ai_interrupt.go
+++ b/center/router/router_ai_interrupt.go
@@ -184,14 +184,15 @@ func parseApprovalVerdict(out string) string {
 	return approvalUnclear
 }
 
-// tryResumePending 处理待确认中断。返回 true 表示本轮已被确定性处理完毕
-// （已写终态、调用方直接 return）；false 表示回复语义不明，回归正常 agent 流程。
+// tryResumePending 处理待确认中断。ctx 是本轮消息的 parentCtx——确认腿的工具
+// 重放挂在它上面，用户点取消（/assistant/message/cancel）时正在等待的工具能
+// 立即收手（如 dispatch_task_stateless 的执行结果轮询最长会等 300s）。
 // 返回 (handled, continuation)：
 //   - handled=true：本轮已被确定性处理完毕（含取消/终态回执），调用方直接 return；
 //   - handled=false 且 continuation==""：回复语义不明（或 input 类），回归正常 agent 流程；
 //   - handled=false 且 continuation!=""：确认成功且工具声明 ResumeAfterConfirm，
 //     由调用方把 continuation 作为正式历史上下文注入 agent，让模型基于结果继续分析。
-func (rt *Router) tryResumePending(state *MessageState, streamID string, pending *models.PendingInterrupt, history []aiagent.ChatMessage, prevRoute *models.ConversationRoute, lang string) (bool, string) {
+func (rt *Router) tryResumePending(ctx context.Context, state *MessageState, streamID string, pending *models.PendingInterrupt, history []aiagent.ChatMessage, prevRoute *models.ConversationRoute, lang string) (bool, string) {
 	msg := state.Msg()
 	if pending == nil {
 		return false, ""
@@ -265,7 +266,7 @@ func (rt *Router) tryResumePending(state *MessageState, streamID string, pending
 		// 语言用本轮的（而非提案轮快照），confirm 腿的回执文案跟随当前 UI 语言。
 		params["lang"] = lang
 
-		out, handled, err := aiagent.ExecuteBuiltinTool(context.Background(), rt.buildToolDeps(), pending.Tool, params, pending.ResumeArgs)
+		out, handled, err := aiagent.ExecuteBuiltinTool(ctx, rt.buildToolDeps(), pending.Tool, params, pending.ResumeArgs)
 		switch {
 		case !handled:
 			text = fmt.Sprintf(resumeText(lang,

--- a/center/router/router_ai_interrupt_test.go
+++ b/center/router/router_ai_interrupt_test.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -162,8 +163,32 @@ func TestTryResumePendingInputPassthrough(t *testing.T) {
 		msg.Query.Content = content
 		state := NewMessageState(nil, msg)
 		pending := &models.PendingInterrupt{Kind: aiagent.InterruptKindInput, Tool: "create_dashboard", SeqID: 1}
-		if rt.tryResumePending(state, "s1", pending, nil, nil, "") {
-			t.Fatalf("input pending must fall through to agent flow (content=%q)", content)
+		handled, continuation := rt.tryResumePending(context.Background(), state, "s1", pending, nil, nil, "")
+		if handled || continuation != "" {
+			t.Fatalf("input pending must fall through to agent flow (content=%q handled=%v continuation=%q)", content, handled, continuation)
 		}
+	}
+}
+
+// TestToolContinuationText：ResumeAfterConfirm 工具确认成功后，工具结果经这里
+// 包成一条正式的 user 上下文交回 agent 续跑。要点是结果原样带上（模型要基于
+// 真实 stdout/stderr 下结论），且中英文各走各的预制文案。
+func TestToolContinuationText(t *testing.T) {
+	const result = "✅ 已在 `host01` 上执行（任务ID: 42）\n- `host01`: **success**"
+
+	zh := toolContinuationText("zh_CN", result)
+	if !strings.Contains(zh, result) {
+		t.Fatalf("zh continuation must carry the tool result verbatim, got %q", zh)
+	}
+	if !strings.Contains(zh, "用户已确认") {
+		t.Fatalf("zh continuation must use the zh copy, got %q", zh)
+	}
+
+	en := toolContinuationText("en_US", result)
+	if !strings.Contains(en, result) {
+		t.Fatalf("en continuation must carry the tool result verbatim, got %q", en)
+	}
+	if !strings.Contains(en, "The user has confirmed") {
+		t.Fatalf("en continuation must use the en copy, got %q", en)
 	}
 }

--- a/models/ai_assistant.go
+++ b/models/ai_assistant.go
@@ -81,6 +81,10 @@ type PendingInterrupt struct {
 	Params     map[string]string `json:"params"`      // 原轮 AgentRequest.Params（user_id 等；重放时覆盖 chat_id/seq_id）
 	Prompt     string            `json:"prompt"`      // 当时给用户看的确认文案（拒绝/重提案时供上下文）
 	SeqID      int64             `json:"seq_id"`      // 提案所在轮
+
+	// ResumeAfterConfirm 仅 approval 类：确认并成功重放工具后回接 agent 续跑
+	// （读工具在 propose 腿声明的 flag，见 aiagent.ToolInterrupt.ResumeAfterConfirm）。
+	ResumeAfterConfirm bool `json:"resume_after_confirm,omitempty"`
 }
 
 // ConversationRoute 会话级路由状态，随每条 AssistantMessage 持久化、下一轮加载读取。

--- a/models/task_record.go
+++ b/models/task_record.go
@@ -30,6 +30,19 @@ func (r *TaskRecord) TableName() string {
 	return "task_record"
 }
 
+// TaskRecordGetById 按 id 取单条任务下发记录，不存在时返回 nil。
+func TaskRecordGetById(ctx *ctx.Context, id int64) (*TaskRecord, error) {
+	var lst []*TaskRecord
+	err := DB(ctx).Where("id = ?", id).Limit(1).Find(&lst).Error
+	if err != nil {
+		return nil, err
+	}
+	if len(lst) == 0 {
+		return nil, nil
+	}
+	return lst[0], nil
+}
+
 // create task
 func (r *TaskRecord) Add(ctx *ctx.Context) error {
 	if !ctx.IsCenter {


### PR DESCRIPTION
**What type of PR is this?**

 feature

**What this PR does / why we need it**:

Adds an **Ibex script task dispatch** workflow to the AI assistant, letting users issue ad-hoc ops scripts to target hosts directly from the chat and close the loop on results:

- Add `dispatch_task_stateless`: dispatch a script to a target host on demand (no pre-existing task template required), wait for the execution result, and feed stdout/stderr back to the agent to continue analysis;
- Add `get_task_status`: query the metadata of a dispatched task record and the real-time execution status + script output per host;
- Add `list_task_records`: list task dispatch records visible to the current user, filtered by business group / keyword / time window / auth level;
- Since `dispatch_task_stateless` is a high-risk write operation, it enforces **two-phase human-in-the-loop confirmation** following the `update_proposal` pattern: the first call does only read-only validation and shows the full script for the user to confirm; only after confirmation does the runtime deterministically replay the actual dispatch. The confirmation step involves zero LLM participation, preventing model-hallucinated confirmations or unauthorized self-execution;
- Add `ToolInterrupt.ResumeAfterConfirm` continuation semantics: after confirmation and a successful replay, the tool result is injected back into the agent as regular history context so it can conclude from the real execution result. The flag is persisted with the proposal and resolved dynamically from what the tool declares at propose time — no per-tool-name hardcoding in routing;
- Graceful capability fallback: introduce `IbexEnabled` into the process, returning a clear message instead of a cascade of DB/Redis errors when ibex is not enabled.

**Which issue(s) this PR fixes**:

Fixes #

<!-- No related issue; fill in or remove as appropriate -->

**Special notes for your reviewer**:

- Permission alignment: dispatch uses `/job-tasks/add`; query/listing uses `/job-tasks`. Target-existence and operation-permission checks follow the router's `CheckTargetsExistByIndent` / `CheckTargetPerm`;
- Idempotency & dedup: `dispatch_` was added to the write-tool prefix list `writeToolPrefixes` and participates in the confirmation replay effect ledger to avoid duplicate dispatch;
- Output truncation: stdout/stderr are each truncated to 16KiB, keeping UTF-8 boundaries intact so model context is not blown up;
- Long-wait protection: defaults to 30s wait after confirmation (up to 300s); on timeout it returns current progress and suggests `get_task_status` for the full result;


<img width="3828" height="1962" alt="6de5165e66a013a3cd24f2521830f944" src="https://github.com/user-attachments/assets/72654417-c399-432c-aa0a-7e912b298f2a" />
<img width="3828" height="1962" alt="4f91106b4f0bf7aff0cf7e23fc9b0fc8" src="https://github.com/user-attachments/assets/28ec2848-eb3a-4247-be47-0cba1bf10052" />
