### PR TITLE
fix(aiagent): inject explicit guard when user confirms but no proposal is pending

### DIFF
--- a/center/router/router_ai_assistant.go
+++ b/center/router/router_ai_assistant.go
@@ -468,11 +468,12 @@ func (rt *Router) processAssistantMessage(parentCtx context.Context, parentCance
 	inputs := buildAgentInputs(chatReq, userId, msg.ChatID, msg.SeqID)
 
 	// 孤儿确认注入（resumeOrphanInject）：用户明确回复确认意图，但上一条消息没有
-	// 待确认的提案——上一轮模型可能伪造了确认文案而未真正调用 update_* 工具，或
-	// 上一轮就是确认腿的回执轮。此时不能静默进入 agent 流程让模型自由发挥（它可
-	// 能谎报"已确认生效"），而是注入明确约束：没有待确认的提案，不得声称任何改动
-	// 已生效。判定口径见 shouldInjectOrphanResume——这里只认显式确认词，裸词应答
-	// 不算（普通对话轮没有确认上下文兜着）。
+	// 待确认的提案——上一轮模型可能伪造了确认文案而未真正调用写工具，或上一轮就是
+	// 确认腿的回执轮。此时不能静默进入 agent 流程让模型自由发挥（它可能谎报"已确认
+	// 生效"），而是把"无提案"这个事实喂给它，底线是不得声称任何改动已生效。
+	// 判定口径见 shouldInjectOrphanResume——这里只认显式确认词，裸词应答不算
+	// （普通对话轮没有确认上下文兜着）。注入是提示词层的 best-effort，不是确定性
+	// 拦截，文案为何分两支见 orphanResumeDirective。
 	// 透传字段 inputs["orphan_resume"] 让 aiagent 层/工具层可见该场景。
 	if shouldInjectOrphanResume(msg.SeqID, prevPending, msg.Query.Content, msg.Query.Action.Param) {
 		userPrompt += orphanResumeDirective(lang)

--- a/center/router/router_ai_assistant.go
+++ b/center/router/router_ai_assistant.go
@@ -467,13 +467,14 @@ func (rt *Router) processAssistantMessage(parentCtx context.Context, parentCance
 
 	inputs := buildAgentInputs(chatReq, userId, msg.ChatID, msg.SeqID)
 
-	// 孤儿确认注入（resumeOrphanInject）：用户明确回复确认意图（approve 词
-	// 精确命中），但上一条消息没有待确认的提案（prevPending == nil —— 上一轮
-	// 模型可能伪造了确认文案而未真正调用 update_* 工具，或提案已过期/被消费）。
-	// 此时不能静默进入 agent 流程让模型自由发挥（它可能谎报"已确认生效"），
-	// 而是注入明确约束：没有待确认的提案，不得声称任何改动已生效。
+	// 孤儿确认注入（resumeOrphanInject）：用户明确回复确认意图，但上一条消息没有
+	// 待确认的提案——上一轮模型可能伪造了确认文案而未真正调用 update_* 工具，或
+	// 上一轮就是确认腿的回执轮。此时不能静默进入 agent 流程让模型自由发挥（它可
+	// 能谎报"已确认生效"），而是注入明确约束：没有待确认的提案，不得声称任何改动
+	// 已生效。判定口径见 shouldInjectOrphanResume——这里只认显式确认词，裸词应答
+	// 不算（普通对话轮没有确认上下文兜着）。
 	// 透传字段 inputs["orphan_resume"] 让 aiagent 层/工具层可见该场景。
-	if prevPending == nil && classifyApprovalExact(msg.Query.Content) == approvalYes {
+	if shouldInjectOrphanResume(msg.SeqID, prevPending, msg.Query.Content, msg.Query.Action.Param) {
 		userPrompt += orphanResumeDirective(lang)
 		inputs["orphan_resume"] = "1"
 	}

--- a/center/router/router_ai_assistant.go
+++ b/center/router/router_ai_assistant.go
@@ -467,6 +467,17 @@ func (rt *Router) processAssistantMessage(parentCtx context.Context, parentCance
 
 	inputs := buildAgentInputs(chatReq, userId, msg.ChatID, msg.SeqID)
 
+	// 孤儿确认注入（resumeOrphanInject）：用户明确回复确认意图（approve 词
+	// 精确命中），但上一条消息没有待确认的提案（prevPending == nil —— 上一轮
+	// 模型可能伪造了确认文案而未真正调用 update_* 工具，或提案已过期/被消费）。
+	// 此时不能静默进入 agent 流程让模型自由发挥（它可能谎报"已确认生效"），
+	// 而是注入明确约束：没有待确认的提案，不得声称任何改动已生效。
+	// 透传字段 inputs["orphan_resume"] 让 aiagent 层/工具层可见该场景。
+	if prevPending == nil && classifyApprovalExact(msg.Query.Content) == approvalYes {
+		userPrompt += orphanResumeDirective(lang)
+		inputs["orphan_resume"] = "1"
+	}
+
 	// 用 UserPromptRendered 而非 UserPromptTemplate：handler.BuildPrompt 已经用
 	// fmt.Sprintf 把 msg.Query.Content 原样拼进 userPrompt，不能再经 text/template
 	// 解析——否则用户问 "告警模板怎么写 {{ .Alertname }}" 会让 Parse 失败，整轮 500。

--- a/center/router/router_ai_interrupt.go
+++ b/center/router/router_ai_interrupt.go
@@ -314,6 +314,16 @@ func resumeText(lang, zh, en string) string {
 	return aiagent.LangText(lang, zh, en)
 }
 
+// orphanResumeDirective 生成"孤儿确认"注入文案：用户明确回复确认意图，但
+// 上一条消息没有待确认的提案（模型伪造提案文案而未调用工具、或提案已过期/
+// 被消费）。注入到 agent 的 userPrompt，强制模型不得在无提案时声称改动已
+// 生效——这是服务端硬防线，闭合 propose 腿，不依赖模型自觉。
+func orphanResumeDirective(lang string) string {
+	return resumeText(lang,
+		"\n\n【系统提示】用户回复了确认，但当前没有待确认的修改提案（上一轮可能只输出了确认文案而实际未调用修改工具，或提案已失效/已被处理）。请如实告知用户当前没有待确认的修改，不要声称任何改动已生效；如果用户仍要修改，请重新调用对应的 update_* 工具提交新提案。",
+		"\n\n[SYSTEM] The user replied with a confirmation, but there is no pending change proposal right now (the previous turn may only have printed the confirmation copy without actually calling the update tool, or the proposal expired / was already consumed). Tell the user honestly that there is no pending change; do NOT claim anything was applied. If a change is still wanted, call the update_* tool again to submit a fresh proposal.")
+}
+
 // formatResumeResult 把工具 apply 腿的 JSON 结果渲染成给用户看的 markdown；
 // 不认识的形态原样返回。
 func formatResumeResult(out, lang string) string {

--- a/center/router/router_ai_interrupt.go
+++ b/center/router/router_ai_interrupt.go
@@ -354,14 +354,31 @@ func shouldInjectOrphanResume(seqID int64, prevPending *models.PendingInterrupt,
 	return orphanApproveExact[normalizeApprovalText(content)]
 }
 
-// orphanResumeDirective 生成"孤儿确认"注入文案：用户明确回复确认意图，但
-// 上一条消息没有待确认的提案（模型伪造提案文案而未调用工具、或提案已过期/
-// 被消费）。注入到 agent 的 userPrompt，强制模型不得在无提案时声称改动已
-// 生效——这是服务端硬防线，闭合 propose 腿，不依赖模型自觉。
+// orphanResumeDirective 生成"孤儿确认"注入文案：用户明确回复确认意图，但上一条
+// 消息没有待确认的提案（模型伪造提案文案而未调用工具、或提案已过期/被消费）。
+//
+// 这是**提示词层的 best-effort 约束**，不是确定性拦截：模型可以不遵守。真正不
+// 依赖模型自觉的门在工具侧——提案的 TTL / 单次消费 / 基线哈希（见
+// aiagent/tools/update_proposal.go 的 confirmUpdateGate），重放不会双写。这里只
+// 是把"无提案"这个事实喂给模型，压低它编造成功回执的概率。
+//
+// 文案分两支而不是一口咬定"没有待确认的修改"：命中本注入的词
+// （确认/同意/confirm…）同时也是正常对话里请用户拍板时的应答词——内置技能明确
+// 要求模型在候选不唯一时"list them in your reply and ask the user to confirm"
+// （create-alert-rule/SKILL.md），GuidedFollowup 又要求每轮结尾追问下一步，这些
+// 轮次都不产生 PendingInterrupt。词表无法区分"伪造的暂存"和"正常的选项确认"，
+// 所以把判别权交给看得见上文的模型，只把"不得声称已生效"设成两支共同的硬底线。
+// 同理不写死 update_*：误判时用户可能正在确认一次 create_*，指名工具族会误导。
 func orphanResumeDirective(lang string) string {
 	return resumeText(lang,
-		"\n\n【系统提示】用户回复了确认，但当前没有待确认的修改提案（上一轮可能只输出了确认文案而实际未调用修改工具，或提案已失效/已被处理）。请如实告知用户当前没有待确认的修改，不要声称任何改动已生效；如果用户仍要修改，请重新调用对应的 update_* 工具提交新提案。",
-		"\n\n[SYSTEM] The user replied with a confirmation, but there is no pending change proposal right now (the previous turn may only have printed the confirmation copy without actually calling the update tool, or the proposal expired / was already consumed). Tell the user honestly that there is no pending change; do NOT claim anything was applied. If a change is still wanted, call the update_* tool again to submit a fresh proposal.")
+		"\n\n【系统提示】用户回复了确认，但当前没有待确认的修改提案。请按以下口径处理：\n"+
+			"- 如果用户确认的是你上一轮请他选择/拍板的内容（业务组、数据源、库表、方案等），据此继续，直接调用对应的工具完成操作；\n"+
+			"- 如果用户确认的是你上一轮声称\"已暂存、待确认\"的改动，请如实告知用户当前没有待确认的修改（上一轮可能只输出了确认文案而实际未调用工具，或提案已失效/已被处理），并重新调用对应的工具提交新提案。\n"+
+			"无论哪种情况，都不要声称任何改动已生效——除非本轮的工具调用确实返回了成功结果。",
+		"\n\n[SYSTEM] The user replied with a confirmation, but there is no pending change proposal right now. Handle it as follows:\n"+
+			"- If the confirmation refers to a choice you asked the user to make in the previous turn (business group, datasource, database/table, a proposed plan), go ahead and call the appropriate tool to carry it out.\n"+
+			"- If the confirmation refers to a change you claimed was staged and awaiting approval, tell the user honestly that there is no pending change (the previous turn may only have printed the confirmation copy without actually calling the tool, or the proposal expired / was already consumed), then call the appropriate tool again to submit a fresh proposal.\n"+
+			"Either way, do NOT claim anything was applied unless a tool call in THIS turn actually returned success.")
 }
 
 // formatResumeResult 把工具 apply 腿的 JSON 结果渲染成给用户看的 markdown；

--- a/center/router/router_ai_interrupt.go
+++ b/center/router/router_ai_interrupt.go
@@ -92,14 +92,20 @@ var (
 	}
 )
 
+// normalizeApprovalText 把用户回复归一成整串比对用的形态。两张确认词表
+// （approveExact / orphanApproveExact）共用它，避免各写一份 trim 集后漂移。
+// trim 集含反引号/引号：A2A 协议提示写的是 Reply exactly `approve`，上游
+// LLM 把 exactly 理解为连反引号照抄时回复是 "`approve`"——自己的协议提示
+// 必须自己接得住，否则白白多烧一次 LLM 分类调用。
+func normalizeApprovalText(text string) string {
+	t := strings.ToLower(strings.TrimSpace(text))
+	return strings.Trim(t, "。.!！~ `\"'“”‘’「」")
+}
+
 // classifyApprovalExact 整串精确匹配层。命不中返回 unclear，由调用方决定是否
 // 升级 LLM 分类。纯函数，可表测。reject 先查：两表撞词时拒绝优先。
 func classifyApprovalExact(text string) string {
-	t := strings.ToLower(strings.TrimSpace(text))
-	// trim 集含反引号/引号：A2A 协议提示写的是 Reply exactly `approve`，上游
-	// LLM 把 exactly 理解为连反引号照抄时回复是 "`approve`"——自己的协议提示
-	// 必须自己接得住，否则白白多烧一次 LLM 分类调用。
-	t = strings.Trim(t, "。.!！~ `\"'“”‘’「」")
+	t := normalizeApprovalText(text)
 	if t == "" {
 		return approvalUnclear
 	}
@@ -312,6 +318,40 @@ func toolContinuationText(lang, result string) string {
 // 生成。语言选取规则（zh 默认 / en 兜底）统一在 aiagent.LangText。
 func resumeText(lang, zh, en string) string {
 	return aiagent.LangText(lang, zh, en)
+}
+
+// orphanApproveExact 是"孤儿确认"判定专用的确认词表，只收无歧义的显式确认词。
+// 不复用 approveExact：那张表里的裸词（好/嗯/对/行/ok/yes/go…）只有在
+// prevPending != nil——上一轮刚问过"确不确认"——的强上下文里才等价于同意。孤儿
+// 判定发生在没有待确认提案的普通对话轮上，而 GuidedFollowup 要求每轮答案末尾
+// 都追问一句"下一步"（见 aiagent/prompts/guided_followup.md），用户回"好"是接受
+// 建议，不是确认写操作；确认腿成功后的回执轮同样不带 pending，用户回"好的"也会
+// 落到这里。按裸词注入会让这两条主路径都被"当前没有待确认的修改"打断。
+//
+// 收窄不损失真阳性：要拦的那条伪造路径本身就在教用户回"确认"——伪造文案抄的是
+// 工具的确认文案，A2A 提示是 Reply exactly `approve`，FE 按钮是 BuildApprovalForm
+// 的"确认执行"/"Apply"。真确认只会落在显式词上。
+var orphanApproveExact = map[string]bool{
+	"确认": true, "确认修改": true, "确认提交": true, "确认无误": true,
+	"同意": true, "就这么改": true,
+	"approve": true, "approved": true, "confirm": true, "confirmed": true,
+}
+
+// shouldInjectOrphanResume 判定本轮是否为"孤儿确认"：用户明确表达了确认，但上
+// 一条消息没有待确认的提案。纯函数，可表测。
+// seqID <= 1 直接否：首轮没有"上一轮"，此时的 confirm 不可能是在确认什么。
+// 结构化通道优先于文本，与 tryResumePending 的分层裁决保持同一口径。
+func shouldInjectOrphanResume(seqID int64, prevPending *models.PendingInterrupt, content string, param map[string]interface{}) bool {
+	if seqID <= 1 || prevPending != nil {
+		return false
+	}
+	switch approvalFromParam(param) {
+	case approvalYes:
+		return true
+	case approvalNo:
+		return false
+	}
+	return orphanApproveExact[normalizeApprovalText(content)]
 }
 
 // orphanResumeDirective 生成"孤儿确认"注入文案：用户明确回复确认意图，但

--- a/center/router/router_ai_interrupt_test.go
+++ b/center/router/router_ai_interrupt_test.go
@@ -206,6 +206,27 @@ func TestOrphanResumeDirective(t *testing.T) {
 	}
 }
 
+// TestOrphanResumeDirectiveBranches：文案必须给模型留出"这是在确认我上一轮请他
+// 挑的选项"这一支并让它继续执行——命中注入的确认词同样是正常选项确认的应答词，
+// 一口咬定"没有待确认的修改"会把内置技能的候选确认流程（create-alert-rule
+// SKILL.md 的"ask the user to confirm"）打断。同时不得写死 update_*：误判时用户
+// 可能正在确认一次 create_*。
+func TestOrphanResumeDirectiveBranches(t *testing.T) {
+	zh := orphanResumeDirective("")
+	if !strings.Contains(zh, "请他选择/拍板") || !strings.Contains(zh, "直接调用对应的工具完成操作") {
+		t.Fatalf("zh directive must keep the choice-confirmation branch, got %q", zh)
+	}
+	en := orphanResumeDirective("en_US")
+	if !strings.Contains(en, "a choice you asked the user to make") || !strings.Contains(en, "call the appropriate tool to carry it out") {
+		t.Fatalf("en directive must keep the choice-confirmation branch, got %q", en)
+	}
+	for _, d := range []string{zh, en} {
+		if strings.Contains(d, "update_*") {
+			t.Fatalf("directive must not name a specific tool family, got %q", d)
+		}
+	}
+}
+
 // TestShouldInjectOrphanResume：孤儿确认判定只认显式确认词。approveExact 里的
 // 裸词（好/嗯/ok/yes…）在没有待确认提案的普通对话轮上是接受 GuidedFollowup
 // 建议或对回执的应答，按它们注入会把主路径打断成"当前没有待确认的修改"。

--- a/center/router/router_ai_interrupt_test.go
+++ b/center/router/router_ai_interrupt_test.go
@@ -192,3 +192,16 @@ func TestToolContinuationText(t *testing.T) {
 		t.Fatalf("en continuation must use the en copy, got %q", en)
 	}
 }
+
+// TestOrphanResumeDirective：孤儿确认注入文案必须明确"没有待确认的提案、
+// 不得声称已生效"，并按语言选取 zh/en。
+func TestOrphanResumeDirective(t *testing.T) {
+	zh := orphanResumeDirective("")
+	if !strings.Contains(zh, "没有待确认的修改提案") || !strings.Contains(zh, "不要声称任何改动已生效") {
+		t.Fatalf("zh directive = %q", zh)
+	}
+	en := orphanResumeDirective("en_US")
+	if !strings.Contains(en, "no pending change proposal") || !strings.Contains(en, "do NOT claim anything was applied") {
+		t.Fatalf("en directive = %q", en)
+	}
+}

--- a/center/router/router_ai_interrupt_test.go
+++ b/center/router/router_ai_interrupt_test.go
@@ -205,3 +205,49 @@ func TestOrphanResumeDirective(t *testing.T) {
 		t.Fatalf("en directive = %q", en)
 	}
 }
+
+// TestShouldInjectOrphanResume：孤儿确认判定只认显式确认词。approveExact 里的
+// 裸词（好/嗯/ok/yes…）在没有待确认提案的普通对话轮上是接受 GuidedFollowup
+// 建议或对回执的应答，按它们注入会把主路径打断成"当前没有待确认的修改"。
+func TestShouldInjectOrphanResume(t *testing.T) {
+	pending := &models.PendingInterrupt{Kind: aiagent.InterruptKindApproval, Tool: "update_alert_rule"}
+	cases := []struct {
+		name    string
+		seqID   int64
+		pending *models.PendingInterrupt
+		content string
+		param   map[string]interface{}
+		want    bool
+	}{
+		{"explicit zh", 2, nil, "确认", nil, true},
+		{"explicit zh with punctuation", 2, nil, "确认。", nil, true},
+		{"explicit en", 2, nil, "approve", nil, true},
+		{"explicit en backticked", 2, nil, "`approve`", nil, true},
+		{"explicit en confirm", 2, nil, "Confirm", nil, true},
+
+		// 裸词：approveExact 命中但这里必须不命中
+		{"bare ok", 2, nil, "好的", nil, false},
+		{"bare en ok", 2, nil, "ok", nil, false},
+		{"bare yes", 2, nil, "yes", nil, false},
+		{"bare hmm", 2, nil, "嗯", nil, false},
+		{"bare go", 2, nil, "go", nil, false},
+		{"bare keyi", 2, nil, "可以", nil, false},
+
+		{"has pending", 2, pending, "确认", nil, false},
+		{"first turn", 1, nil, "确认", nil, false},
+		{"reject", 2, nil, "取消", nil, false},
+		{"empty", 2, nil, "", nil, false},
+		{"free text", 2, nil, "确认一下这个规则现在的阈值是多少", nil, false},
+
+		{"structured approve", 2, nil, "", map[string]interface{}{aiagent.ApprovalParamKey: "approve"}, true},
+		{"structured reject beats text", 2, nil, "确认", map[string]interface{}{aiagent.ApprovalParamKey: "reject"}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := shouldInjectOrphanResume(c.seqID, c.pending, c.content, c.param); got != c.want {
+				t.Fatalf("shouldInjectOrphanResume(%d, %v, %q, %v) = %v, want %v",
+					c.seqID, c.pending != nil, c.content, c.param, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The `update_*` tools use a two-phase propose/confirm flow: the first call computes a change set and returns an approval interrupt (the pending proposal is persisted to the message extra), and a later user reply "confirm" is resolved deterministically by replaying the apply leg via `tryResumePending` — which only fires when the previous message carries `extra.pending`.

**Problem:** the model can print the confirmation copy ("即将修改… 回复确认立即生效") in plain reply text **without actually invoking the tool**, so no pending proposal exists. When the user then replies "confirm", `tryResumePending` finds `prevPending == nil` and silently falls back to the normal agent flow, where the model is free to fabricate a "✅ 已确认并写入" receipt. The change is never persisted while the user believes it succeeded.

**Observed in production:** a threshold change on `update_alert_rule` took 7 turns / 8 minutes before one turn actually invoked the tool, with multiple fabricated success receipts in between.

## Change

When the reply is an unambiguous approval (`classifyApprovalExact` hits the approve table) but `prevPending == nil`, inject `orphanResumeDirective` into the agent prompt and pass `orphan_resume` through the inputs. The model must then tell the user there is nothing pending instead of inventing a success; if a change is still wanted it re-invokes the tool to submit a fresh proposal.

Replies that carry extra requirements still classify as `unclear` and are left to the agent flow (unchanged behavior).

## Tests

- `TestOrphanResumeDirective`: zh/en directive wording contains the mandatory "no pending proposal / do NOT claim anything was applied" semantics.

Fixes: #3369 (the server-side guard half)