### PR TITLE
fix: preserve notification line breaks by transport

### DIFF
--- a/alert/dispatch/dispatch.go
+++ b/alert/dispatch/dispatch.go
@@ -621,7 +621,7 @@ func SendNotifyRuleMessage(ctx *ctx.Context, userCache *memsto.UserCacheType, us
 	// flashduty / pagerduty 直接从 event 字段构造 payload，不需要模板，
 	// 与 dispatch 入口处 messageTemplate 的可空判断保持一致，避免 nil 解引用。
 	if notifyChannel.RequestType != "flashduty" && notifyChannel.RequestType != "pagerduty" && messageTemplate != nil {
-		tplContent = messageTemplate.RenderEvent(events, siteInfo.SiteUrl)
+		tplContent = messageTemplate.RenderEventForRequestType(events, siteInfo.SiteUrl, notifyChannel.RequestType)
 	}
 
 	nc, err := BuildNotifyContext(ctx, userCache, userGroupCache, events, notifyRuleId,

--- a/center/router/router_notify_channel.go
+++ b/center/router/router_notify_channel.go
@@ -609,7 +609,7 @@ func buildTestTplContent(nc *models.NotifyChannelConfig, tplSrc map[string]strin
 		return make(map[string]interface{}), nil
 	}
 	tpl := &models.MessageTemplate{Content: tplSrc, NotifyChannelIdent: nc.Ident}
-	return tpl.RenderEventStrict(events, siteUrl)
+	return tpl.RenderEventStrictForRequestType(events, siteUrl, nc.RequestType)
 }
 
 func (rt *Router) notifyChannelConfigTest(c *gin.Context) {

--- a/center/router/router_notify_rule.go
+++ b/center/router/router_notify_rule.go
@@ -314,7 +314,7 @@ func SendNotifyChannelMessage(ctx *ctx.Context, userCache *memsto.UserCacheType,
 		if len(messageTemplates) == 0 {
 			return "", fmt.Errorf("message template not found")
 		}
-		tplContent = messageTemplates[0].RenderEvent(events, siteUrl)
+		tplContent = messageTemplates[0].RenderEventForRequestType(events, siteUrl, notifyChannel.RequestType)
 	}
 
 	return sendToNotifyChannel(ctx, userCache, userGroup, notifyConfig, notifyChannel, events, tplContent, siteUrl)

--- a/models/message_tpl.go
+++ b/models/message_tpl.go
@@ -3840,10 +3840,10 @@ func isSlackIdent(ident string) bool {
 //
 // 与 RenderEvent 的唯一区别是错误处理：这里把错误交给调用方，由调用方决定是继续
 // 投递（RenderEvent：把错误文本当正文，保持既有行为）还是中止（RenderEventStrict）。
-func (t *MessageTemplate) renderField(key, msgTpl string, renderData map[string]interface{}) (interface{}, error) {
+func (t *MessageTemplate) renderField(key, msgTpl string, renderData map[string]interface{}, requestType string) (interface{}, error) {
 	text := strings.Join(append(GetDefs(renderData), msgTpl), "")
 
-	if t.NotifyChannelIdent == "email" {
+	if requestType == "smtp" || requestType == "script" || (requestType == "" && t.NotifyChannelIdent == "email") {
 		tpl, err := texttemplate.New(key).Funcs(tplx.TemplateFuncMap).Parse(text)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse template: %v", err)
@@ -3874,6 +3874,17 @@ func (t *MessageTemplate) renderField(key, msgTpl string, renderData map[string]
 }
 
 func (t *MessageTemplate) RenderEvent(events []*AlertCurEvent, siteUrl string) map[string]interface{} {
+	return t.renderEvent(events, siteUrl, "")
+}
+
+// RenderEventForRequestType renders message fields for a concrete transport.
+// Transports that serialize the result themselves need raw text, while HTTP
+// request templates need JSON-string escaping before interpolation.
+func (t *MessageTemplate) RenderEventForRequestType(events []*AlertCurEvent, siteUrl, requestType string) map[string]interface{} {
+	return t.renderEvent(events, siteUrl, requestType)
+}
+
+func (t *MessageTemplate) renderEvent(events []*AlertCurEvent, siteUrl, requestType string) map[string]interface{} {
 	if t == nil {
 		return nil
 	}
@@ -3883,7 +3894,7 @@ func (t *MessageTemplate) RenderEvent(events []*AlertCurEvent, siteUrl string) m
 	// event 内容渲染到 messageTemplate
 	tplContent := make(map[string]interface{})
 	for key, msgTpl := range t.Content {
-		val, err := t.renderField(key, msgTpl, renderData)
+		val, err := t.renderField(key, msgTpl, renderData, requestType)
 		if err != nil {
 			logger.Errorf("failed to render template field %s: %v events: %v", key, err, events)
 			// slack 分支历来是把出错的字段整个丢掉（下游按缺字段处理），其余分支把错误
@@ -3906,6 +3917,16 @@ func (t *MessageTemplate) RenderEvent(events []*AlertCurEvent, siteUrl string) m
 // 会让模板写错时接口仍报成功，而第三方群里收到的是一段 "failed to parse template: ..."，
 // 错误只在真实消息里才看得见。
 func (t *MessageTemplate) RenderEventStrict(events []*AlertCurEvent, siteUrl string) (map[string]interface{}, error) {
+	return t.renderEventStrict(events, siteUrl, "")
+}
+
+// RenderEventStrictForRequestType is the strict counterpart of
+// RenderEventForRequestType.
+func (t *MessageTemplate) RenderEventStrictForRequestType(events []*AlertCurEvent, siteUrl, requestType string) (map[string]interface{}, error) {
+	return t.renderEventStrict(events, siteUrl, requestType)
+}
+
+func (t *MessageTemplate) renderEventStrict(events []*AlertCurEvent, siteUrl, requestType string) (map[string]interface{}, error) {
 	if t == nil {
 		return nil, nil
 	}
@@ -3922,7 +3943,7 @@ func (t *MessageTemplate) RenderEventStrict(events []*AlertCurEvent, siteUrl str
 
 	tplContent := make(map[string]interface{}, len(keys))
 	for _, key := range keys {
-		val, err := t.renderField(key, t.Content[key], renderData)
+		val, err := t.renderField(key, t.Content[key], renderData, requestType)
 		if err != nil {
 			return nil, fmt.Errorf("template field %q: %v", key, err)
 		}

--- a/models/message_tpl_test.go
+++ b/models/message_tpl_test.go
@@ -439,6 +439,31 @@ func TestRenderEventBranchDependsOnNotifyChannelIdent(t *testing.T) {
 	})
 }
 
+func TestRenderEventBranchDependsOnRequestType(t *testing.T) {
+	events := []*AlertCurEvent{{RuleName: "r1", TagsMap: map[string]string{}}}
+	content := map[string]string{"content": "line1\nsay \"hi\""}
+
+	for _, requestType := range []string{"smtp", "script"} {
+		t.Run(requestType+" keeps raw text for provider serialization", func(t *testing.T) {
+			got := (&MessageTemplate{Content: content, NotifyChannelIdent: "custom"}).RenderEventForRequestType(
+				events, "http://site", requestType,
+			)
+			if want := "line1\nsay \"hi\""; fmt.Sprint(got["content"]) != want {
+				t.Fatalf("got %q, want %q", fmt.Sprint(got["content"]), want)
+			}
+		})
+	}
+
+	t.Run("http keeps JSON string escaping", func(t *testing.T) {
+		got := (&MessageTemplate{Content: content, NotifyChannelIdent: "custom"}).RenderEventForRequestType(
+			events, "http://site", "http",
+		)
+		if want := `line1\nsay \"hi\"`; fmt.Sprint(got["content"]) != want {
+			t.Fatalf("got %q, want %q", fmt.Sprint(got["content"]), want)
+		}
+	})
+}
+
 // RenderEvent 把模板错误当正文返回（生产链路的既有行为，不改），
 // RenderEventStrict 必须往外抛——否则「保存前测试」会在模板写错时报成功，
 // 而第三方收到的是一段 "failed to parse template: ..."。


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What this PR does / why we need it**:

Render notification template fields according to the concrete request type. SMTP and script transports now keep real line breaks before their providers serialize the payload, while HTTP request templates retain the existing JSON escaping behavior.

This also applies the same transport-aware rendering to notification test sends and keeps the existing rendering APIs compatible for other callers.

Tests cover raw SMTP and script output plus unchanged HTTP escaping.

**Which issue(s) this PR fixes**:

Fixes #3371

**Special notes for your reviewer**:

Validation:

* `go test ./models -run 'TestRenderEvent' -count=1`
* `go test ./center/router -run 'TestBuildTestTplContent|TestNotifyChannelConfigTest' -count=1`
* `go test ./alert/dispatch -count=1`
* `git diff --check`
