### PR TITLE
fix(models): converge config key init across center replicas (Fixes #3384)

### DIFF
--- a/models/configs.go
+++ b/models/configs.go
@@ -130,7 +130,15 @@ func InitJWTSigningKey(ctx *ctx.Context) string {
 		log.Fatalln("init jwt signing key in mysql", err)
 	}
 
-	return key
+	// Re-read the stored value so all center instances converge on the SAME key even if
+	// they raced on a fresh database (each generated its own key and inserted a row).
+	// ConfigsGet returns a deterministic (lowest-id) row, so every instance now agrees.
+	val, err = ConfigsGet(ctx, JWT_SIGNING_KEY)
+	if err != nil {
+		log.Fatalln("init jwt signing key in mysql", err)
+	}
+
+	return val
 }
 
 // InitSalt generate random salt
@@ -167,7 +175,13 @@ func InitRSAPassWord(ctx *ctx.Context) (string, error) {
 	if err != nil {
 		return "", errors.WithMessage(err, "failed to set rsa password")
 	}
-	return pwd, nil
+
+	// Re-read so all center instances converge on the same value (see InitJWTSigningKey).
+	val, err = ConfigsGet(ctx, RSA_PASSWORD)
+	if err != nil {
+		return "", errors.WithMessage(err, "failed to get rsa password after set")
+	}
+	return val, nil
 }
 
 func ConfigsGet(ctx *ctx.Context, ckey string) (string, error) { //select built-in type configs
@@ -180,6 +194,7 @@ func ConfigsGet(ctx *ctx.Context, ckey string) (string, error) { //select built-
 	err := DB(ctx).Model(&Configs{}).
 		Where("ckey = ?", ckey).
 		Where(configExternalEq(0)).
+		Order("id").
 		Pluck("cval", &lst).Error
 	if err != nil {
 		return "", errors.WithMessage(err, "failed to query configs")


### PR DESCRIPTION
**What this PR does / why we need it**

Fixes a race in `configs` key initialization that causes a 401 / login-redirect loop when the n9e **center runs with multiple replicas**. When N center instances start against a fresh `configs` table, `InitJWTSigningKey` / `InitSalt` / `InitRSAPassWord` each read empty, generate their **own** value, and `ConfigsSet` (Count → INSERT/UPDATE) inserts **duplicate rows**. Each instance keeps the in-memory key it generated, so a token signed by one replica is rejected by the others → `401` → the frontend redirects to `/login?redirect=…`.

**Changes**

- `InitJWTSigningKey` / `InitRSAPassWord`: re-read the stored value via `ConfigsGet` after `ConfigsSet` and return it, so all instances converge on the same (first-written) key.
- `ConfigsGet`: add `Order("id")` so the "first" row is deterministic across replicas, making the re-read reliable.

A unique index on `configs.ckey` is intentionally **not** added — `migrate.go` drops it on every run (`DropUniqueFiledLimit`). The re-read + deterministic ordering fix convergence without a schema change; duplicate rows are tolerated and read consistently.

**Related issue(s)**
Fixes #3384

**Verification**
- `go build ./models` passes.
- Live check (3 replicas): after deduping the duplicate `configs` rows and rolling out, a token issued by one center pod is accepted (`200`) by all three replicas.
- `go test ./models` has a pre-existing unrelated failure (`TestConvertAlert`).
