### PR TITLE
fix: populate recovery time before dispatching alert events

### DIFF
--- a/alert/process/process.go
+++ b/alert/process/process.go
@@ -424,6 +424,7 @@ func (p *Processor) RecoverSingle(byRecover bool, hash string, now int64, value 
 	cachedRule.UpdateEvent(event)
 	event.IsRecovered = true
 	event.LastEvalTime = now
+	event.RecoverTime = now
 
 	// 恢复通知是否屏蔽，按"恢复时刻"（clock=now）重新判定，而不是沿用触发期写入 p.fires 的陈旧 NotifyMuted：
 	// 仅当此刻仍命中「只屏蔽通知」规则才继续静默恢复通知，屏蔽已到期/删除则正常发出恢复通知。

--- a/alert/process/process_test.go
+++ b/alert/process/process_test.go
@@ -1,11 +1,95 @@
 package process
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/ccfos/nightingale/v6/alert/queue"
+	"github.com/ccfos/nightingale/v6/memsto"
 	"github.com/ccfos/nightingale/v6/models"
 )
+
+func TestRecoverSingleSetsRecoverTime(t *testing.T) {
+	const now int64 = 200
+	for _, tc := range []struct {
+		name            string
+		judgeType       models.RecoverJudge
+		byRecover       bool
+		recoverDuration int64
+	}{
+		{name: "normal", judgeType: models.Origin},
+		{name: "explicit condition", judgeType: models.RecoverOnCondition, byRecover: true},
+		{name: "observation period", judgeType: models.Origin, recoverDuration: 60},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			queue.EventQueue.RemoveAll()
+			defer queue.EventQueue.RemoveAll()
+
+			var hookCalled bool
+			var hookRecoverTime int64
+			p := &Processor{
+				rule:                 &models.AlertRule{Id: 1, RecoverDuration: tc.recoverDuration},
+				fires:                NewAlertCurEventMap(nil),
+				pendings:             NewAlertCurEventMap(nil),
+				pendingsUseByRecover: NewAlertCurEventMap(nil),
+				alertMuteCache:       &memsto.AlertMuteCacheType{},
+				HandleRecoverEventHook: func(event *models.AlertCurEvent) {
+					hookCalled = true
+					hookRecoverTime = event.RecoverTime
+				},
+			}
+			event := &models.AlertCurEvent{
+				Hash:          "recover-time",
+				RuleId:        1,
+				TriggerTime:   100,
+				LastEvalTime:  140,
+				RecoverConfig: models.RecoverConfig{JudgeType: tc.judgeType},
+			}
+			p.pushEventToQueue(event)
+			p.pendingsUseByRecover.Set(event.Hash, event)
+
+			if tc.byRecover || tc.recoverDuration > 0 {
+				p.RecoverSingle(false, event.Hash, now-1, nil)
+				if event.IsRecovered || event.RecoverTime != 0 || event.LastEvalTime != 140 || hookCalled {
+					t.Fatal("event recovered before its recovery condition was satisfied")
+				}
+			}
+
+			p.RecoverSingle(tc.byRecover, event.Hash, now, nil)
+			if !hookCalled || hookRecoverTime != now {
+				t.Errorf("recovery hook: called=%v recover_time=%d, want true and %d", hookCalled, hookRecoverTime, now)
+			}
+			items := queue.EventQueue.PopBackBy(10)
+			if len(items) != 2 {
+				t.Fatalf("queued events: got %d, want one firing and one recovery event", len(items))
+			}
+			firing := items[0].(*models.AlertCurEvent)
+			if firing.IsRecovered || firing.RecoverTime != 0 {
+				t.Fatal("firing snapshot must not have a recovery time")
+			}
+			recovered := items[1].(*models.AlertCurEvent)
+			if !recovered.IsRecovered || recovered.RecoverTime != now || recovered.LastEvalTime != now {
+				t.Fatalf("recovery snapshot: is_recovered=%v recover_time=%d last_eval_time=%d, want true and %d", recovered.IsRecovered, recovered.RecoverTime, recovered.LastEvalTime, now)
+			}
+			if his := recovered.ToHis(nil); his.RecoverTime != recovered.RecoverTime {
+				t.Errorf("history recover_time=%d differs from notification recover_time=%d", his.RecoverTime, recovered.RecoverTime)
+			}
+			body, err := json.Marshal(recovered)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var payload struct {
+				RecoverTime int64 `json:"recover_time"`
+			}
+			if err := json.Unmarshal(body, &payload); err != nil {
+				t.Fatal(err)
+			}
+			if payload.RecoverTime != now {
+				t.Errorf("JSON recover_time: got %d, want %d", payload.RecoverTime, now)
+			}
+		})
+	}
+}
 
 // 回归：队列里必须是事件快照，不能是 p.fires 持有的活对象。
 //


### PR DESCRIPTION
What type of PR is this?

  Bug fix.

  What this PR does / why we need it:

  Real-time recovery notifications currently contain recover_time: 0 because RecoverSingle() sets LastEvalTime but never
  populates RecoverTime. Historical events have the correct recovery time because ToHis() derives it from LastEvalTime.

  This PR sets RecoverTime alongside LastEvalTime, before recovery hooks and queueing, so real-time recovery
  notifications carry the same recovery timestamp as historical events.

  Which issue(s) this PR fixes:

  No linked issue.

  Special notes for your reviewer:

  - The production change is a single assignment; no database migration is required.
  - Regression tests cover normal recovery, explicit recovery conditions, and the recovery observation period. They also
    verify timestamps in recovery hooks, queued snapshots, historical event conversion, and JSON serialization.

  - Validation: go test ./alert/process ./alert/sender -count=1 passes. The new regression test fails in all three
    recovery scenarios before the fix.