### PR TITLE
feat(aiagent): align dashboard builder output with FE renderer

### DIFF
--- a/aiagent/skill/embedded/builtin/create-dashboard/SKILL.md
+++ b/aiagent/skill/embedded/builtin/create-dashboard/SKILL.md
@@ -79,7 +79,7 @@ When the same component often has both categraf and exporter templates, **prefer
 
 Use `create_dashboard`. **You only need to provide the panel title, type, and PromQL**; the tool automatically generates the full configuration (layout, datasource variables, styling, units, etc., are all handled automatically).
 
-> create_dashboard accepts the following set of **simplified fields**. Any field beyond these (thresholds, overrides, value mappings, heatmap/hexbin/tableNG/iframe, etc.) is **not supported** — they will be ignored even if written. When you need such rich configuration, switch to path A and import a template.
+> create_dashboard accepts the following set of **simplified fields**. Any field beyond these (overrides, value mappings, heatmap/hexbin/iframe, etc.) is **not supported** — they will be ignored even if written. When you need such rich configuration, switch to path A and import a template.
 
 ### Call example
 
@@ -112,7 +112,7 @@ Each panel requires 3 fields:
 | `stack` | Whether to stack (timeseries only) | false |
 | `description` | Panel description | none |
 
-Query field `instant`: for single-value panels such as stat/gauge/barGauge/pie/table, it is recommended to set `"instant": true` (instant query).
+Query field `instant`: for single-value panels such as stat/gauge/barGauge/pie, it is recommended to set `"instant": true` (instant query). tableNG always uses instant queries automatically.
 
 ### Supported panel types (only these 8)
 
@@ -123,7 +123,7 @@ Query field `instant`: for single-value panels such as stat/gauge/barGauge/pie/t
 | `gauge` | Gauge | 6×6 |
 | `barGauge` | Horizontal bar ranking | 8×8 |
 | `pie` | Pie chart | 6×6 |
-| `table` | Table | 12×10 |
+| `tableNG` | Table | 12×10 |
 | `text` | Text note (uses description as content) | 6×4 |
 | `row` | Grouping row (automatically full width) | 24×1 |
 

--- a/aiagent/tools/common.go
+++ b/aiagent/tools/common.go
@@ -36,6 +36,31 @@ const (
 	PermUsers                = "/users"
 )
 
+const n9eVersion = "3.4.0"
+
+func stringVal(m map[string]interface{}, key string) string {
+	switch v := m[key].(type) {
+	case string:
+		return v
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64)
+	}
+	return ""
+}
+
+// refIDAt returns the query reference used by the frontend: A..Z, AA..AZ,
+// BA...  The sequence is zero-based so refIDAt(0) is A.
+func refIDAt(index int) string {
+	refID := ""
+	for {
+		refID = string(rune('A'+index%26)) + refID
+		index = index/26 - 1
+		if index < 0 {
+			return refID
+		}
+	}
+}
+
 // =============================================================================
 // User & permission helpers
 // =============================================================================

