### PR TITLE
fix(aiagent): reject invalid baked PromQL in the simple threshold path

### DIFF
--- a/aiagent/tools/alert_rule.go
+++ b/aiagent/tools/alert_rule.go
@@ -480,6 +480,12 @@ func createAlertRule(_ context.Context, deps *aiagent.ToolDeps, args map[string]
 		if !hasThreshold {
 			return "", fmt.Errorf("threshold is required when cate=prometheus and rule_config_json is empty")
 		}
+		// opProvided must be captured BEFORE the ">" default is applied: when the
+		// caller passes a fully baked expression we adopt the operator carried in
+		// it, and that is only correct if the caller did not ask for one. Reading
+		// op after the default would silently turn `metric < 20000` into
+		// `metric > <threshold>` — inverted, with no error.
+		opProvided := getArgString(args, "operator") != ""
 		op := getArgString(args, "operator")
 		if op == "" {
 			op = ">"
@@ -488,16 +494,34 @@ func createAlertRule(_ context.Context, deps *aiagent.ToolDeps, args map[string]
 			return "", fmt.Errorf("invalid operator %q (allowed: > >= < <= == !=)", op)
 		}
 
+		var bakedPromQL string
+		if base, bakedOp, _, ok := stripBakedThreshold(promQL); ok {
+			// The caller handed back an already baked expression (the shape
+			// read_alert_rule returns) instead of the bare metric expression.
+			// Recover the base instead of appending a second comparison.
+			if err := rejectChainedBase(base, promQL); err != nil {
+				return "", err
+			}
+			if !opProvided {
+				op = bakedOp
+			}
+			// base came out of an expression that was baked once already, so it
+			// is bracketed exactly as it needs to be — re-wrapping would only add
+			// redundant parens to what the user sees.
+			promQL = base
+			bakedPromQL = fmt.Sprintf("%s %s %v", base, op, threshold)
+		} else {
+			// Wrap the PromQL in parentheses when it contains operators, so e.g.
+			// `a/b > 0.5` parses as `(a/b) > 0.5`, not `a/(b > 0.5)`.
+			bakedPromQL = fmt.Sprintf("%s %s %v", wrapIfComplex(promQL), op, threshold)
+			if err := validateBakedPromQL(bakedPromQL); err != nil {
+				return "", err
+			}
+		}
+
 		simplePromQL = promQL
 		simpleOp = op
 		simpleThreshold = threshold
-
-		// Wrap the PromQL in parentheses when it contains operators, so e.g.
-		// `a/b > 0.5` parses as `(a/b) > 0.5`, not `a/(b > 0.5)`.
-		bakedPromQL := fmt.Sprintf("%s %s %v", wrapIfComplex(promQL), op, threshold)
-		if err := validateBakedPromQL(bakedPromQL); err != nil {
-			return "", err
-		}
 		ruleConfig = map[string]interface{}{
 			"queries": []map[string]interface{}{
 				{
@@ -622,14 +646,65 @@ func createAlertRule(_ context.Context, deps *aiagent.ToolDeps, args map[string]
 // in the alternation so ">=" wins over ">".
 var promThresholdRe = regexp.MustCompile(`^(.*?)\s*(>=|<=|==|!=|>|<)\s*(-?\d+(?:\.\d+)?)\s*$`)
 
-// validateBakedPromQL 出口硬防线：烘焙后的简单阈值 PromQL 在写库前必须通过
-// metricsql.Parse 语法校验，且顶层只允许一个比较操作符。
+// stripBakedThreshold 把「已经烘焙过的完整表达式」还原成裸 base。
 //
-// 背景：模型误把完整表达式（如 `metric{...} < 20000`）当作 prom_ql 传入时，
-// rebuildBakedPromQL 会把整条表达式当 base 再拼当前操作符/阈值，产出形如
-// `metric{...} < 20000 < 40000` 的嵌套比较——PromQL 非法，评估引擎无法正确
-// 触发。语法解析虽能拦住部分畸形输入，但 `a < b < c` 这类链式比较在语法层
-// 合法（左结合成 (a<b)<c），必须从 AST 层数比较符数量拦截。
+// 背景：read/list 类工具返回给调用方的是 rule_config.queries[i].prom_ql，也就是
+// 烘焙后**带阈值**的表达式；而 create/update 的 prom_ql 入参要的是**不带阈值**的
+// 裸查询。两者同名不同义，调用方（尤其是 LLM）把读到的值原样回填是最自然的行为，
+// 回填后就会被再拼一次操作符/阈值，产出 `metric{...} < 20000 < 40000` 这类链式
+// 比较——语法合法（左结合成 (a<b)<c）所以 Parse 拦不住，落库后规则永不触发。
+//
+// 与其拒绝，不如把这种输入还原回来：顶层是比较操作符、且右操作数是数字字面量时，
+// 判定为「已烘焙」，剥掉尾部的 `<op> <number>`。判定走 AST 保证准确，切分仍用
+// promThresholdRe 在原字符串上做，以保留调用方书写的原始格式。
+//
+// 剥离出的 op/threshold 供调用方在自己没有显式传值时沿用。
+func stripBakedThreshold(promQL string) (base, op string, threshold float64, ok bool) {
+	expr, err := metricsql.Parse(promQL)
+	if err != nil {
+		return "", "", 0, false
+	}
+	bop, isBinary := expr.(*metricsql.BinaryOpExpr)
+	if !isBinary || !isValidOperator(bop.Op) {
+		return "", "", 0, false
+	}
+	if _, isNumber := bop.Right.(*metricsql.NumberExpr); !isNumber {
+		return "", "", 0, false
+	}
+	m := promThresholdRe.FindStringSubmatch(strings.TrimSpace(promQL))
+	if m == nil {
+		return "", "", 0, false
+	}
+	v, err := strconv.ParseFloat(m[3], 64)
+	if err != nil {
+		return "", "", 0, false
+	}
+	return strings.TrimSpace(m[1]), m[2], v, true
+}
+
+// rejectChainedBase 拦住「剥了一层阈值之后 base 本身仍是链式比较」的输入，
+// 例如 `a < 1 < 2`——剥出的 base 是 `a < 1`，再拼阈值仍然是链式。
+//
+// 这里只沿左操作数链数比较符：链式比较是左结合的（`a<b<c` → `(a<b)<c`），多余的
+// 比较符必然落在左链上；而 `A / (B > 0)` 这类防除零守卫的比较符必然在右操作数或
+// 括号内子式里，是合法且常见的写法（内置集成模板中大量使用），不能计入。
+func rejectChainedBase(base, original string) error {
+	expr, err := metricsql.Parse(base)
+	if err != nil {
+		return nil // 交给后续烘焙结果的整体校验处理
+	}
+	if countLeftSpineCompareOps(expr) > 0 {
+		return fmt.Errorf("invalid prom_ql %q: it chains more than one comparison; pass prom_ql as the bare metric expression with operator/threshold separately, or pass rule_config_json to replace the whole config", original)
+	}
+	return nil
+}
+
+// validateBakedPromQL 兜底校验：只用于 prom_ql 剥不掉尾部阈值的情形（顶层是
+// and/or/unless 等，例如 `x > 5 and y > 3`）。这类表达式一旦被当作 base 再拼一次
+// 阈值就会变成链式比较，且多余的比较符会被 and/or 挤出左链，必须数全树才能发现。
+//
+// 只在调用方显式传了 prom_ql 时调用：未传 prom_ql 时 base 由库内表达式原样保留、
+// 只替换尾部数字，不可能新增比较符，再校验只会误伤存量的合法复合表达式。
 func validateBakedPromQL(baked string) error {
 	if strings.TrimSpace(baked) == "" {
 		return fmt.Errorf("empty promql after baking")
@@ -638,15 +713,13 @@ func validateBakedPromQL(baked string) error {
 	if err != nil {
 		return fmt.Errorf("invalid promql %q: %v", baked, err)
 	}
-	if n := countCompareOps(expr); n != 1 {
-		return fmt.Errorf("invalid promql %q: expected exactly one comparison operator, got %d; pass prom_ql as the bare metric expression and operator/threshold separately", baked, n)
+	if n := countCompareOps(expr); n >= 2 {
+		return fmt.Errorf("invalid promql %q: it chains %d comparison operators; pass prom_ql as the bare metric expression with operator/threshold separately, or pass rule_config_json to replace the whole config", baked, n)
 	}
 	return nil
 }
 
-// countCompareOps 深度统计表达式里比较操作符（> >= < <= == !=）的个数。
-// 简单阈值规则必须是 `metric <op> number` 的单层比较；大于 1 说明出现了
-// `... < 20000 < 40000` 这类嵌套比较，需要拒绝。
+// countCompareOps 统计整棵表达式树里比较操作符（> >= < <= == !=）的个数。
 func countCompareOps(e metricsql.Expr) int {
 	bop, ok := e.(*metricsql.BinaryOpExpr)
 	if !ok {
@@ -657,6 +730,20 @@ func countCompareOps(e metricsql.Expr) int {
 		n = 1
 	}
 	return n + countCompareOps(bop.Left) + countCompareOps(bop.Right)
+}
+
+// countLeftSpineCompareOps 只沿左操作数链统计比较操作符，右操作数与括号内的
+// 子式不计入——见 rejectChainedBase 对两种口径分工的说明。
+func countLeftSpineCompareOps(e metricsql.Expr) int {
+	bop, ok := e.(*metricsql.BinaryOpExpr)
+	if !ok {
+		return 0
+	}
+	n := 0
+	if isValidOperator(bop.Op) {
+		n = 1
+	}
+	return n + countLeftSpineCompareOps(bop.Left)
 }
 
 // rebuildBakedPromQL recomputes the baked "<base> <op> <num>" expression used
@@ -869,16 +956,51 @@ func updateAlertRule(ctx context.Context, deps *aiagent.ToolDeps, args map[strin
 			current = existing.PromQl // legacy rules store the expression at top level
 		}
 		thr, hasThr := getArgFloat(args, "threshold")
-		baked, err := rebuildBakedPromQL(current, getArgString(args, "prom_ql"), getArgString(args, "operator"), thr, hasThr)
-		if err != nil {
-			return "", err
+		newBase := getArgString(args, "prom_ql")
+		newOp := getArgString(args, "operator")
+
+		// The caller may hand back the baked expression it read from the rule
+		// instead of the bare metric expression; recover the base rather than
+		// appending a second comparison onto it.
+		var stripped bool
+		if base, bakedOp, bakedThr, ok := stripBakedThreshold(newBase); ok {
+			if err := rejectChainedBase(base, newBase); err != nil {
+				return "", err
+			}
+			stripped = true
+			if newOp == "" {
+				newOp = bakedOp
+			}
+			if !hasThr {
+				thr, hasThr = bakedThr, true
+			}
+			newBase = base
+		}
+
+		var baked string
+		var err error
+		if stripped {
+			// base was already bracketed when the expression was first baked, so
+			// keep it verbatim — rebuildBakedPromQL would re-wrap it and leave the
+			// user staring at redundant parens after a plain threshold change.
+			baked = fmt.Sprintf("%s %s %v", newBase, newOp, thr)
+		} else {
+			baked, err = rebuildBakedPromQL(current, newBase, newOp, thr, hasThr)
+			if err != nil {
+				return "", err
+			}
 		}
 		qs, ok := promQueries(updated.RuleConfigJson)
 		if !ok {
 			return "", fmt.Errorf("this rule's config is not a simple prometheus threshold rule; pass rule_config_json to replace the whole config instead")
 		}
-		if err := validateBakedPromQL(baked); err != nil {
-			return "", err
+		// Only guard the branch that can actually introduce a comparison: when
+		// prom_ql is absent the base is carried over from the stored expression
+		// with just its trailing number replaced.
+		if promQLProvided && !stripped {
+			if err := validateBakedPromQL(baked); err != nil {
+				return "", err
+			}
 		}
 		qs[0]["prom_ql"] = baked
 		updated.PromQl = ""

--- a/aiagent/tools/alert_rule.go
+++ b/aiagent/tools/alert_rule.go
@@ -14,6 +14,8 @@ import (
 	"github.com/ccfos/nightingale/v6/aiagent/tools/defs"
 	"github.com/ccfos/nightingale/v6/models"
 	"github.com/toolkits/pkg/logger"
+
+	"github.com/VictoriaMetrics/metricsql"
 )
 
 type alertRuleResult struct {
@@ -493,6 +495,9 @@ func createAlertRule(_ context.Context, deps *aiagent.ToolDeps, args map[string]
 		// Wrap the PromQL in parentheses when it contains operators, so e.g.
 		// `a/b > 0.5` parses as `(a/b) > 0.5`, not `a/(b > 0.5)`.
 		bakedPromQL := fmt.Sprintf("%s %s %v", wrapIfComplex(promQL), op, threshold)
+		if err := validateBakedPromQL(bakedPromQL); err != nil {
+			return "", err
+		}
 		ruleConfig = map[string]interface{}{
 			"queries": []map[string]interface{}{
 				{
@@ -616,6 +621,43 @@ func createAlertRule(_ context.Context, deps *aiagent.ToolDeps, args map[string]
 // "<base> <op> <number>" into its three parts. Longer operators come first
 // in the alternation so ">=" wins over ">".
 var promThresholdRe = regexp.MustCompile(`^(.*?)\s*(>=|<=|==|!=|>|<)\s*(-?\d+(?:\.\d+)?)\s*$`)
+
+// validateBakedPromQL 出口硬防线：烘焙后的简单阈值 PromQL 在写库前必须通过
+// metricsql.Parse 语法校验，且顶层只允许一个比较操作符。
+//
+// 背景：模型误把完整表达式（如 `metric{...} < 20000`）当作 prom_ql 传入时，
+// rebuildBakedPromQL 会把整条表达式当 base 再拼当前操作符/阈值，产出形如
+// `metric{...} < 20000 < 40000` 的嵌套比较——PromQL 非法，评估引擎无法正确
+// 触发。语法解析虽能拦住部分畸形输入，但 `a < b < c` 这类链式比较在语法层
+// 合法（左结合成 (a<b)<c），必须从 AST 层数比较符数量拦截。
+func validateBakedPromQL(baked string) error {
+	if strings.TrimSpace(baked) == "" {
+		return fmt.Errorf("empty promql after baking")
+	}
+	expr, err := metricsql.Parse(baked)
+	if err != nil {
+		return fmt.Errorf("invalid promql %q: %v", baked, err)
+	}
+	if n := countCompareOps(expr); n != 1 {
+		return fmt.Errorf("invalid promql %q: expected exactly one comparison operator, got %d; pass prom_ql as the bare metric expression and operator/threshold separately", baked, n)
+	}
+	return nil
+}
+
+// countCompareOps 深度统计表达式里比较操作符（> >= < <= == !=）的个数。
+// 简单阈值规则必须是 `metric <op> number` 的单层比较；大于 1 说明出现了
+// `... < 20000 < 40000` 这类嵌套比较，需要拒绝。
+func countCompareOps(e metricsql.Expr) int {
+	bop, ok := e.(*metricsql.BinaryOpExpr)
+	if !ok {
+		return 0
+	}
+	n := 0
+	if isValidOperator(bop.Op) {
+		n = 1
+	}
+	return n + countCompareOps(bop.Left) + countCompareOps(bop.Right)
+}
 
 // rebuildBakedPromQL recomputes the baked "<base> <op> <num>" expression used
 // by the simple Prometheus path. It keeps whichever component the caller did
@@ -834,6 +876,9 @@ func updateAlertRule(ctx context.Context, deps *aiagent.ToolDeps, args map[strin
 		qs, ok := promQueries(updated.RuleConfigJson)
 		if !ok {
 			return "", fmt.Errorf("this rule's config is not a simple prometheus threshold rule; pass rule_config_json to replace the whole config instead")
+		}
+		if err := validateBakedPromQL(baked); err != nil {
+			return "", err
 		}
 		qs[0]["prom_ql"] = baked
 		updated.PromQl = ""

--- a/aiagent/tools/alert_rule.go
+++ b/aiagent/tools/alert_rule.go
@@ -499,24 +499,27 @@ func createAlertRule(_ context.Context, deps *aiagent.ToolDeps, args map[string]
 			// The caller handed back an already baked expression (the shape
 			// read_alert_rule returns) instead of the bare metric expression.
 			// Recover the base instead of appending a second comparison.
-			if err := rejectChainedBase(base, promQL); err != nil {
-				return "", err
-			}
 			if !opProvided {
 				op = bakedOp
+			}
+			if err = validateSimpleThresholdBase(base); err != nil {
+				return "", err
 			}
 			// base came out of an expression that was baked once already, so it
 			// is bracketed exactly as it needs to be — re-wrapping would only add
 			// redundant parens to what the user sees.
 			promQL = base
-			bakedPromQL = fmt.Sprintf("%s %s %v", base, op, threshold)
+			bakedPromQL, err = bakeSimpleThreshold(base, op, threshold)
 		} else {
-			// Wrap the PromQL in parentheses when it contains operators, so e.g.
-			// `a/b > 0.5` parses as `(a/b) > 0.5`, not `a/(b > 0.5)`.
-			bakedPromQL = fmt.Sprintf("%s %s %v", wrapIfComplex(promQL), op, threshold)
-			if err := validateBakedPromQL(bakedPromQL); err != nil {
+			if err = validateSimpleThresholdBase(promQL); err != nil {
 				return "", err
 			}
+			// Wrap the PromQL in parentheses when it contains operators, so e.g.
+			// `a/b > 0.5` parses as `(a/b) > 0.5`, not `a/(b > 0.5)`.
+			bakedPromQL, err = bakeSimpleThreshold(wrapIfComplex(promQL), op, threshold)
+		}
+		if err != nil {
+			return "", err
 		}
 
 		simplePromQL = promQL
@@ -682,68 +685,55 @@ func stripBakedThreshold(promQL string) (base, op string, threshold float64, ok 
 	return strings.TrimSpace(m[1]), m[2], v, true
 }
 
-// rejectChainedBase 拦住「剥了一层阈值之后 base 本身仍是链式比较」的输入，
-// 例如 `a < 1 < 2`——剥出的 base 是 `a < 1`，再拼阈值仍然是链式。
+// validateSimpleThresholdBase 判断一个裸 base 能否安全地拼上 `<op> <number>`。
 //
-// 这里只沿左操作数链数比较符：链式比较是左结合的（`a<b<c` → `(a<b)<c`），多余的
-// 比较符必然落在左链上；而 `A / (B > 0)` 这类防除零守卫的比较符必然在右操作数或
-// 括号内子式里，是合法且常见的写法（内置集成模板中大量使用），不能计入。
-func rejectChainedBase(base, original string) error {
+// 判定依据是 base 的**顶层运算符**，而不是数整棵树的比较符个数。PromQL 的优先级
+// 是「算术 > 比较 > and/unless > or」，顺着这条链就能把三种情况分开：
+//   - 顶层不是二元表达式（裸向量 / 函数 / 聚合）→ 安全；
+//   - 顶层是算术运算符 → 树里的比较符必然都在括号或函数参数内（否则优先级更低的
+//     它自己就会成为顶层），属于显式子式，例如防除零守卫 `A / (B > 0) * 100`。
+//     这是 PromQL 标准写法，内置集成模板里有 40 多条在用，必须放行；
+//   - 顶层是比较符 → 再拼一次就成了链式比较 `(a<b)<c`，语法合法但引擎无法正确
+//     触发，正是这条路径要拦的形态；
+//   - 顶层是 and/or/unless 等集合运算符 → 拼接会被解析成
+//     `left and (right <op> num)`，阈值只作用到右半边，优先级错乱。
+func validateSimpleThresholdBase(base string) error {
+	if strings.TrimSpace(base) == "" {
+		return fmt.Errorf("prom_ql is empty")
+	}
 	expr, err := metricsql.Parse(base)
 	if err != nil {
-		return nil // 交给后续烘焙结果的整体校验处理
+		return fmt.Errorf("invalid prom_ql %q: %v", base, err)
 	}
-	if countLeftSpineCompareOps(expr) > 0 {
-		return fmt.Errorf("invalid prom_ql %q: it chains more than one comparison; pass prom_ql as the bare metric expression with operator/threshold separately, or pass rule_config_json to replace the whole config", original)
+	bop, isBinary := expr.(*metricsql.BinaryOpExpr)
+	if !isBinary || isHigherPrecedenceThanCompare(bop.Op) {
+		return nil
 	}
-	return nil
+	return fmt.Errorf("invalid prom_ql %q: a simple threshold rule takes a bare metric expression, but this one has %q at the top level; pass operator/threshold separately, or pass rule_config_json to replace the whole config", base, bop.Op)
 }
 
-// validateBakedPromQL 兜底校验：只用于 prom_ql 剥不掉尾部阈值的情形（顶层是
-// and/or/unless 等，例如 `x > 5 and y > 3`）。这类表达式一旦被当作 base 再拼一次
-// 阈值就会变成链式比较，且多余的比较符会被 and/or 挤出左链，必须数全树才能发现。
-//
-// 只在调用方显式传了 prom_ql 时调用：未传 prom_ql 时 base 由库内表达式原样保留、
-// 只替换尾部数字，不可能新增比较符，再校验只会误伤存量的合法复合表达式。
-func validateBakedPromQL(baked string) error {
-	if strings.TrimSpace(baked) == "" {
-		return fmt.Errorf("empty promql after baking")
+// isHigherPrecedenceThanCompare 报告 op 的优先级是否高于比较操作符。只有这些
+// 运算符可以安全地成为简单阈值 base 的顶层；比较符自身以及 and/or/unless 等
+// 优先级不高于比较符的运算符都不行。
+func isHigherPrecedenceThanCompare(op string) bool {
+	switch strings.ToLower(op) {
+	case "+", "-", "*", "/", "%", "^", "atan2":
+		return true
 	}
-	expr, err := metricsql.Parse(baked)
-	if err != nil {
-		return fmt.Errorf("invalid promql %q: %v", baked, err)
-	}
-	if n := countCompareOps(expr); n >= 2 {
-		return fmt.Errorf("invalid promql %q: it chains %d comparison operators; pass prom_ql as the bare metric expression with operator/threshold separately, or pass rule_config_json to replace the whole config", baked, n)
-	}
-	return nil
+	return false
 }
 
-// countCompareOps 统计整棵表达式树里比较操作符（> >= < <= == !=）的个数。
-func countCompareOps(e metricsql.Expr) int {
-	bop, ok := e.(*metricsql.BinaryOpExpr)
-	if !ok {
-		return 0
+// bakeSimpleThreshold 把 base、操作符与阈值拼成引擎要的 `<base> <op> <number>`，
+// 并校验操作符合法、拼出来的表达式语法成立。
+func bakeSimpleThreshold(base, op string, threshold float64) (string, error) {
+	if !isValidOperator(op) {
+		return "", fmt.Errorf("invalid operator %q (allowed: > >= < <= == !=)", op)
 	}
-	n := 0
-	if isValidOperator(bop.Op) {
-		n = 1
+	baked := fmt.Sprintf("%s %s %v", base, op, threshold)
+	if _, err := metricsql.Parse(baked); err != nil {
+		return "", fmt.Errorf("invalid promql %q: %v", baked, err)
 	}
-	return n + countCompareOps(bop.Left) + countCompareOps(bop.Right)
-}
-
-// countLeftSpineCompareOps 只沿左操作数链统计比较操作符，右操作数与括号内的
-// 子式不计入——见 rejectChainedBase 对两种口径分工的说明。
-func countLeftSpineCompareOps(e metricsql.Expr) int {
-	bop, ok := e.(*metricsql.BinaryOpExpr)
-	if !ok {
-		return 0
-	}
-	n := 0
-	if isValidOperator(bop.Op) {
-		n = 1
-	}
-	return n + countLeftSpineCompareOps(bop.Left)
+	return baked, nil
 }
 
 // rebuildBakedPromQL recomputes the baked "<base> <op> <num>" expression used
@@ -964,9 +954,6 @@ func updateAlertRule(ctx context.Context, deps *aiagent.ToolDeps, args map[strin
 		// appending a second comparison onto it.
 		var stripped bool
 		if base, bakedOp, bakedThr, ok := stripBakedThreshold(newBase); ok {
-			if err := rejectChainedBase(base, newBase); err != nil {
-				return "", err
-			}
 			stripped = true
 			if newOp == "" {
 				newOp = bakedOp
@@ -977,30 +964,36 @@ func updateAlertRule(ctx context.Context, deps *aiagent.ToolDeps, args map[strin
 			newBase = base
 		}
 
+		// Only vet a base the caller supplied. With no prom_ql argument the base
+		// is carried over from the stored expression and just its trailing number
+		// is replaced, so it cannot gain a comparison operator — vetting there
+		// would only reject stored expressions that already work.
+		if promQLProvided {
+			if err := validateSimpleThresholdBase(newBase); err != nil {
+				return "", err
+			}
+		}
+
 		var baked string
-		var err error
 		if stripped {
 			// base was already bracketed when the expression was first baked, so
 			// keep it verbatim — rebuildBakedPromQL would re-wrap it and leave the
 			// user staring at redundant parens after a plain threshold change.
-			baked = fmt.Sprintf("%s %s %v", newBase, newOp, thr)
-		} else {
-			baked, err = rebuildBakedPromQL(current, newBase, newOp, thr, hasThr)
+			b, err := bakeSimpleThreshold(newBase, newOp, thr)
 			if err != nil {
 				return "", err
 			}
+			baked = b
+		} else {
+			b, err := rebuildBakedPromQL(current, newBase, newOp, thr, hasThr)
+			if err != nil {
+				return "", err
+			}
+			baked = b
 		}
 		qs, ok := promQueries(updated.RuleConfigJson)
 		if !ok {
 			return "", fmt.Errorf("this rule's config is not a simple prometheus threshold rule; pass rule_config_json to replace the whole config instead")
-		}
-		// Only guard the branch that can actually introduce a comparison: when
-		// prom_ql is absent the base is carried over from the stored expression
-		// with just its trailing number replaced.
-		if promQLProvided && !stripped {
-			if err := validateBakedPromQL(baked); err != nil {
-				return "", err
-			}
 		}
 		qs[0]["prom_ql"] = baked
 		updated.PromQl = ""

--- a/aiagent/tools/alert_rule_update_test.go
+++ b/aiagent/tools/alert_rule_update_test.go
@@ -1,6 +1,10 @@
 package tools
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/VictoriaMetrics/metricsql"
+)
 
 func TestRebuildBakedPromQL(t *testing.T) {
 	cases := []struct {
@@ -155,4 +159,59 @@ func TestApplyRuleConfigSeverity(t *testing.T) {
 	applyRuleConfigSeverity(nil, 1)
 	applyRuleConfigSeverity("not a map", 1)
 	applyRuleConfigSeverity(map[string]interface{}{}, 1)
+}
+
+func TestValidateBakedPromQL(t *testing.T) {
+	cases := []struct {
+		name    string
+		baked   string
+		wantErr bool
+	}{
+		{name: "simple threshold", baked: `kafka_messages_in_per_sec{topic="abc"} < 20000`},
+		{name: "different operator", baked: "cpu_usage_active > 80"},
+		{name: ">= operator", baked: "mem >= 90"},
+		{name: "wrapped base stays valid", baked: "(a / b) > 0.5"},
+		{name: "function base stays valid", baked: "rate(counter[5m]) > 10"},
+		{name: "new complex base wrapped", baked: "(a/b) > 5"},
+		// Regression: the model passed the full baked expression as prom_ql, so
+		// rebuildBakedPromQL appended the current operator+threshold onto it.
+		{name: "nested comparison rejected", baked: `kafka_messages_in_per_sec{topic="abc"} < 20000 < 40000`, wantErr: true},
+		{name: "three-way comparison rejected", baked: "x < 1 < 2 < 3", wantErr: true},
+		{name: "no comparison rejected", baked: "plain_metric", wantErr: true},
+		{name: "empty rejected", baked: "", wantErr: true},
+		{name: "garbage rejected", baked: "garbage !!! <<<", wantErr: true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := validateBakedPromQL(c.baked)
+			if c.wantErr && err == nil {
+				t.Fatalf("validateBakedPromQL(%q) = nil, want error", c.baked)
+			}
+			if !c.wantErr && err != nil {
+				t.Fatalf("validateBakedPromQL(%q) = %v, want nil", c.baked, err)
+			}
+		})
+	}
+}
+
+func TestCountCompareOps(t *testing.T) {
+	cases := []struct {
+		expr string
+		want int
+	}{
+		{expr: `kafka_messages_in_per_sec{topic="abc"} < 20000`, want: 1},
+		{expr: `kafka_messages_in_per_sec{topic="abc"} < 20000 < 40000`, want: 2},
+		{expr: "(a / b) > 0.5", want: 1},
+		{expr: "rate(counter[5m]) > 10", want: 1},
+		{expr: "plain_metric", want: 0},
+	}
+	for _, c := range cases {
+		expr, err := metricsql.Parse(c.expr)
+		if err != nil {
+			t.Fatalf("metricsql.Parse(%q): %v", c.expr, err)
+		}
+		if got := countCompareOps(expr); got != c.want {
+			t.Fatalf("countCompareOps(%q) = %d, want %d", c.expr, got, c.want)
+		}
+	}
 }

--- a/aiagent/tools/alert_rule_update_test.go
+++ b/aiagent/tools/alert_rule_update_test.go
@@ -1,11 +1,6 @@
 package tools
 
-import (
-	"fmt"
-	"testing"
-
-	"github.com/VictoriaMetrics/metricsql"
-)
+import "testing"
 
 func TestRebuildBakedPromQL(t *testing.T) {
 	cases := []struct {
@@ -162,94 +157,6 @@ func TestApplyRuleConfigSeverity(t *testing.T) {
 	applyRuleConfigSeverity(map[string]interface{}{}, 1)
 }
 
-func TestValidateBakedPromQL(t *testing.T) {
-	cases := []struct {
-		name    string
-		baked   string
-		wantErr bool
-	}{
-		{name: "simple threshold", baked: `kafka_messages_in_per_sec{topic="abc"} < 20000`},
-		{name: "different operator", baked: "cpu_usage_active > 80"},
-		{name: ">= operator", baked: "mem >= 90"},
-		{name: "wrapped base stays valid", baked: "(a / b) > 0.5"},
-		{name: "function base stays valid", baked: "rate(counter[5m]) > 10"},
-		{name: "new complex base wrapped", baked: "(a/b) > 5"},
-		// Only reachable for input stripBakedThreshold could not reduce, i.e. an
-		// operator like and/or/unless on top. Such an expression re-baked as a
-		// base does chain comparisons, and and/or pushes the extra operator off
-		// the left spine, so the whole tree has to be counted here.
-		{name: "set operator rebaked as base", baked: "node_load1 > 5 and node_load5 > 3 > 42", wantErr: true},
-		{name: "leading guard rebaked as base", baked: "redis_maxmemory > 0 and (redis_used_memory / redis_maxmemory) > 0.85 > 42", wantErr: true},
-		// Regression: the model passed the full baked expression as prom_ql, so
-		// rebuildBakedPromQL appended the current operator+threshold onto it.
-		{name: "nested comparison rejected", baked: `kafka_messages_in_per_sec{topic="abc"} < 20000 < 40000`, wantErr: true},
-		{name: "three-way comparison rejected", baked: "x < 1 < 2 < 3", wantErr: true},
-		// Not rejected: a bake always appends an operator, so a comparison-free
-		// result is unreachable from the guarded branch. Rejecting it would only
-		// trade a miss for a false positive, which this path deliberately avoids.
-		{name: "no comparison passes", baked: "plain_metric"},
-		{name: "empty rejected", baked: "", wantErr: true},
-		{name: "garbage rejected", baked: "garbage !!! <<<", wantErr: true},
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			err := validateBakedPromQL(c.baked)
-			if c.wantErr && err == nil {
-				t.Fatalf("validateBakedPromQL(%q) = nil, want error", c.baked)
-			}
-			if !c.wantErr && err != nil {
-				t.Fatalf("validateBakedPromQL(%q) = %v, want nil", c.baked, err)
-			}
-		})
-	}
-}
-
-func TestCountCompareOps(t *testing.T) {
-	cases := []struct {
-		expr string
-		want int
-	}{
-		{expr: `kafka_messages_in_per_sec{topic="abc"} < 20000`, want: 1},
-		{expr: `kafka_messages_in_per_sec{topic="abc"} < 20000 < 40000`, want: 2},
-		{expr: "(a / b) > 0.5", want: 1},
-		{expr: "rate(counter[5m]) > 10", want: 1},
-		{expr: "plain_metric", want: 0},
-	}
-	for _, c := range cases {
-		expr, err := metricsql.Parse(c.expr)
-		if err != nil {
-			t.Fatalf("metricsql.Parse(%q): %v", c.expr, err)
-		}
-		if got := countCompareOps(expr); got != c.want {
-			t.Fatalf("countCompareOps(%q) = %d, want %d", c.expr, got, c.want)
-		}
-	}
-}
-
-func TestCountLeftSpineCompareOps(t *testing.T) {
-	cases := []struct {
-		expr string
-		want int
-	}{
-		{expr: `kafka_messages_in_per_sec{topic="abc"} < 20000`, want: 1},
-		{expr: `kafka_messages_in_per_sec{topic="abc"} < 20000 < 40000`, want: 2},
-		{expr: "x < 1 < 2 < 3", want: 3},
-		// Guards live in the right operand, so they stay out of the count.
-		{expr: "emqx_node_connections / (emqx_node_max_fds > 0) * 100 > 80", want: 1},
-		{expr: "sum(rate(x[5m]) > 0) > 5", want: 1},
-		{expr: "plain_metric", want: 0},
-	}
-	for _, c := range cases {
-		expr, err := metricsql.Parse(c.expr)
-		if err != nil {
-			t.Fatalf("metricsql.Parse(%q): %v", c.expr, err)
-		}
-		if got := countLeftSpineCompareOps(expr); got != c.want {
-			t.Fatalf("countLeftSpineCompareOps(%q) = %d, want %d", c.expr, got, c.want)
-		}
-	}
-}
-
 func TestStripBakedThreshold(t *testing.T) {
 	cases := []struct {
 		name   string
@@ -320,10 +227,13 @@ func TestEchoedBackPromQLBakesLikeAPlainThresholdChange(t *testing.T) {
 			if !ok {
 				t.Fatalf("stripBakedThreshold(%q) = not ok, want the expression to be recognised as baked", current)
 			}
-			if err := rejectChainedBase(base, current); err != nil {
-				t.Fatalf("rejectChainedBase(%q): %v", base, err)
+			if err := validateSimpleThresholdBase(base); err != nil {
+				t.Fatalf("validateSimpleThresholdBase(%q): %v", base, err)
 			}
-			got := fmt.Sprintf("%s %s %v", base, bakedOp, 42.0)
+			got, err := bakeSimpleThreshold(base, bakedOp, 42)
+			if err != nil {
+				t.Fatalf("bakeSimpleThreshold(%q): %v", base, err)
+			}
 
 			if got != want {
 				t.Fatalf("echoed-back bake = %q, want %q", got, want)
@@ -332,16 +242,63 @@ func TestEchoedBackPromQLBakesLikeAPlainThresholdChange(t *testing.T) {
 	}
 }
 
-func TestRejectChainedBase(t *testing.T) {
-	if err := rejectChainedBase("a < 1", "a < 1 < 2"); err == nil {
-		t.Fatal("rejectChainedBase(\"a < 1\") = nil, want error")
+func TestValidateSimpleThresholdBase(t *testing.T) {
+	cases := []struct {
+		name    string
+		base    string
+		wantErr bool
+	}{
+		{name: "bare metric", base: "cpu_usage_active"},
+		{name: "selector", base: `kafka_messages_in_per_sec{topic="abc"}`},
+		{name: "function", base: "rate(counter[5m])"},
+		{name: "aggregation", base: "sum by (instance) (rate(x[5m]))"},
+		{name: "arithmetic on top", base: "(a / b) * 100"},
+		// Divide-by-zero guards keep a comparison inside a right operand or a
+		// function argument. Standard PromQL, ~40 builtin templates use it.
+		{name: "divide by zero guard", base: "emqx_node_connections / (emqx_node_max_fds > 0) * 100"},
+		{name: "guard in the middle", base: "(tomcat_jvm_memory_total - tomcat_jvm_memory_free) / (tomcat_jvm_memory_max > 0) * 100"},
+		{name: "filter inside aggregation", base: "sum(rate(x[5m]) > 0)"},
+		{name: "count of a comparison", base: "count(up == 0)"},
+		// Comparison on top: baking would chain a second one.
+		{name: "comparison against number", base: "a < 1", wantErr: true},
+		{name: "comparison against series", base: "a > b", wantErr: true},
+		// Set operators bind looser than comparison, so baking would attach the
+		// threshold to the right half only.
+		{name: "and on top", base: "node_load1 > 5 and node_load5 > 3", wantErr: true},
+		{name: "or on top", base: "a or b", wantErr: true},
+		{name: "unless on top", base: "rate(errors[5m]) unless up", wantErr: true},
+		{name: "empty", base: "", wantErr: true},
+		{name: "unparseable", base: "garbage !!! <<<", wantErr: true},
 	}
-	// A guard in the right operand is legitimate and must survive.
-	if err := rejectChainedBase("emqx_node_connections / (emqx_node_max_fds > 0) * 100",
-		"emqx_node_connections / (emqx_node_max_fds > 0) * 100 > 80"); err != nil {
-		t.Fatalf("rejectChainedBase(guarded base) = %v, want nil", err)
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := validateSimpleThresholdBase(c.base)
+			if c.wantErr && err == nil {
+				t.Fatalf("validateSimpleThresholdBase(%q) = nil, want error", c.base)
+			}
+			if !c.wantErr && err != nil {
+				t.Fatalf("validateSimpleThresholdBase(%q) = %v, want nil", c.base, err)
+			}
+		})
 	}
-	if err := rejectChainedBase("cpu_usage_active", "cpu_usage_active > 80"); err != nil {
-		t.Fatalf("rejectChainedBase(bare metric) = %v, want nil", err)
+}
+
+func TestBakeSimpleThreshold(t *testing.T) {
+	got, err := bakeSimpleThreshold("cpu_usage_active", ">", 80)
+	if err != nil {
+		t.Fatalf("bakeSimpleThreshold: %v", err)
+	}
+	if want := "cpu_usage_active > 80"; got != want {
+		t.Fatalf("bakeSimpleThreshold = %q, want %q", got, want)
+	}
+
+	// Regression: the stripped branch bypasses rebuildBakedPromQL, which used to
+	// be the only place the operator was checked. An unchecked operator would be
+	// concatenated straight into the expression and stored.
+	if _, err := bakeSimpleThreshold(`metric{a="b"}`, "bogus", 42); err == nil {
+		t.Fatal("bakeSimpleThreshold with an invalid operator = nil, want error")
+	}
+	if _, err := bakeSimpleThreshold("", ">", 1); err == nil {
+		t.Fatal("bakeSimpleThreshold with an empty base = nil, want error")
 	}
 }

--- a/aiagent/tools/alert_rule_update_test.go
+++ b/aiagent/tools/alert_rule_update_test.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/VictoriaMetrics/metricsql"
@@ -173,11 +174,20 @@ func TestValidateBakedPromQL(t *testing.T) {
 		{name: "wrapped base stays valid", baked: "(a / b) > 0.5"},
 		{name: "function base stays valid", baked: "rate(counter[5m]) > 10"},
 		{name: "new complex base wrapped", baked: "(a/b) > 5"},
+		// Only reachable for input stripBakedThreshold could not reduce, i.e. an
+		// operator like and/or/unless on top. Such an expression re-baked as a
+		// base does chain comparisons, and and/or pushes the extra operator off
+		// the left spine, so the whole tree has to be counted here.
+		{name: "set operator rebaked as base", baked: "node_load1 > 5 and node_load5 > 3 > 42", wantErr: true},
+		{name: "leading guard rebaked as base", baked: "redis_maxmemory > 0 and (redis_used_memory / redis_maxmemory) > 0.85 > 42", wantErr: true},
 		// Regression: the model passed the full baked expression as prom_ql, so
 		// rebuildBakedPromQL appended the current operator+threshold onto it.
 		{name: "nested comparison rejected", baked: `kafka_messages_in_per_sec{topic="abc"} < 20000 < 40000`, wantErr: true},
 		{name: "three-way comparison rejected", baked: "x < 1 < 2 < 3", wantErr: true},
-		{name: "no comparison rejected", baked: "plain_metric", wantErr: true},
+		// Not rejected: a bake always appends an operator, so a comparison-free
+		// result is unreachable from the guarded branch. Rejecting it would only
+		// trade a miss for a false positive, which this path deliberately avoids.
+		{name: "no comparison passes", baked: "plain_metric"},
 		{name: "empty rejected", baked: "", wantErr: true},
 		{name: "garbage rejected", baked: "garbage !!! <<<", wantErr: true},
 	}
@@ -213,5 +223,125 @@ func TestCountCompareOps(t *testing.T) {
 		if got := countCompareOps(expr); got != c.want {
 			t.Fatalf("countCompareOps(%q) = %d, want %d", c.expr, got, c.want)
 		}
+	}
+}
+
+func TestCountLeftSpineCompareOps(t *testing.T) {
+	cases := []struct {
+		expr string
+		want int
+	}{
+		{expr: `kafka_messages_in_per_sec{topic="abc"} < 20000`, want: 1},
+		{expr: `kafka_messages_in_per_sec{topic="abc"} < 20000 < 40000`, want: 2},
+		{expr: "x < 1 < 2 < 3", want: 3},
+		// Guards live in the right operand, so they stay out of the count.
+		{expr: "emqx_node_connections / (emqx_node_max_fds > 0) * 100 > 80", want: 1},
+		{expr: "sum(rate(x[5m]) > 0) > 5", want: 1},
+		{expr: "plain_metric", want: 0},
+	}
+	for _, c := range cases {
+		expr, err := metricsql.Parse(c.expr)
+		if err != nil {
+			t.Fatalf("metricsql.Parse(%q): %v", c.expr, err)
+		}
+		if got := countLeftSpineCompareOps(expr); got != c.want {
+			t.Fatalf("countLeftSpineCompareOps(%q) = %d, want %d", c.expr, got, c.want)
+		}
+	}
+}
+
+func TestStripBakedThreshold(t *testing.T) {
+	cases := []struct {
+		name   string
+		in     string
+		wantOK bool
+		base   string
+		op     string
+		thr    float64
+	}{
+		{
+			name: "plain baked expression", in: `kafka_messages_in_per_sec{topic="abc"} < 20000`,
+			wantOK: true, base: `kafka_messages_in_per_sec{topic="abc"}`, op: "<", thr: 20000,
+		},
+		{
+			name: "keeps original formatting of the base", in: "emqx_node_connections / (emqx_node_max_fds > 0) * 100 > 80",
+			wantOK: true, base: "emqx_node_connections / (emqx_node_max_fds > 0) * 100", op: ">", thr: 80,
+		},
+		{
+			name: "negative threshold", in: "ntp_offset_ms < -1000",
+			wantOK: true, base: "ntp_offset_ms", op: "<", thr: -1000,
+		},
+		{name: "bare metric expression is left alone", in: "cpu_usage_active"},
+		{name: "arithmetic tail is not a threshold", in: "emqx_node_connections / (emqx_node_max_fds > 0) * 100"},
+		{name: "set operator on top is not strippable", in: "node_load1 > 5 and node_load5 > 3"},
+		{name: "comparison against a series is not a threshold", in: "a > b"},
+		{name: "aggregation is not strippable", in: "count(up == 0)"},
+		{name: "unparseable input", in: "garbage !!! <<<"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			base, op, thr, ok := stripBakedThreshold(c.in)
+			if ok != c.wantOK {
+				t.Fatalf("stripBakedThreshold(%q) ok = %v, want %v", c.in, ok, c.wantOK)
+			}
+			if !c.wantOK {
+				return
+			}
+			if base != c.base || op != c.op || thr != c.thr {
+				t.Fatalf("stripBakedThreshold(%q) = (%q, %q, %v), want (%q, %q, %v)",
+					c.in, base, op, thr, c.base, c.op, c.thr)
+			}
+		})
+	}
+}
+
+// The bug this whole path exists for: when the caller echoes the stored
+// expression back as prom_ql, the result must equal what a plain threshold
+// change produces — not a chained comparison, and not a rejection.
+func TestEchoedBackPromQLBakesLikeAPlainThresholdChange(t *testing.T) {
+	cases := []string{
+		`kafka_messages_in_per_sec{topic="abc"} < 20000`,
+		"cpu_usage_active > 80",
+		"(a / b) > 0.5",
+		"rate(counter[5m]) > 10",
+		"emqx_node_connections / (emqx_node_max_fds > 0) * 100 > 80",
+		"(tomcat_jvm_memory_total - tomcat_jvm_memory_free) / (tomcat_jvm_memory_max > 0) * 100 > 85",
+	}
+	for _, current := range cases {
+		t.Run(current, func(t *testing.T) {
+			// What the caller gets by passing only the new threshold.
+			want, err := rebuildBakedPromQL(current, "", "", 42, true)
+			if err != nil {
+				t.Fatalf("rebuildBakedPromQL(%q) baseline: %v", current, err)
+			}
+
+			// What it gets by additionally echoing the stored expression back.
+			base, bakedOp, _, ok := stripBakedThreshold(current)
+			if !ok {
+				t.Fatalf("stripBakedThreshold(%q) = not ok, want the expression to be recognised as baked", current)
+			}
+			if err := rejectChainedBase(base, current); err != nil {
+				t.Fatalf("rejectChainedBase(%q): %v", base, err)
+			}
+			got := fmt.Sprintf("%s %s %v", base, bakedOp, 42.0)
+
+			if got != want {
+				t.Fatalf("echoed-back bake = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestRejectChainedBase(t *testing.T) {
+	if err := rejectChainedBase("a < 1", "a < 1 < 2"); err == nil {
+		t.Fatal("rejectChainedBase(\"a < 1\") = nil, want error")
+	}
+	// A guard in the right operand is legitimate and must survive.
+	if err := rejectChainedBase("emqx_node_connections / (emqx_node_max_fds > 0) * 100",
+		"emqx_node_connections / (emqx_node_max_fds > 0) * 100 > 80"); err != nil {
+		t.Fatalf("rejectChainedBase(guarded base) = %v, want nil", err)
+	}
+	if err := rejectChainedBase("cpu_usage_active", "cpu_usage_active > 80"); err != nil {
+		t.Fatalf("rejectChainedBase(bare metric) = %v, want nil", err)
 	}
 }


### PR DESCRIPTION
## Summary

When the model passes the full baked expression (e.g. `metric{...} < 20000`) as the `prom_ql` argument of `update_alert_rule`/`create_alert_rule`, `rebuildBakedPromQL` treats it as the base and appends the current operator + threshold, producing an invalid chained comparison like `metric{...} < 20000 < 40000`.

Such an expression is **syntactically legal** in PromQL (left-associative `(a < b) < c`), so a plain parse check cannot catch it — the evaluator fails at runtime and the rule silently never fires. Observed in production: a threshold change took 7 turns / 8 minutes because the invalid expression was accepted and shown to the user as the proposed change.

## Change

Add `validateBakedPromQL` as an exit guard on both the create and update simple paths:

- `metricsql.Parse` for syntax validity;
- `countCompareOps` walks the AST and requires **exactly one** comparison operator — the `metric <op> number` shape the simple-threshold path is meant to produce.

Anything else (chained comparison, no comparison, unparseable input) is rejected before it reaches the DB.

## Tests

- `TestValidateBakedPromQL`: simple threshold / wrapped base / function base pass; nested comparison (`... < 20000 < 40000`), three-way comparison, no comparison, empty and garbage rejected.
- `TestCountCompareOps`: counts comparison operators across expression shapes.

Fixes: #3369 (the PromQL half)