### PR TITLE
Historical alerts support querying by hash.

### DIFF
--- a/center/router/router_alert_his_event.go
+++ b/center/router/router_alert_his_event.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/toolkits/pkg/logger"
 	"golang.org/x/exp/slices"
+	"gorm.io/gorm"
 )
 
 // 历史告警 count(*) 缓存：大表上每次翻页都重算 count 代价很高，
@@ -76,6 +77,8 @@ func (rt *Router) alertHisEventsList(c *gin.Context) {
 	severity := ginx.QueryInt(c, "severity", -1)
 	recovered := ginx.QueryInt(c, "is_recovered", -1)
 	query := ginx.QueryStr(c, "query", "")
+	// hash 一般是从告警通知文本或日志里复制来的，带上尾随空格/换行时等值查询会静默返回空
+	hash := strings.TrimSpace(ginx.QueryStr(c, "hash", ""))
 	limit := ginx.QueryInt(c, "limit", 20)
 	dsIds := queryDatasourceIds(c)
 
@@ -102,9 +105,15 @@ func (rt *Router) alertHisEventsList(c *gin.Context) {
 
 	offset := ginx.Offset(c, limit)
 
-	// hours 模式下 stime/etime 随请求时刻漂移，缓存 key 里按分钟取整，翻页请求才能命中
-	cacheKey := fmt.Sprintf("%v|%v|%d|%d|%d|%d|%v|%v|%d|%s",
-		prods, bgids, stime/60, etime/60, severity, recovered, dsIds, cates, ruleId, query)
+	var scopes []func(*gorm.DB) *gorm.DB
+	if hash != "" {
+		scopes = append(scopes, models.AlertHisEventHashScope(hash))
+	}
+
+	// hours 模式下 stime/etime 随请求时刻漂移，缓存 key 里按分钟取整，翻页请求才能命中；
+	// query、hash 这类自由文本用 %q 引起来，否则值里的 | 会和分隔符混淆，撞上别的条件组合
+	cacheKey := fmt.Sprintf("%v|%v|%d|%d|%d|%d|%v|%v|%d|%q|%q",
+		prods, bgids, stime/60, etime/60, severity, recovered, dsIds, cates, ruleId, query, hash)
 
 	total, hit := int64(0), false
 	if offset > 0 {
@@ -112,7 +121,7 @@ func (rt *Router) alertHisEventsList(c *gin.Context) {
 	}
 	if !hit {
 		total, err = models.AlertHisEventTotal(rt.Ctx, prods, bgids, stime, etime, severity,
-			recovered, dsIds, cates, ruleId, query, []int64{})
+			recovered, dsIds, cates, ruleId, query, []int64{}, scopes...)
 		ginx.Dangerous(err)
 		hisTotalCacheSet(cacheKey, total)
 	}
@@ -124,10 +133,10 @@ func (rt *Router) alertHisEventsList(c *gin.Context) {
 	var list []models.AlertHisEvent
 	if cursorTime > 0 && cursorId > 0 {
 		list, err = models.AlertHisEventGetsByCursor(rt.Ctx, prods, bgids, stime, etime, severity,
-			recovered, dsIds, cates, ruleId, query, cursorTime, cursorId, limit, []int64{})
+			recovered, dsIds, cates, ruleId, query, cursorTime, cursorId, limit, []int64{}, scopes...)
 	} else {
 		list, err = models.AlertHisEventGets(rt.Ctx, prods, bgids, stime, etime, severity, recovered,
-			dsIds, cates, ruleId, query, limit, offset, []int64{})
+			dsIds, cates, ruleId, query, limit, offset, []int64{}, scopes...)
 	}
 	ginx.Dangerous(err)
 

--- a/models/alert_his_event.go
+++ b/models/alert_his_event.go
@@ -264,6 +264,17 @@ func AlertHisEventGetByHash(ctx *ctx.Context, hash string) (*AlertHisEvent, erro
 	return lst[0], nil
 }
 
+// AlertHisEventHashScope 把历史告警列表限定为指定 hash 的事件，等值匹配走 alert_his_event 的 KEY(hash)。
+// 走 scopes 而不是给 AlertHisEventGets/Total 加位置参数：这几个函数在 n9e-plus 里也被调用
+// （go.mod 用 replace 指向本仓库），改签名会变成必须成对提交的跨仓改动；
+// 用 scope 还能让 hash 过滤天然只作用于显式传它的调用方，通知规则详情、聚合告警等复用路径不受影响。
+// hash 是否为空由调用方判断
+func AlertHisEventHashScope(hash string) func(*gorm.DB) *gorm.DB {
+	return func(db *gorm.DB) *gorm.DB {
+		return db.Where("hash = ?", hash)
+	}
+}
+
 // AlertHisEventBatchDelete 按 id 游标批量删除 last_eval_time 早于 timestamp 的历史事件，
 // activeIds 是活跃告警 id 快照（cur.id 即对应的 his.id），命中的记录跳过不删。
 // 返回本批候选数 fetched（< limit 表示已扫完）、实际删除数 deleted、本批最大 id（下一批游标）。

--- a/models/alert_his_event_query_test.go
+++ b/models/alert_his_event_query_test.go
@@ -34,12 +34,12 @@ func newHisEventCtx(t *testing.T) *ctx.Context {
 func seedHisEvents(t *testing.T, c *ctx.Context) {
 	t.Helper()
 	events := []models.AlertHisEvent{
-		{Id: 1, GroupId: 1, Severity: 2, IsRecovered: 0, RuleId: 11, RuleName: "cpu high", Tags: "host=a", TriggerTime: 100, LastEvalTime: 100},
-		{Id: 2, GroupId: 1, Severity: 1, IsRecovered: 0, RuleId: 12, RuleName: "mem high", Tags: "host=b", TriggerTime: 150, LastEvalTime: 200},
-		{Id: 3, GroupId: 1, Severity: 1, IsRecovered: 1, RuleId: 12, RuleName: "mem high", Tags: "host=b", TriggerTime: 90, LastEvalTime: 200},
-		{Id: 4, GroupId: 2, Severity: 3, IsRecovered: 0, RuleId: 13, RuleName: "disk full", Tags: "host=c", TriggerTime: 300, LastEvalTime: 300},
-		{Id: 5, GroupId: 2, Severity: 2, IsRecovered: 1, RuleId: 13, RuleName: "disk full", Tags: "host=c", TriggerTime: 240, LastEvalTime: 250},
-		{Id: 6, GroupId: 1, Severity: 2, IsRecovered: 0, RuleId: 11, RuleName: "cpu high", Tags: "host=a", TriggerTime: 400, LastEvalTime: 400},
+		{Id: 1, GroupId: 1, Severity: 2, IsRecovered: 0, RuleId: 11, RuleName: "cpu high", Tags: "host=a", Hash: "h-cpu-a", TriggerTime: 100, LastEvalTime: 100},
+		{Id: 2, GroupId: 1, Severity: 1, IsRecovered: 0, RuleId: 12, RuleName: "mem high", Tags: "host=b", Hash: "h-mem-b", TriggerTime: 150, LastEvalTime: 200},
+		{Id: 3, GroupId: 1, Severity: 1, IsRecovered: 1, RuleId: 12, RuleName: "mem high", Tags: "host=b", Hash: "h-mem-b", TriggerTime: 90, LastEvalTime: 200},
+		{Id: 4, GroupId: 2, Severity: 3, IsRecovered: 0, RuleId: 13, RuleName: "disk full", Tags: "host=c", Hash: "h-disk-c", TriggerTime: 300, LastEvalTime: 300},
+		{Id: 5, GroupId: 2, Severity: 2, IsRecovered: 1, RuleId: 13, RuleName: "disk full", Tags: "host=c", Hash: "h-disk-c2", TriggerTime: 240, LastEvalTime: 250},
+		{Id: 6, GroupId: 1, Severity: 2, IsRecovered: 0, RuleId: 11, RuleName: "cpu high", Tags: "host=a", Hash: "h-cpu-a2", TriggerTime: 400, LastEvalTime: 400},
 	}
 	for i := range events {
 		if err := events[i].Add(c); err != nil {
@@ -156,4 +156,76 @@ func TestAlertHisEventGetsByCursor(t *testing.T) {
 		t.Fatalf("first: %v", err)
 	}
 	assertIds(t, eventIdsOf(first), 6, 4)
+}
+
+func TestAlertHisEventHashScope(t *testing.T) {
+	c := newHisEventCtx(t)
+	seedHisEvents(t, c)
+
+	hashScope := models.AlertHisEventHashScope("h-mem-b")
+
+	// 列表与计数是两条独立路径，都要验证，否则按 hash 筛选后翻页的 total 可能不对
+	total, err := models.AlertHisEventTotal(c, nil, nil, 0, 1000, -1, -1, nil, nil, 0, "", nil, hashScope)
+	if err != nil {
+		t.Fatalf("total: %v", err)
+	}
+	if total != 2 {
+		t.Fatalf("total by hash = %d, want 2", total)
+	}
+
+	lst, err := models.AlertHisEventGets(c, nil, nil, 0, 1000, -1, -1, nil, nil, 0, "", 10, 0, nil, hashScope)
+	if err != nil {
+		t.Fatalf("gets: %v", err)
+	}
+	assertIds(t, eventIdsOf(lst), 3, 2)
+
+	// 精确匹配：前缀相同的 hash 不应命中
+	lst, err = models.AlertHisEventGets(c, nil, nil, 0, 1000, -1, -1, nil, nil, 0, "", 10, 0, nil,
+		models.AlertHisEventHashScope("h-mem"))
+	if err != nil {
+		t.Fatalf("gets by prefix hash: %v", err)
+	}
+	if len(lst) != 0 {
+		t.Fatalf("gets by prefix hash = %v, want empty", eventIdsOf(lst))
+	}
+
+	// hash 不存在时返回空列表且不报错
+	total, err = models.AlertHisEventTotal(c, nil, nil, 0, 1000, -1, -1, nil, nil, 0, "", nil,
+		models.AlertHisEventHashScope("h-not-exist"))
+	if err != nil {
+		t.Fatalf("total by absent hash: %v", err)
+	}
+	if total != 0 {
+		t.Fatalf("total by absent hash = %d, want 0", total)
+	}
+
+	// 与其他筛选条件叠加：hash 命中 2 条，其中未恢复的只有 id 2
+	lst, err = models.AlertHisEventGets(c, nil, []int64{1}, 0, 1000, 1, 0, nil, nil, 0, "mem", 10, 0, nil, hashScope)
+	if err != nil {
+		t.Fatalf("gets with filters: %v", err)
+	}
+	assertIds(t, eventIdsOf(lst), 2)
+
+	// 游标翻页同样要带上 scope，否则深翻页会返回没被 hash 过滤的行
+	page1, err := models.AlertHisEventGetsByCursor(c, nil, nil, 0, 1000, -1, -1, nil, nil, 0, "", 0, 0, 1, nil, hashScope)
+	if err != nil {
+		t.Fatalf("cursor page1: %v", err)
+	}
+	assertIds(t, eventIdsOf(page1), 3)
+
+	last := page1[len(page1)-1]
+	page2, err := models.AlertHisEventGetsByCursor(c, nil, nil, 0, 1000, -1, -1, nil, nil, 0, "", last.LastEvalTime, last.Id, 1, nil, hashScope)
+	if err != nil {
+		t.Fatalf("cursor page2: %v", err)
+	}
+	assertIds(t, eventIdsOf(page2), 2)
+
+	// 时间窗仍然生效：两条的 last_eval_time 都是 200，窗口 [0,150] 内一条都不该命中
+	total, err = models.AlertHisEventTotal(c, nil, nil, 0, 150, -1, -1, nil, nil, 0, "", nil, hashScope)
+	if err != nil {
+		t.Fatalf("total in window: %v", err)
+	}
+	if total != 0 {
+		t.Fatalf("total by hash in [0,150] = %d, want 0", total)
+	}
 }


### PR DESCRIPTION
## 一句话目标

在「历史告警」列表页新增按事件 hash 查询的能力，用户输入某个 hash 即可查出该 hash 对应的所有历史告警事件。

## 功能点

1. 历史告警列表页筛选区新增一个独立的 hash 输入框（与现有的『模糊搜索规则和标签』搜索框分开），输入 hash 后回车即可筛选
2. hash 采用**精确匹配**（等值查询），不是模糊搜索，也不并入现有关键词搜索框的模糊逻辑，避免改变现有搜索行为
3. hash 筛选与其他筛选条件（业务组、监控类型、数据源、级别、事件类别、关键词、时间范围）正常叠加生效
4. hash 输入框的值同步到 URL，支持直接用形如 `?hash=xxx` 的链接打开页面即为已筛选状态（用户通常是从告警通知/日志里拿到 hash 再来查）
5. 导出 CSV 时遵循当前的 hash 筛选条件
6. 输入框加占位提示文案，并补齐多语言（历史告警页现有 12 种语言文件）
7. 【假设项】为了让用户能拿到 hash，在告警事件详情里展示 hash 并支持一键复制；若用户的 hash 来源本来就是通知消息/日志，这一条可以去掉

## 涉及的 repo / 页面

- `nightingale`：历史告警列表接口 `center/router/router_alert_his_event.go`、查询构造 `models/alert_his_event.go`
- `n9e/fe`：历史告警页 `src/pages/historyEvents/`（`index.tsx` 筛选与 URL 同步、`ListNG/index.tsx` 筛选区与列表、`exportEvents.ts` 导出、`locale/` 多语言）

## 验收标准

1. 在历史告警页输入一个真实存在的 hash，列表只返回该 hash 的事件；输入不存在的 hash 返回空列表且无报错
2. hash 为空时页面行为与改动前完全一致（现有关键词模糊搜索的结果不受影响）
3. 按 hash 筛选后，总条数与分页正确，不会复用上一次查询缓存的总数；翻页结果正确
4. 带 `?hash=xxx` 的 URL 直接打开，输入框已回填且列表已按该 hash 筛选；刷新页面筛选条件不丢失
5. 导出 CSV 的内容与当前 hash 筛选结果一致
6. hash 查询在大数据量下响应正常（hash 字段本身已有索引，不应退化成全表扫描）

## 现状与既有约定

- 列表接口为 `GET /api/n9e/alert-his-events/list`，现有 `query` 参数是对 `rule_name` 和 `tags` 的模糊匹配（多个关键词空格分隔），hash 不在其中
- `alert_his_event` 表已有 `hash` 字段且建有索引，等值查询代价低
- 后端已有按 hash 取单条最新事件的能力（`models/alert_his_event.go` 中的 `AlertHisEventGetByHash`），但列表接口没有 hash 过滤条件
- 列表接口对总条数做了 120 秒缓存，缓存 key 由各筛选条件拼成——新增筛选条件需要一并纳入，否则翻页会拿到错误总数
- 页面筛选条件通过 URL query 参数双向同步（`historyEvents/index.tsx` 的 getFilter/setFilter）
- 列表组件 `historyEvents/ListNG` 被复用于「通知规则详情-事件」页和商业版「聚合告警」页，且已有 `hideExportButton` 这类开关 prop 的约定

## 假设与待确认

1. hash 输入框做成独立筛选项而非并入现有搜索框（理由：hash 是精确值，混进模糊搜索会拖慢查询并改变现有搜索语义）
2. 时间范围继续生效：页面默认最近 6 小时，同一 hash 的事件可能更早，用户可能需要手动放宽时间范围才能查到——是否在 hash 非空时自动放宽/忽略默认时间范围，待确认
3. 本次只要求历史告警页；复用同一列表组件的「通知规则详情-事件」和「聚合告警」页是否也要出现该筛选项，待确认（默认不出现）
4. 「当前告警」列表页同样有 hash 字段，本轮不改，如需一并支持请说明
5. 功能点 7（详情页展示并复制 hash）是为了闭环 hash 的来源而加的假设项，不需要可去掉

---
Created by Ironship task b53d8d34beefe031