--- a/aiagent/tools/dashboard_builder.go
+++ b/aiagent/tools/dashboard_builder.go
@@ -114,7 +114,7 @@ const datasourceVarRef = "${" + datasourceVarName + "}"
 // to it — users can switch datasources from the header after opening.
 func buildConfigs(datasourceId int64, variables []VariableSpec, panels []PanelSpec) (string, error) {
 	configs := map[string]interface{}{
-		"version":      "3.4.0",
+		"version":      n9eVersion,
 		"graphTooltip": "sharedCrosshair",
 		"graphZoom":    "default",
 		"links":        []interface{}{},
@@ -122,7 +122,11 @@ func buildConfigs(datasourceId int64, variables []VariableSpec, panels []PanelSp
 
 	// 构建变量：datasource 变量置顶，后跟用户声明的 query 变量
 	vars := make([]interface{}, 0, len(variables)+1)
-	vars = append(vars, buildDatasourceVariable())
+	datasourceVar := buildDatasourceVariable()
+	if datasourceId > 0 {
+		datasourceVar["defaultValue"] = datasourceId
+	}
+	vars = append(vars, datasourceVar)
 	for _, v := range variables {
 		vars = append(vars, buildVariable(v))
 	}
@@ -132,6 +136,7 @@ func buildConfigs(datasourceId int64, variables []VariableSpec, panels []PanelSp
 	builtPanels := make([]interface{}, 0, len(panels))
 	x, y, rowMaxH := 0, 0, 0
 	for i, spec := range panels {
+		spec.Type = canonicalPanelType(spec.Type)
 		w, h := defaultSize(spec.Type, spec.W, spec.H)
 
 		// row 类型固定全宽
@@ -162,11 +167,6 @@ func buildConfigs(datasourceId int64, variables []VariableSpec, panels []PanelSp
 		}
 	}
 	configs["panels"] = builtPanels
-
-	// datasourceId is intentionally unused in the marshalled payload —
-	// panels reference ${prom} instead. Touch it to keep the parameter
-	// surface stable for future wiring (e.g. defaultValue).
-	_ = datasourceId
 
 	result, err := json.Marshal(configs)
 	if err != nil {
@@ -224,21 +224,20 @@ func buildPanel(spec PanelSpec, index, x, y, w, h int) map[string]interface{} {
 	// datasourceValue uses the "${prom}" template variable so panels
 	// inherit whichever datasource the user picks in the header dropdown.
 	panel := map[string]interface{}{
-		"version":           "3.4.0",
-		"id":                panelId,
-		"type":              spec.Type,
-		"name":              spec.Name,
-		"datasourceCate":    "prometheus",
-		"datasourceValue":   datasourceVarRef,
-		"layout":            map[string]interface{}{"x": x, "y": y, "w": w, "h": h, "i": panelId, "isResizable": true},
-		"targets":           buildTargets(spec.Queries),
-		"options":           buildOptions(spec),
-		"custom":            buildCustom(spec),
-		"overrides":         []interface{}{},
-		"transformationsNG": []interface{}{},
+		"version":         n9eVersion,
+		"id":              panelId,
+		"type":            spec.Type,
+		"name":            spec.Name,
+		"datasourceCate":  "prometheus",
+		"datasourceValue": datasourceVarRef,
+		"layout":          map[string]interface{}{"x": x, "y": y, "w": w, "h": h, "i": panelId},
+		"targets":         buildTargets(spec.Queries, spec.Type == "tableNG"),
+		"options":         buildOptions(spec),
+		"custom":          buildCustom(spec),
+		"overrides":       []interface{}{},
 	}
 
-	if spec.Desc != "" {
+	if spec.Type != "text" {
 		panel["description"] = spec.Desc
 	}
 
@@ -248,11 +247,11 @@ func buildPanel(spec PanelSpec, index, x, y, w, h int) map[string]interface{} {
 func buildRowPanel(spec PanelSpec, index, y int) map[string]interface{} {
 	panelId := fmt.Sprintf("panel-%d", index)
 	return map[string]interface{}{
-		"version":   "3.4.0",
+		"version":   n9eVersion,
 		"id":        panelId,
 		"type":      "row",
 		"name":      spec.Name,
-		"layout":    map[string]interface{}{"x": 0, "y": y, "w": 24, "h": 1, "i": panelId, "isResizable": false},
+		"layout":    map[string]interface{}{"x": 0, "y": y, "w": 24, "h": 1, "i": panelId},
 		"targets":   []interface{}{},
 		"options":   map[string]interface{}{},
 		"custom":    map[string]interface{}{},
@@ -260,11 +259,11 @@ func buildRowPanel(spec PanelSpec, index, y int) map[string]interface{} {
 	}
 }
 
-func buildTargets(queries []QuerySpec) []interface{} {
+func buildTargets(queries []QuerySpec, forceInstant bool) []interface{} {
 	targets := make([]interface{}, 0, len(queries))
 	for i, q := range queries {
 		t := map[string]interface{}{
-			"refId": string(rune('A' + i)),
+			"refId": refIDAt(i),
 			"expr":  q.PromQL,
 		}
 		if q.Legend != "" {
@@ -275,7 +274,9 @@ func buildTargets(queries []QuerySpec) []interface{} {
 			// the read side (which still tolerates historical legendFormat).
 			t["legend"] = q.Legend
 		}
-		if q.Instant != nil {
+		if forceInstant {
+			t["instant"] = true
+		} else if q.Instant != nil {
 			t["instant"] = *q.Instant
 		}
 		if q.Step != nil {
@@ -290,20 +291,15 @@ func buildTargets(queries []QuerySpec) []interface{} {
 }
 
 func buildOptions(spec PanelSpec) map[string]interface{} {
-	opts := map[string]interface{}{}
-
 	// standardOptions. Panels are emitted at schema version 3.4.0, and the FE
 	// renderer/editor reads the unit from "unit" (the legacy "util" key is only
 	// migrated to "unit" for panels older than 3.3.0), so we must write "unit".
+	standardOptions := map[string]interface{}{}
 	if spec.Unit != "" {
-		opts["standardOptions"] = map[string]interface{}{"unit": spec.Unit}
-	} else {
-		opts["standardOptions"] = map[string]interface{}{}
+		standardOptions["unit"] = spec.Unit
 	}
-
-	for k, v := range typeOptions(spec.Type) {
-		opts[k] = v
-	}
+	opts := map[string]interface{}{"standardOptions": standardOptions}
+	applyPanelTypeOptions(opts, spec.Type)
 
 	return opts
 }
@@ -318,17 +314,64 @@ func typeOptions(panelType string) map[string]interface{} {
 			"legend":  map[string]interface{}{"displayMode": "table", "placement": "bottom"},
 			"tooltip": map[string]interface{}{"mode": "all", "sort": "desc"},
 		}
-	case "stat":
-		return map[string]interface{}{
-			"legend":  map[string]interface{}{"displayMode": "hidden"},
-			"tooltip": map[string]interface{}{"mode": "single"},
-		}
-	case "gauge", "barGauge":
-		return map[string]interface{}{
-			"legend": map[string]interface{}{"displayMode": "hidden"},
-		}
 	}
 	return map[string]interface{}{}
+}
+
+func canonicalPanelType(panelType string) string {
+	if panelType == "table" {
+		return "tableNG"
+	}
+	return panelType
+}
+
+func baseThresholds() map[string]interface{} {
+	return map[string]interface{}{
+		"mode": "absolute",
+		"steps": []interface{}{map[string]interface{}{
+			"color": "rgb(44, 157, 61)", "value": nil, "type": "base",
+		}},
+	}
+}
+
+func gaugeThresholds() map[string]interface{} {
+	return map[string]interface{}{
+		"mode": "absolute",
+		"steps": []interface{}{
+			map[string]interface{}{"color": "#3FC453", "value": nil, "type": "base"},
+			map[string]interface{}{"color": "#FF9919", "value": 60},
+			map[string]interface{}{"color": "#FF656B", "value": 80},
+		},
+	}
+}
+
+// applyPanelTypeOptions writes the rendering defaults shared by creation and
+// visualization changes while preserving type-agnostic standard options (unit,
+// decimals, mappings, and so on) already authored on a panel.
+func applyPanelTypeOptions(opts map[string]interface{}, panelType string) {
+	if panelType == "gauge" {
+		opts["thresholds"] = gaugeThresholds()
+	} else {
+		opts["thresholds"] = baseThresholds()
+	}
+	opts["thresholdsStyle"] = map[string]interface{}{"mode": "dashed"}
+
+	standardOptions, _ := opts["standardOptions"].(map[string]interface{})
+	if standardOptions == nil {
+		standardOptions = map[string]interface{}{}
+		opts["standardOptions"] = standardOptions
+	}
+	if panelType == "gauge" {
+		standardOptions["min"] = 0
+		standardOptions["max"] = 100
+	} else {
+		delete(standardOptions, "min")
+		delete(standardOptions, "max")
+	}
+
+	for k, v := range typeOptions(panelType) {
+		opts[k] = v
+	}
 }
 
 func buildCustom(spec PanelSpec) map[string]interface{} {
@@ -338,9 +381,12 @@ func buildCustom(spec PanelSpec) map[string]interface{} {
 			"drawStyle":         "lines",
 			"lineInterpolation": "smooth",
 			"lineWidth":         2,
-			"fillOpacity":       0.2,
+			"fillOpacity":       0.01,
 			"gradientMode":      "none",
 			"showPoints":        "none",
+			"pointSize":         5,
+			"barAlignment":      0,
+			"barWidthFactor":    0.6,
 			"scaleDistribution": map[string]interface{}{"type": "linear"},
 		}
 		if spec.Stack {
@@ -351,34 +397,42 @@ func buildCustom(spec PanelSpec) map[string]interface{} {
 		return c
 	case "stat":
 		return map[string]interface{}{
-			"textMode":  "valueAndName",
-			"colorMode": "value",
-			"calc":      "lastNotNull",
-			"colSpan":   1,
-			"textSize":  map[string]interface{}{},
+			"textMode":    "valueAndName",
+			"colorMode":   "value",
+			"calc":        "lastNotNull",
+			"colSpan":     0,
+			"textSize":    map[string]interface{}{},
+			"valueField":  "Value",
+			"orientation": "auto",
 		}
 	case "gauge":
 		return map[string]interface{}{
-			"calc":     "lastNotNull",
-			"min":      0,
-			"max":      100,
-			"textSize": map[string]interface{}{},
+			"calc":       "lastNotNull",
+			"textMode":   "valueAndName",
+			"valueField": "Value",
 		}
 	case "barGauge":
 		return map[string]interface{}{
-			"calc":        "lastNotNull",
-			"displayMode": "basic",
-			"orientation": "horizontal",
-			"textSize":    map[string]interface{}{},
+			"calc":          "lastNotNull",
+			"displayMode":   "basic",
+			"valueField":    "Value",
+			"sortOrder":     "desc",
+			"otherPosition": "none",
+			"valueMode":     "color",
 		}
 	case "pie":
 		return map[string]interface{}{
-			"calc": "lastNotNull",
+			"calc":      "lastNotNull",
+			"textMode":  "valueAndName",
+			"colorMode": "value",
+			"textSize":  map[string]interface{}{},
 			// FE reads custom.legengPosition (note the spelling — types.ts /
 			// Renderer/Pie/index.tsx); "legentPosition" silently dropped the
-			// intended bottom placement on both created and type-converted pies.
-			"legengPosition": "bottom",
+			// configured placement on both created and type-converted pies.
+			"legengPosition": "right",
 			"detailUrl":      "",
+			"valueField":     "Value",
+			"detailName":     "",
 		}
 	case "table":
 		return map[string]interface{}{
@@ -386,10 +440,24 @@ func buildCustom(spec PanelSpec) map[string]interface{} {
 			"showHeader":  true,
 			"calc":        "lastNotNull",
 			"colorMode":   "value",
+			"tableLayout": "auto",
+			"nowrap":      true,
+		}
+	case "tableNG":
+		return map[string]interface{}{
+			"showHeader":  true,
+			"filterable":  false,
+			"cellOptions": map[string]interface{}{"type": "none"},
 		}
 	case "text":
 		return map[string]interface{}{
-			"content": spec.Desc,
+			"content":        spec.Desc,
+			"textSize":       12,
+			"textColor":      "#000000",
+			"textDarkColor":  "#FFFFFF",
+			"bgColor":        "rgba(0, 0, 0, 0)",
+			"justifyContent": "center",
+			"alignItems":     "center",
 		}
 	default:
 		return map[string]interface{}{}
@@ -407,15 +475,22 @@ func defaultSize(panelType string, specW, specH int) (int, int) {
 	case "stat":
 		w, h = 6, 4
 	case "gauge":
-		w, h = 6, 6
+		// Keep the first-row 12+6+6 composition aligned. ReactGridLayout
+		// vertically compacts panels on load; a shorter gauge would otherwise
+		// let a later half-width panel slide up and break the intended row.
+		w, h = 6, 8
 	case "barGauge":
-		w, h = 8, 8
+		// Pair barGauge and pie as two equal half-width panels. Besides being
+		// easier to scan, this leaves no horizontal hole for the next panel to
+		// be vertically compacted into by the frontend grid.
+		w, h = 12, 8
 	case "pie":
-		w, h = 6, 6
-	case "table":
+		w, h = 12, 8
+	case "table", "tableNG":
 		w, h = 12, 10
 	case "text":
-		w, h = 6, 4
+		// Text commonly accompanies a table or another half-width panel.
+		w, h = 12, 4
 	case "row":
 		w, h = 24, 1
 	}

--- a/aiagent/tools/dashboard_builder_test.go
+++ b/aiagent/tools/dashboard_builder_test.go
@@ -52,6 +52,9 @@ func TestBuildConfigs_Basic(t *testing.T) {
 	if dsVar["name"] != "prom" || dsVar["type"] != "datasource" || dsVar["definition"] != "prometheus" {
 		t.Errorf("datasource var unexpected: %+v", dsVar)
 	}
+	if dsVar["defaultValue"] != float64(5) {
+		t.Errorf("datasource var defaultValue: got %v, want 5", dsVar["defaultValue"])
+	}
 	v := vars[1].(map[string]interface{})
 	if v["name"] != "ident" {
 		t.Errorf("query var name: got %v, want ident", v["name"])
@@ -118,6 +121,28 @@ func TestBuildConfigs_Basic(t *testing.T) {
 	}
 }
 
+func TestBuildConfigs_RefIDsFollowFrontendSequence(t *testing.T) {
+	queries := make([]QuerySpec, 28)
+	for i := range queries {
+		queries[i] = QuerySpec{PromQL: "up"}
+	}
+
+	result, err := buildConfigs(1, nil, []PanelSpec{{Name: "many queries", Type: "timeseries", Queries: queries}})
+	if err != nil {
+		t.Fatalf("buildConfigs failed: %v", err)
+	}
+	var configs map[string]interface{}
+	if err := json.Unmarshal([]byte(result), &configs); err != nil {
+		t.Fatalf("unmarshal configs: %v", err)
+	}
+	targets := configs["panels"].([]interface{})[0].(map[string]interface{})["targets"].([]interface{})
+	for index, want := range map[int]string{0: "A", 25: "Z", 26: "AA", 27: "AB"} {
+		if got := targets[index].(map[string]interface{})["refId"]; got != want {
+			t.Errorf("target[%d] refId = %v, want %s", index, got, want)
+		}
+	}
+}
+
 func TestBuildConfigs_WithRows(t *testing.T) {
 	panels := []PanelSpec{
 		{Name: "概览", Type: "row"},
@@ -158,5 +183,149 @@ func TestBuildConfigs_WithRows(t *testing.T) {
 	ts := builtPanels[3].(map[string]interface{})
 	if layoutVal(ts, "y") != 6 {
 		t.Errorf("timeseries after row: y=%v, want 6", layoutVal(ts, "y"))
+	}
+}
+
+// TestBuildConfigs_MixedPanelTypesKeepAlignedRows protects the default layout
+// from ReactGridLayout's vertical compaction. Every position here is blocked
+// by an overlapping panel above it, so loading the dashboard cannot pull a
+// panel into a visual gap and make the generated dashboard look staggered.
+func TestBuildConfigs_MixedPanelTypesKeepAlignedRows(t *testing.T) {
+	panels := []PanelSpec{
+		{Name: "trend", Type: "timeseries"},
+		{Name: "stat", Type: "stat"},
+		{Name: "gauge", Type: "gauge"},
+		{Name: "bar", Type: "barGauge"},
+		{Name: "pie", Type: "pie"},
+		{Name: "table", Type: "tableNG"},
+		{Name: "text", Type: "text"},
+	}
+	result, err := buildConfigs(1, nil, panels)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var configs map[string]interface{}
+	if err := json.Unmarshal([]byte(result), &configs); err != nil {
+		t.Fatal(err)
+	}
+
+	byName := make(map[string]map[string]interface{})
+	for _, raw := range configs["panels"].([]interface{}) {
+		panel := raw.(map[string]interface{})
+		byName[panel["name"].(string)] = panel
+	}
+	for name, want := range map[string][4]float64{
+		"trend": {0, 0, 12, 8},
+		"stat":  {12, 0, 6, 4},
+		"gauge": {18, 0, 6, 8},
+		"bar":   {0, 8, 12, 8},
+		"pie":   {12, 8, 12, 8},
+		"table": {0, 16, 12, 10},
+		"text":  {12, 16, 12, 4},
+	} {
+		got := [4]float64{layoutVal(byName[name], "x"), layoutVal(byName[name], "y"), layoutVal(byName[name], "w"), layoutVal(byName[name], "h")}
+		if got != want {
+			t.Errorf("%s layout = %v, want %v", name, got, want)
+		}
+	}
+}
+
+func TestBuildConfigs_PanelDefaultsAndTableNG(t *testing.T) {
+	falseValue := false
+	panels := []PanelSpec{
+		{Name: "trend", Type: "timeseries"},
+		{Name: "stat", Type: "stat"},
+		{Name: "gauge", Type: "gauge"},
+		{Name: "bar", Type: "barGauge"},
+		{Name: "pie", Type: "pie"},
+		{Name: "legacy table", Type: "table", Queries: []QuerySpec{{PromQL: "up", Instant: &falseValue}}},
+		{Name: "new table", Type: "tableNG", Queries: []QuerySpec{{PromQL: "up", Instant: &falseValue}}},
+		{Name: "note", Type: "text", Desc: "runbook"},
+	}
+	result, err := buildConfigs(1, nil, panels)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var configs map[string]interface{}
+	if err := json.Unmarshal([]byte(result), &configs); err != nil {
+		t.Fatal(err)
+	}
+	built := configs["panels"].([]interface{})
+	byName := make(map[string]map[string]interface{}, len(built))
+	for _, raw := range built {
+		p := raw.(map[string]interface{})
+		byName[p["name"].(string)] = p
+		if _, ok := p["transformationsNG"]; ok {
+			t.Fatalf("%q unexpectedly has transformationsNG", p["name"])
+		}
+		if _, ok := p["layout"].(map[string]interface{})["isResizable"]; ok {
+			t.Fatalf("%q layout unexpectedly has isResizable", p["name"])
+		}
+		thresholds := p["options"].(map[string]interface{})["thresholds"].(map[string]interface{})
+		steps := thresholds["steps"].([]interface{})
+		if len(steps) == 0 || steps[0].(map[string]interface{})["type"] != "base" {
+			t.Fatalf("%q thresholds has no base step: %#v", p["name"], thresholds)
+		}
+	}
+
+	trend := byName["trend"]["custom"].(map[string]interface{})
+	for key, want := range map[string]interface{}{"fillOpacity": 0.01, "pointSize": float64(5), "barAlignment": float64(0), "barWidthFactor": 0.6} {
+		if trend[key] != want {
+			t.Errorf("timeseries custom.%s = %v, want %v", key, trend[key], want)
+		}
+	}
+	stat := byName["stat"]["custom"].(map[string]interface{})
+	if stat["colSpan"] != float64(0) || stat["valueField"] != "Value" || stat["orientation"] != "auto" {
+		t.Errorf("unexpected stat custom: %#v", stat)
+	}
+	gauge := byName["gauge"]
+	if _, ok := gauge["custom"].(map[string]interface{})["min"]; ok {
+		t.Error("gauge min must live in standardOptions, not custom")
+	}
+	gaugeOptions := gauge["options"].(map[string]interface{})
+	gaugeStandard := gaugeOptions["standardOptions"].(map[string]interface{})
+	if gaugeStandard["min"] != float64(0) || gaugeStandard["max"] != float64(100) {
+		t.Errorf("unexpected gauge range: %#v", gaugeStandard)
+	}
+	if len(gaugeOptions["thresholds"].(map[string]interface{})["steps"].([]interface{})) != 3 {
+		t.Errorf("gauge should have three thresholds: %#v", gaugeOptions["thresholds"])
+	}
+	bar := byName["bar"]["custom"].(map[string]interface{})
+	if _, ok := bar["orientation"]; ok {
+		t.Error("barGauge must not write orientation")
+	}
+	for _, key := range []string{"valueField", "sortOrder", "otherPosition", "valueMode"} {
+		if _, ok := bar[key]; !ok {
+			t.Errorf("barGauge missing custom.%s", key)
+		}
+	}
+	pie := byName["pie"]["custom"].(map[string]interface{})
+	if pie["valueField"] != "Value" || pie["detailName"] != "" ||
+		pie["textMode"] != "valueAndName" || pie["colorMode"] != "value" ||
+		pie["legengPosition"] != "right" {
+		t.Errorf("unexpected pie custom: %#v", pie)
+	}
+	if textSize, ok := pie["textSize"].(map[string]interface{}); !ok || len(textSize) != 0 {
+		t.Errorf("pie custom.textSize = %#v, want empty object", pie["textSize"])
+	}
+	for _, name := range []string{"legacy table", "new table"} {
+		p := byName[name]
+		if p["type"] != "tableNG" || layoutVal(p, "w") != 12 || layoutVal(p, "h") != 10 {
+			t.Errorf("%s should be a 12x10 tableNG: %#v", name, p)
+		}
+		custom := p["custom"].(map[string]interface{})
+		if custom["showHeader"] != true || custom["filterable"] != false || custom["cellOptions"].(map[string]interface{})["type"] != "none" {
+			t.Errorf("unexpected tableNG custom: %#v", custom)
+		}
+		if p["targets"].([]interface{})[0].(map[string]interface{})["instant"] != true {
+			t.Errorf("%s target must be instant", name)
+		}
+	}
+	note := byName["note"]
+	if _, ok := note["description"]; ok {
+		t.Error("text panel must keep its content only in custom.content")
+	}
+	if note["custom"].(map[string]interface{})["textColor"] != "#000000" {
+		t.Errorf("text defaults not applied: %#v", note["custom"])
 	}
 }

--- a/aiagent/tools/dashboard_e2e_test.go
+++ b/aiagent/tools/dashboard_e2e_test.go
@@ -1,0 +1,175 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/ccfos/nightingale/v6/models"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDashboardToolsE2E_FrontendConfigAlignment exercises the public AI-tool
+// flow end-to-end: create_dashboard persists the FE-compatible defaults for
+// every supported chart type, update_dashboard changes a timeseries to tableNG
+// through its approval flow, and get_dashboard_detail reads the persisted
+// shape back.
+func TestDashboardToolsE2E_FrontendConfigAlignment(t *testing.T) {
+	deps := newDashboardTestDeps(t)
+	params := map[string]string{"user_id": "1", "chat_id": "dashboard-e2e", "seq_id": "1"}
+
+	created, err := createDashboard(context.Background(), deps, map[string]interface{}{
+		"group_id":      float64(1),
+		"name":          "AI dashboard tableNG e2e",
+		"datasource_id": float64(1),
+		"panels": `[
+			{"name":"Legacy table alias","type":"table","queries":[{"promql":"up","instant":false}]},
+			{"name":"CPU trend","type":"timeseries","queries":[{"promql":"rate(cpu_usage_active[5m])","instant":false}]},
+			{"name":"Summary stat","type":"stat","queries":[{"promql":"avg(cpu_usage_active)"}]},
+			{"name":"Usage gauge","type":"gauge","queries":[{"promql":"avg(cpu_usage_active)"}],"unit":"percent"},
+			{"name":"Top hosts","type":"barGauge","queries":[{"promql":"sum by (ident) (cpu_usage_active)"}]},
+			{"name":"Usage distribution","type":"pie","queries":[{"promql":"sum by (ident) (cpu_usage_active)"}]},
+			{"name":"Runbook","type":"text","description":"# CPU runbook"}
+		]`,
+	}, params)
+	require.NoError(t, err)
+
+	var createResp struct {
+		ID int64 `json:"id"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(created), &createResp))
+	require.NotZero(t, createResp.ID)
+
+	payload, err := models.BoardPayloadGet(deps.DBCtx, createResp.ID)
+	require.NoError(t, err)
+	var createdConfigs map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(payload), &createdConfigs))
+	require.Equal(t, n9eVersion, createdConfigs["version"])
+	datasourceVar := createdConfigs["var"].([]interface{})[0].(map[string]interface{})
+	require.Equal(t, float64(1), datasourceVar["defaultValue"])
+	for _, raw := range createdConfigs["panels"].([]interface{}) {
+		panel := raw.(map[string]interface{})
+		options := panel["options"].(map[string]interface{})
+		thresholds := options["thresholds"].(map[string]interface{})
+		steps := thresholds["steps"].([]interface{})
+		require.NotEmpty(t, steps, "%s must have threshold defaults", panel["name"])
+		require.Equal(t, "base", steps[0].(map[string]interface{})["type"], "%s must have a base threshold", panel["name"])
+		require.Equal(t, "dashed", options["thresholdsStyle"].(map[string]interface{})["mode"])
+	}
+
+	legacyTable := findPanel(createdConfigs["panels"].([]interface{}), "", "Legacy table alias")
+	require.NotNil(t, legacyTable)
+	require.Equal(t, "tableNG", legacyTable["type"], "the legacy input alias must create tableNG")
+	require.Equal(t, true, legacyTable["targets"].([]interface{})[0].(map[string]interface{})["instant"])
+	require.NotContains(t, legacyTable, "transformationsNG")
+	require.NotContains(t, legacyTable["layout"].(map[string]interface{}), "isResizable")
+	require.Equal(t, map[string]interface{}{"type": "none"}, legacyTable["custom"].(map[string]interface{})["cellOptions"])
+
+	trend := findPanel(createdConfigs["panels"].([]interface{}), "", "CPU trend")
+	require.NotNil(t, trend)
+	trendCustom := trend["custom"].(map[string]interface{})
+	require.Equal(t, float64(0.01), trendCustom["fillOpacity"])
+	require.Equal(t, float64(5), trendCustom["pointSize"])
+	require.Equal(t, float64(0), trendCustom["barAlignment"])
+	require.Equal(t, float64(0.6), trendCustom["barWidthFactor"])
+	require.Empty(t, trend["description"])
+
+	stat := findPanel(createdConfigs["panels"].([]interface{}), "", "Summary stat")
+	require.NotNil(t, stat)
+	statCustom := stat["custom"].(map[string]interface{})
+	require.Equal(t, float64(0), statCustom["colSpan"])
+	require.Equal(t, "Value", statCustom["valueField"])
+	require.Equal(t, "auto", statCustom["orientation"])
+
+	gauge := findPanel(createdConfigs["panels"].([]interface{}), "", "Usage gauge")
+	require.NotNil(t, gauge)
+	gaugeOptions := gauge["options"].(map[string]interface{})
+	gaugeStandard := gaugeOptions["standardOptions"].(map[string]interface{})
+	require.Equal(t, float64(0), gaugeStandard["min"])
+	require.Equal(t, float64(100), gaugeStandard["max"])
+	require.Len(t, gaugeOptions["thresholds"].(map[string]interface{})["steps"], 3)
+	require.NotContains(t, gauge["custom"].(map[string]interface{}), "min")
+
+	barGauge := findPanel(createdConfigs["panels"].([]interface{}), "", "Top hosts")
+	require.NotNil(t, barGauge)
+	barGaugeCustom := barGauge["custom"].(map[string]interface{})
+	require.Equal(t, "Value", barGaugeCustom["valueField"])
+	require.Equal(t, "desc", barGaugeCustom["sortOrder"])
+	require.Equal(t, "none", barGaugeCustom["otherPosition"])
+	require.Equal(t, "color", barGaugeCustom["valueMode"])
+	require.NotContains(t, barGaugeCustom, "orientation")
+	require.NotContains(t, barGaugeCustom, "baseColor")
+
+	pie := findPanel(createdConfigs["panels"].([]interface{}), "", "Usage distribution")
+	require.NotNil(t, pie)
+	pieCustom := pie["custom"].(map[string]interface{})
+	require.Equal(t, "Value", pieCustom["valueField"])
+	require.Equal(t, "", pieCustom["detailName"])
+	require.Equal(t, "right", pieCustom["legengPosition"])
+	require.Equal(t, "valueAndName", pieCustom["textMode"])
+	require.Equal(t, "value", pieCustom["colorMode"])
+	require.Equal(t, map[string]interface{}{}, pieCustom["textSize"])
+
+	text := findPanel(createdConfigs["panels"].([]interface{}), "", "Runbook")
+	require.NotNil(t, text)
+	textCustom := text["custom"].(map[string]interface{})
+	require.Equal(t, "# CPU runbook", textCustom["content"])
+	require.Equal(t, float64(12), textCustom["textSize"])
+	require.Equal(t, "#000000", textCustom["textColor"])
+	require.Equal(t, "#FFFFFF", textCustom["textDarkColor"])
+	require.Equal(t, "rgba(0, 0, 0, 0)", textCustom["bgColor"])
+	require.Equal(t, "center", textCustom["justifyContent"])
+	require.Equal(t, "center", textCustom["alignItems"])
+	require.NotContains(t, text, "description")
+
+	trendID := trend["id"].(string)
+
+	// A request may carry instant:false while changing to tableNG; the resulting
+	// stored target must still be instant:true after the approval confirmation.
+	ti, proposalID := proposeInterrupt(t, deps, map[string]interface{}{
+		"id":     float64(createResp.ID),
+		"panels": `[{"id":"` + trendID + `","type":"tableNG","queries":[{"ref":"A","promql":"rate(cpu_usage_active[5m])","instant":false}]}]`,
+	}, params)
+	require.Contains(t, ti.Prompt, "tableNG")
+
+	confirmed, err := updateDashboard(context.Background(), deps, map[string]interface{}{
+		"id":          float64(createResp.ID),
+		"proposal_id": proposalID,
+		"confirmed":   true,
+	}, map[string]string{"user_id": "1", "chat_id": "dashboard-e2e", "seq_id": "2"})
+	require.NoError(t, err)
+	require.Contains(t, confirmed, `"applied":true`)
+
+	payload, err = models.BoardPayloadGet(deps.DBCtx, createResp.ID)
+	require.NoError(t, err)
+	var updatedConfigs map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(payload), &updatedConfigs))
+	updatedTrend := findPanel(updatedConfigs["panels"].([]interface{}), trendID, "")
+	require.Equal(t, "tableNG", updatedTrend["type"])
+	require.Equal(t, true, updatedTrend["targets"].([]interface{})[0].(map[string]interface{})["instant"])
+	require.Equal(t, false, updatedTrend["custom"].(map[string]interface{})["filterable"])
+	require.Equal(t, "none", updatedTrend["custom"].(map[string]interface{})["cellOptions"].(map[string]interface{})["type"])
+	require.NotContains(t, updatedTrend["options"].(map[string]interface{}), "legend")
+
+	// The detail tool is the read API exposed to the agent. It must surface the
+	// persisted tableNG type and its forced instant setting after the full flow.
+	detail, err := getDashboardDetail(context.Background(), deps,
+		map[string]interface{}{"id": float64(createResp.ID), "include_config": true},
+		map[string]string{"user_id": "1"})
+	require.NoError(t, err)
+	var detailResp struct {
+		Panels []panelSummary `json:"panels"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(detail), &detailResp))
+	for _, panel := range detailResp.Panels {
+		if panel.Id != trendID {
+			continue
+		}
+		require.Equal(t, "tableNG", panel.Type)
+		require.Len(t, panel.Queries, 1)
+		require.NotNil(t, panel.Queries[0].Instant)
+		require.True(t, *panel.Queries[0].Instant)
+		return
+	}
+	t.Fatalf("updated panel %q missing from get_dashboard_detail response: %#v", trendID, detailResp.Panels)
+}

--- a/aiagent/tools/dashboard_normalize.go
+++ b/aiagent/tools/dashboard_normalize.go
@@ -3,12 +3,9 @@ package tools
 import (
 	"encoding/json"
 	"fmt"
-	"strconv"
 
 	"github.com/toolkits/pkg/logger"
 )
-
-const n9eVersion = "3.4.0"
 
 // defaultTimeseriesCustom timeseries 面板的默认 custom 配置
 var defaultTimeseriesCustom = map[string]interface{}{
@@ -25,12 +22,12 @@ var defaultTimeseriesCustom = map[string]interface{}{
 
 // defaultStatCustom stat 面板的默认 custom 配置
 var defaultStatCustom = map[string]interface{}{
-	"version":    n9eVersion,
-	"textMode":   "valueAndName",
-	"colorMode":  "value",
-	"calc":       "lastNotNull",
-	"colSpan":    1,
-	"textSize":   map[string]interface{}{},
+	"version":     n9eVersion,
+	"textMode":    "valueAndName",
+	"colorMode":   "value",
+	"calc":        "lastNotNull",
+	"colSpan":     1,
+	"textSize":    map[string]interface{}{},
 	"orientation": "",
 }
 
@@ -284,7 +281,7 @@ func normalizeTarget(t map[string]interface{}, index int) int {
 			delete(t, "ref")
 			fixed++
 		} else {
-			t["refId"] = string(rune('A' + index))
+			t["refId"] = refIDAt(index)
 			fixed++
 		}
 	}
@@ -299,16 +296,6 @@ func normalizeTarget(t map[string]interface{}, index int) int {
 }
 
 // --- helpers ---
-
-func stringVal(m map[string]interface{}, key string) string {
-	switch v := m[key].(type) {
-	case string:
-		return v
-	case float64:
-		return strconv.FormatFloat(v, 'f', -1, 64)
-	}
-	return ""
-}
 
 func setDefault(m map[string]interface{}, key string, val interface{}) {
 	if _, ok := m[key]; !ok {

--- a/aiagent/tools/dashboard_normalize_test.go
+++ b/aiagent/tools/dashboard_normalize_test.go
@@ -153,6 +153,16 @@ func TestNormalizeConfigs_GrafanaStyle(t *testing.T) {
 	t.Logf("Normalized result (first 500 chars): %.500s...", result)
 }
 
+func TestNormalizeTarget_RefIDsFollowFrontendSequence(t *testing.T) {
+	for index, want := range map[int]string{0: "A", 25: "Z", 26: "AA", 27: "AB"} {
+		target := map[string]interface{}{"expr": "up"}
+		normalizeTarget(target, index)
+		if got := target["refId"]; got != want {
+			t.Errorf("target[%d] refId = %v, want %s", index, got, want)
+		}
+	}
+}
+
 func TestNormalizeConfigs_RealCase(t *testing.T) {
 	// 用户反馈的真实错误 configs
 	input := `{"version":"1.0","var":[{"name":"ident","type":"query","definition":"label_values(cpu_usage_active,ident)","options":[],"multi":true}],"panels":[{"type":"timeseries","title":"CPU 使用率","x":0,"y":0,"w":12,"h":8,"targets":[{"ref":"A","expr":"cpu_usage_active{cpu=\"cpu-total\",ident=~\"$ident\"}"}],"options":{"legend":{"displayMode":"table","placement":"bottom"}}},{"type":"timeseries","title":"内存使用率","x":12,"y":0,"w":12,"h":8,"targets":[{"ref":"A","expr":"mem_used_percent{ident=~\"$ident\"}"}],"options":{"legend":{"displayMode":"table","placement":"bottom"}}},{"type":"timeseries","title":"系统负载","x":0,"y":8,"w":12,"h":8,"targets":[{"ref":"A","expr":"load1{ident=~\"$ident\"}"},{"ref":"B","expr":"load5{ident=~\"$ident\"}"},{"ref":"C","expr":"load15{ident=~\"$ident\"}"}],"options":{"legend":{"displayMode":"table","placement":"bottom"}}},{"type":"timeseries","title":"磁盘使用率","x":12,"y":8,"w":12,"h":8,"targets":[{"ref":"A","expr":"disk_used_percent{ident=~\"$ident\"}"}],"options":{"legend":{"displayMode":"table","placement":"bottom"}}}]}`

--- a/aiagent/tools/dashboard_update.go
+++ b/aiagent/tools/dashboard_update.go
@@ -596,7 +596,7 @@ func applyPanelPatches(lang string, configs map[string]interface{}, patches []pa
 // custom.content, so converting a query panel to/from either would strand its
 // config rather than re-render it.
 var updatablePanelTypes = map[string]bool{
-	"timeseries": true, "stat": true, "gauge": true, "barGauge": true, "pie": true, "table": true,
+	"timeseries": true, "stat": true, "gauge": true, "barGauge": true, "pie": true, "table": true, "tableNG": true,
 }
 
 // effectivePanelType is the type the FE actually renders a panel as. A panel
@@ -620,14 +620,14 @@ func checkPanelTypeChange(pm map[string]interface{}, label, newType string) erro
 	cur := effectivePanelType(pm)
 	switch {
 	case !updatablePanelTypes[newType]:
-		return fmt.Errorf("cannot change panel %q to type %q: supported chart types are timeseries / stat / gauge / barGauge / pie / table", label, newType)
+		return fmt.Errorf("cannot change panel %q to type %q: supported chart types are timeseries / stat / gauge / barGauge / pie / table / tableNG", label, newType)
 	case cur == "row":
 		return fmt.Errorf("cannot change type of %q: it is a layout row, not a chart", label)
 	case !updatablePanelTypes[cur]:
 		// changePanelType wholesale-replaces `custom`: on a text panel that
 		// would destroy custom.content (the authored markdown) with no way
 		// back, since non-chart types are not valid conversion targets.
-		return fmt.Errorf("cannot change type of %q: it is a %q panel whose config (e.g. a text panel's content) would be destroyed by the conversion; only chart panels (timeseries / stat / gauge / barGauge / pie / table) can switch types", label, cur)
+		return fmt.Errorf("cannot change type of %q: it is a %q panel whose config (e.g. a text panel's content) would be destroyed by the conversion; only chart panels (timeseries / stat / gauge / barGauge / pie / table / tableNG) can switch types", label, cur)
 	}
 	// Same stance as the queries path above: the defaults changePanelType
 	// writes (buildCustom/typeOptions) are designed and tested for Prometheus
@@ -654,9 +654,7 @@ func changePanelType(pm map[string]interface{}, newType string) {
 	}
 	delete(opts, "legend")
 	delete(opts, "tooltip")
-	for k, v := range typeOptions(newType) {
-		opts[k] = v
-	}
+	applyPanelTypeOptions(opts, newType)
 	pm["options"] = opts
 }
 
@@ -674,6 +672,21 @@ func clearTargetsInstant(pm map[string]interface{}) {
 	for _, t := range targets {
 		if tm, ok := t.(map[string]interface{}); ok {
 			delete(tm, "instant")
+		}
+	}
+}
+
+// forceTargetsInstant makes tableNG safe for large dashboard time ranges: its
+// renderer produces one row per data point, so range queries can explode into
+// an unusable number of rows.
+func forceTargetsInstant(pm map[string]interface{}) {
+	targets, ok := pm["targets"].([]interface{})
+	if !ok {
+		return
+	}
+	for _, t := range targets {
+		if tm, ok := t.(map[string]interface{}); ok {
+			tm["instant"] = true
 		}
 	}
 }
@@ -711,6 +724,9 @@ func applyPanelFields(lang string, pm map[string]interface{}, p panelPatch) []st
 	// targets are settled — not inside changePanelType.
 	if p.Type != nil && *p.Type == "timeseries" {
 		clearTargetsInstant(pm)
+	}
+	if p.Type != nil && *p.Type == "tableNG" {
+		forceTargetsInstant(pm)
 	}
 	return parts
 }
@@ -860,18 +876,11 @@ func cloneTarget(t map[string]interface{}) map[string]interface{} {
 	return out
 }
 
-// nextRefId returns the first refId not in used, preferring single letters
-// A..Z and falling back to Q0, Q1, ... once the alphabet is exhausted. The
+// nextRefId returns the first frontend-compatible refId not in used. The
 // caller is responsible for marking the returned id used.
 func nextRefId(used map[string]bool) string {
-	for i := 0; i < 26; i++ {
-		r := string(rune('A' + i))
-		if !used[r] {
-			return r
-		}
-	}
 	for i := 0; ; i++ {
-		r := fmt.Sprintf("Q%d", i)
+		r := refIDAt(i)
 		if !used[r] {
 			return r
 		}

--- a/aiagent/tools/dashboard_update_test.go
+++ b/aiagent/tools/dashboard_update_test.go
@@ -838,6 +838,34 @@ func TestApplyPanelPatches_TypeChangeWithQueriesClearsInstant(t *testing.T) {
 	}
 }
 
+func TestApplyPanelPatches_TypeChangeToTableNGForcesInstant(t *testing.T) {
+	const raw = `{
+		"panels":[
+			{"id":"panel-1","type":"timeseries","name":"CPU","datasourceCate":"prometheus",
+			 "targets":[{"refId":"A","expr":"cpu_usage_active","instant":false}]}
+		]
+	}`
+	var cfg map[string]interface{}
+	if err := json.Unmarshal([]byte(raw), &cfg); err != nil {
+		t.Fatal(err)
+	}
+	queries := []QuerySpec{{Ref: "A", PromQL: "cpu_usage_active", Instant: ptrBool(false)}}
+	if _, err := applyPanelPatches("", cfg, []panelPatch{{ID: "panel-1", Type: ptrStr("tableNG"), Queries: &queries}}); err != nil {
+		t.Fatalf("timeseries→tableNG should succeed: %v", err)
+	}
+	p := findPanel(cfg["panels"].([]interface{}), "panel-1", "")
+	if p["type"] != "tableNG" {
+		t.Fatalf("type = %v, want tableNG", p["type"])
+	}
+	if p["targets"].([]interface{})[0].(map[string]interface{})["instant"] != true {
+		t.Fatalf("tableNG target must be instant: %#v", p["targets"])
+	}
+	options := p["options"].(map[string]interface{})
+	if _, ok := options["legend"]; ok {
+		t.Errorf("tableNG must not retain legend: %#v", options)
+	}
+}
+
 // TestApplyPanelPatches_TypelessPanelTimeseriesIsNoOp is the regression for the
 // effective-type bug: a type-less panel (the FE renders it as timeseries) set to
 // type:timeseries is a no-op and must NOT run a full changePanelType, which would
@@ -1069,6 +1097,17 @@ func TestMergeTargets_NextRefIdSkipsTaken(t *testing.T) {
 	got := out[2].(map[string]interface{})["refId"]
 	if got != "B" {
 		t.Fatalf("new refId = %v, want B (first free letter)", got)
+	}
+}
+
+func TestMergeTargets_NextRefIdContinuesPastZ(t *testing.T) {
+	existing := make([]interface{}, 26)
+	for i := range existing {
+		existing[i] = map[string]interface{}{"refId": refIDAt(i), "expr": "up"}
+	}
+	out := mergeTargets(existing, []QuerySpec{{PromQL: "new"}})
+	if got := out[len(out)-1].(map[string]interface{})["refId"]; got != "AA" {
+		t.Fatalf("new refId = %v, want AA", got)
 	}
 }
 

--- a/aiagent/tools/defs/defs.go
+++ b/aiagent/tools/defs/defs.go
@@ -304,14 +304,14 @@ var UpdateDashboard = aiagent.AgentTool{
 - 用户如果拒绝或提出新要求，你会在新一轮收到反馈，按新要求重新调用提案即可（旧提案自动作废）。
 能力：
 - 改变量（variables）：按 name 匹配已有变量，合并你传的字段（definition / label / multi / default_value / type）；name 不存在则视为新增一个 query 变量（必须带 definition，否则报错——名字写错会落到新增分支，靠这个守卫拦下）；传 delete=true 删除该变量。
-- 改图表曲线（panels）：按 id（优先）或 name 定位图表；queries 传入则按 ref（即原曲线 refId）与现有曲线做增量合并，只覆盖你写的字段，原曲线的 step/hide/time/__mode__ 等及按 refId 关联的 overrides/transformations 一律保留；改已有曲线必须带上其 ref（不带 ref 一律视为新增曲线，没有位置匹配）；未在 queries 里提及的现有曲线原样保留（不会被删），要删某条曲线在该曲线项上带其 ref 并传 delete=true；每条 {promql, legend?, instant?, ref?, step?, hide?, delete?}；new_name 改标题；unit 改单位；description 改说明；type 改图表类型（仅 timeseries/stat/gauge/barGauge/pie/table，改类型会把该图表的类型样式选项重置为新类型默认值，改成 timeseries 时还会清掉曲线上的 instant 标志以恢复范围查询，row 布局行不能改）；delete=true 删除整个图表。panels 里只有这些字段有效，其他字段（颜色、阈值、布局等）不支持：patch 里只含不支持字段会被直接拒绝；混在支持字段里传则不支持的部分被丢弃，只有返回的改动清单里列出的才是真正写入的改动。
+- 改图表曲线（panels）：按 id（优先）或 name 定位图表；queries 传入则按 ref（即原曲线 refId）与现有曲线做增量合并，只覆盖你写的字段，原曲线的 step/hide/time/__mode__ 等及按 refId 关联的 overrides/transformations 一律保留；改已有曲线必须带上其 ref（不带 ref 一律视为新增曲线，没有位置匹配）；未在 queries 里提及的现有曲线原样保留（不会被删），要删某条曲线在该曲线项上带其 ref 并传 delete=true；每条 {promql, legend?, instant?, ref?, step?, hide?, delete?}；new_name 改标题；unit 改单位；description 改说明；type 改图表类型（仅 timeseries/stat/gauge/barGauge/pie/table/tableNG，改类型会把该图表的类型样式选项重置为新类型默认值，改成 timeseries 时还会清掉曲线上的 instant 标志以恢复范围查询，改成 tableNG 时会强制曲线使用即时查询，row 布局行不能改）；delete=true 删除整个图表。panels 里只有这些字段有效，其他字段（颜色、阈值、布局等）不支持：patch 里只含不支持字段会被直接拒绝；混在支持字段里传则不支持的部分被丢弃，只有返回的改动清单里列出的才是真正写入的改动。
 - 修复变量/数据源引用（fix_datasource=true）：把图表与变量里悬空/写死的数据源引用统一重指到大盘的数据源变量（修复"图表查不到数据/数据源引用不一致"类坏味道）。
 业务组、数据源从仪表盘本身读取，不需要、也不要向用户索要。`,
 	Type: aiagent.ToolTypeBuiltin,
 	Parameters: []aiagent.ToolParameter{
 		{Name: "id", Type: "integer", Description: "要修改的仪表盘 ID（必填）", Required: true},
 		{Name: "variables", Type: "string", Description: `变量改动 JSON 数组，按 name 匹配。每项: {"name":"ident", "definition":"label_values(cpu_usage_idle, ident)", "label":"主机", "multi":true, "default_value":"", "delete":false}。只写要改的字段；name 不存在则视为新增（必须带 definition）；delete=true 删除`, Required: false},
-		{Name: "panels", Type: "string", Description: `图表改动 JSON 数组，按 id（优先）或 name 定位。每项: {"id":"panel-3", "new_name":"CPU使用率(总)", "unit":"percent", "description":"...", "type":"timeseries", "queries":[{"ref":"A","promql":"...","legend":"{{ident}}","instant":false,"step":15,"hide":false}], "delete":false}。type 改图表类型(可选 timeseries/stat/gauge/barGauge/pie/table，会重置该图表的类型样式为新类型默认值；改成 timeseries 时会清掉曲线上的 instant 标志以恢复范围查询)。queries 传入则与现有曲线增量合并：按 ref(原 refId)匹配，只覆盖所写字段，未写字段(含 step/hide/__mode__ 及按 refId 关联的 overrides/transformations)原样保留；改已有曲线必须带上其 ref，不带 ref 一律视为新增曲线(没有位置匹配)；未在 queries 里出现的现有曲线一律原样保留、不会被删。要删某条曲线，在该曲线项上带其 ref 并传 delete:true。instant 传 true 即时查询、传 false 范围查询(true↔false 均可改)。不传 queries 则不动曲线`, Required: false},
+		{Name: "panels", Type: "string", Description: `图表改动 JSON 数组，按 id（优先）或 name 定位。每项: {"id":"panel-3", "new_name":"CPU使用率(总)", "unit":"percent", "description":"...", "type":"timeseries", "queries":[{"ref":"A","promql":"...","legend":"{{ident}}","instant":false,"step":15,"hide":false}], "delete":false}。type 改图表类型(可选 timeseries/stat/gauge/barGauge/pie/table/tableNG，会重置该图表的类型样式为新类型默认值；改成 timeseries 时会清掉曲线上的 instant 标志以恢复范围查询；改成 tableNG 时会强制曲线使用即时查询)。queries 传入则与现有曲线增量合并：按 ref(原 refId)匹配，只覆盖所写字段，未写字段(含 step/hide/__mode__ 及按 refId 关联的 overrides/transformations)原样保留；改已有曲线必须带上其 ref，不带 ref 一律视为新增曲线(没有位置匹配)；未在 queries 里出现的现有曲线一律原样保留、不会被删。要删某条曲线，在该曲线项上带其 ref 并传 delete:true。instant 传 true 即时查询、传 false 范围查询(true↔false 均可改)。不传 queries 则不动曲线`, Required: false},
 		{Name: "fix_datasource", Type: "boolean", Description: "是否修复悬空/写死的数据源引用，统一重指到大盘数据源变量。默认 false", Required: false},
 		{Name: "proposal_id", Type: "string", Description: "系统确认通道专用（用户确认后由系统自动重放时携带），模型不要传", Required: false},
 		{Name: "confirmed", Type: "boolean", Description: "系统确认通道专用，模型不要传", Required: false},
@@ -327,7 +327,7 @@ var CreateDashboard = aiagent.AgentTool{
 		{Name: "group_id", Type: "integer", Description: "业务组ID", Required: true},
 		{Name: "name", Type: "string", Description: "仪表盘名称", Required: true},
 		{Name: "datasource_id", Type: "integer", Description: "Prometheus 数据源ID（从 list_datasources 获取）", Required: true},
-		{Name: "panels", Type: "string", Description: `面板列表 JSON 数组。每个面板: {"name":"标题", "type":"timeseries", "queries":[{"promql":"PromQL表达式", "legend":"{{label}}"}]}。type 可选: timeseries/stat/gauge/barGauge/pie/table/row。可选字段: w(宽度)/h(高度)/unit(单位:percent,bytesIEC,seconds等)/stack(是否堆叠)`, Required: true},
+		{Name: "panels", Type: "string", Description: `面板列表 JSON 数组。每个面板: {"name":"标题", "type":"timeseries", "queries":[{"promql":"PromQL表达式", "legend":"{{label}}"}]}。type 可选: timeseries/stat/gauge/barGauge/pie/tableNG/row。可选字段: w(宽度)/h(高度)/unit(单位:percent,bytesIEC,seconds等)/stack(是否堆叠)`, Required: true},
 		{Name: "variables", Type: "string", Description: `变量列表 JSON 数组。每个变量: {"name":"变量名", "definition":"label_values(metric, label)"}。可选字段: label(显示名)/multi(是否多选,默认true)`, Required: false},
 		{Name: "tags", Type: "string", Description: "仪表盘标签，多个用空格分隔", Required: false},
 	},


### PR DESCRIPTION
Bring create_dashboard / update_dashboard panel configs in line with what the frontend actually renders, so generated dashboards no longer look broken or staggered on load.

Panel types & layout:
- Treat `table` as `tableNG` (the renderer's table type); drop the legacy `table` shape from the supported set in the skill/defs and keep `tableNG` instant-forced to avoid row explosions on wide ranges.
- Recompute default panel sizes so ReactGridLayout's vertical compaction can't pull a later panel into a visual gap: gauge 6x8, barGauge/pie 12x8 (paired half-width), text 12x4; keep the first row's 12+6+6 composition aligned.
- Drop `isResizable` / `transformationsNG` from emitted panels and stop writing `description` on text panels (content lives in custom.content only).

Config defaults:
- Move gauge min/max into standardOptions and give gauges a 3-step threshold scale; add base thresholds + dashed threshold style to every chart; preserve already-authored standardOptions on type conversion via the shared applyPanelTypeOptions helper.
- Rework per-type custom blocks (timeseries fillOpacity/pointSize/ bar*, stat colSpan/valueField/orientation, barGauge valueMode/ sortOrder, pie legengPosition=right + text fields, tableNG cell options, text color/alignment defaults).
- Set the datasource variable defaultValue from datasourceId so the header dropdown opens preselected.

refId generation:
- Use the frontend's A..Z, AA..AZ, BA... sequence (refIDAt) for both build and normalize paths, replacing the single-letter + Q0/Q1 fallback that produced refIds the FE didn't recognize.

Tests:
- Add builder tests for refId sequencing, aligned mixed-type layout, panel defaults / tableNG, and a dashboard e2e test; extend update and normalize tests for tableNG and forced-instant behavior.

**What type of PR is this?**

**What this PR does / why we need it**:
<!--
"Nice to have" "You need it" is not a good reason. :)
-->

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or "Fixes (paste link of issue)"
-->
Fixes #
 
**Special notes for your reviewer**: